### PR TITLE
Fix Vinayaka Chaturthi day assignment for partial day-2 madhyaahna vyaapti

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/tithi_festival.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/tithi_festival.py
@@ -40,6 +40,35 @@ class TithiFestivalAssigner(FestivalAssigner):
     self.assign_mahaa_paurnamii()
     self.assign_dinakshaya()
     self.assign_anadhyayana_days()
+    self.check_festival_corner_cases()
+
+  def check_festival_corner_cases(self):
+    """ Post-hoc corrections to festival days already assigned by the generic TOML-rule-driven engine (priority_decision.decide()), for cases that generic priority can't fully express on its own.
+
+    Unlike the assign_* methods above (which assign festival days from scratch), each check_* method here only overrules a day already present in self.panchaanga.festival_id_to_days.
+    """
+    self.check_vinayaka_chaturthi()
+    # self.check_guru_purnima()          # future: same aparaahna-touch-based full-vyaapti override, kaala="saangava".
+    # self.check_kamakshi_avirbhava()    # future: ditto.
+
+  def check_vinayaka_chaturthi(self):
+    # Base assignment (kaala="madhyaahna", priority="puurvaviddha") already picks the right day whenever
+    # only one of the two candidate days touches madhyaahna. It defaults to day 1 whenever day 1 touches
+    # madhyaahna, without checking day 2 at all -- so the one case it can't express is the traditional
+    # exception: if day 2's tithi has puurna (full) vyaapti of madhyaahna, day 2 should win instead.
+    # Full vyaapti of day 2's madhyaahna is evidenced by the tithi extending into (touching) day 2's aparaahna.
+    festival_name = 'zrIvinAyaka-caturthI'
+    if festival_name not in self.rules_collection.name_to_rule:
+      return
+    if festival_name not in self.panchaanga.festival_id_to_days:
+      return
+    for assigned_date in list(self.panchaanga.festival_id_to_days[festival_name]):
+      day_panchaanga = self.panchaanga.date_str_to_panchaanga[assigned_date.get_date_str()]
+      next_day_panchaanga = self.panchaanga.date_str_to_panchaanga[(assigned_date + 1).get_date_str()]
+      (_, d1_apar_angas) = get_2_day_interval_boundary_angas(kaala="aparaahna", anga_type=AngaType.TITHI, p0=day_panchaanga, p1=next_day_panchaanga)
+      if d1_apar_angas.start.index == 4 or d1_apar_angas.end.index == 4:
+        self.panchaanga.delete_festival_date(fest_id=festival_name, date=assigned_date)
+        self.panchaanga.add_festival(fest_id=festival_name, date=assigned_date + 1)
 
   def assign_dinakshaya(self):
     if 'dinakSayaH' not in self.rules_collection.name_to_rule:

--- a/jyotisha_tests/temporal/festival/applier/tithi_test.py
+++ b/jyotisha_tests/temporal/festival/applier/tithi_test.py
@@ -1,0 +1,38 @@
+from jyotisha.panchaanga.spatio_temporal import City, periodical
+from jyotisha.panchaanga.temporal import ComputationSystem
+from jyotisha.panchaanga.temporal.festival.applier.tithi_festival import TithiFestivalAssigner
+from jyotisha.panchaanga.temporal.time import Date
+
+chennai = City.get_city_from_db('Chennai')
+
+VINAYAKA_CHATURTHI = 'zrIvinAyaka-caturthI'
+
+
+def test_check_vinayaka_chaturthi_overrules_for_full_day2_vyaapti():
+  # 2023, Chennai: caturthI touches 2023-09-18's madhyaahna only at its end, but fully covers
+  # 2023-09-19's madhyaahna and extends into 2023-09-19's aparaahna -- the traditional "puurna
+  # vyaapti of day 2" exception, which should overrule a default (puurvaviddha, prefer day 1)
+  # pick of day 1 to day 2.
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2023, 9, 15), end_date=Date(2023, 9, 21), computation_system=computation_system)
+  assigner = TithiFestivalAssigner(panchaanga=panchaanga)
+
+  # Simulate the generic engine's base decision (kaala="madhyaahna", priority="puurvaviddha"),
+  # which -- absent the full-vyaapti exception -- would have picked day 1.
+  panchaanga.festival_id_to_days[VINAYAKA_CHATURTHI] = {Date(2023, 9, 18)}
+  assigner.check_vinayaka_chaturthi()
+  assert panchaanga.festival_id_to_days[VINAYAKA_CHATURTHI] == {Date(2023, 9, 19)}
+
+
+def test_check_vinayaka_chaturthi_no_op_without_full_day2_vyaapti():
+  # 2027, Chennai: caturthI never touches 2027-09-03's madhyaahna at all (it begins only within
+  # 2027-09-03's aparaahna), and only partially touches 2027-09-04's madhyaahna, ending before
+  # 2027-09-04's aparaahna begins. Day 2 (2027-09-04, already correctly picked by the base
+  # decision since only it touches madhyaahna) should not be moved further by the override.
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2027, 9, 1), end_date=Date(2027, 9, 7), computation_system=computation_system)
+  assigner = TithiFestivalAssigner(panchaanga=panchaanga)
+
+  panchaanga.festival_id_to_days[VINAYAKA_CHATURTHI] = {Date(2027, 9, 4)}
+  assigner.check_vinayaka_chaturthi()
+  assert panchaanga.festival_id_to_days[VINAYAKA_CHATURTHI] == {Date(2027, 9, 4)}


### PR DESCRIPTION
The prior aparaahna-based check for Vinayaka Chaturthi wrongly picked
day 1 whenever the tithi merely began sometime during day 1's
aparaahna, even if it never touched day 1's madhyaahna at all and only
day 2 did. The traditional rule is decided by madhyaahna presence
(existing puurvaviddha priority already gets this right), with day 2
overruling day 1 only when day 2 has full vyaapti of madhyaahna --
evidenced by the tithi extending into day 2's aparaahna.

Add check_vinayaka_chaturthi (grouped under a new
check_festival_corner_cases hook in assign_all, for future overrides
of this kind) to apply that full-vyaapti override after the generic
TOML-rule engine's base pick. Verified against real 2023 and 2027
Chennai ephemeris data, including a corresponding local kaala/priority
correction to the zrIvinAyaka-caturthI rule (kaala -> madhyaahna,
priority -> puurvaviddha) needed in the adyatithi data repo for the
full fix to take effect.