### PR TITLE
Prioritize vyaapti's adjacent-day comparison over month_number cleanup

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -216,12 +216,14 @@ class RuleLookupAssigner(FestivalAssigner):
           if len(self.festival_id_to_days[fest_id]) > 0:
             previous_fest_day = sorted(self.festival_id_to_days[fest_id])[-1]
             p_previous_fday = self.panchaanga.date_str_to_panchaanga[previous_fest_day.get_date_str()]
-            # Regarding the fest_rule.timing.month_number != 0 below:
-            # This is required so as to avoid omissions as in the following case: sthAlIpAka_1 (which occurs every lunar month on tithi 1 at pUrvaviddha pUrvAhNa) occurs within the same "sunrise lunar month" but on different "pUrvAhNa lunar months" on 2019-07-03 and 2019-08-01.
-            # Plus, a gap of not much more than 1 month is desirable for monthly festivals even otherwise - https://github.com/jyotisham/jyotisha/issues/54#issuecomment-735355325 .
-            if fest_rule.timing.month_number != 0 and p_fday.date - previous_fest_day <= 32 and p_previous_fday.get_date(month_type=month_type).month == month:
-              self.panchaanga.delete_festival_date(fest_id=fest_id, date=previous_fest_day)
-            elif priority == 'vyaapti' and abs(p_fday.date - previous_fest_day) == 1:
+            # priority == 'vyaapti' with a 1-day gap is checked FIRST, ahead of the month_number-based clause
+            # below: such a gap is always an adjacent-day conflict for the *same* occurrence (never a distinct
+            # month's occurrence, which is never just 1 day away), so it must be settled by direct duration
+            # comparison rather than falling through to the month_number clause's unconditional delete (which
+            # would otherwise win first for the very common case of a month-scoped vyaapti festival, ie.
+            # fest_rule.timing.month_number != 0, silently discarding the comparison this whole mechanism exists
+            # for).
+            if priority == 'vyaapti' and abs(p_fday.date - previous_fest_day) == 1:
               # previous_fest_day and p_fday.date are adjacent candidates for the same vyaapti-priority
               # occurrence. Neither day's own pairwise decide_vyaapti() result can be trusted here on its
               # own -- a boundary-touch match can be a spurious re-detection of the tail/lead of an
@@ -236,6 +238,11 @@ class RuleLookupAssigner(FestivalAssigner):
               else:
                 # The already-assigned day wins the direct comparison; discard this candidate.
                 assign_festival = False
+            # Regarding the fest_rule.timing.month_number != 0 below:
+            # This is required so as to avoid omissions as in the following case: sthAlIpAka_1 (which occurs every lunar month on tithi 1 at pUrvaviddha pUrvAhNa) occurs within the same "sunrise lunar month" but on different "pUrvAhNa lunar months" on 2019-07-03 and 2019-08-01.
+            # Plus, a gap of not much more than 1 month is desirable for monthly festivals even otherwise - https://github.com/jyotisham/jyotisha/issues/54#issuecomment-735355325 .
+            elif fest_rule.timing.month_number != 0 and p_fday.date - previous_fest_day <= 32 and p_previous_fday.get_date(month_type=month_type).month == month:
+              self.panchaanga.delete_festival_date(fest_id=fest_id, date=previous_fest_day)
           # TODO : Set intervals for preceeding_arunodaya differently?
 
           if assign_festival:


### PR DESCRIPTION
## Summary

Found while investigating a report that `manvAdiH~(uttamaH~[3])` was landing on 2028-03-29 instead of 2028-03-28 (the tithi spans the entirety of 2028-03-28's aparāhṇa but only ~30 minutes of 2028-03-29's).

The `month_number`-based "delete stale previous assignment" clause in `apply_month_anga_events` was checked **before** the vyāpti-specific 1-day-gap comparison introduced in #175. Its condition (`gap <= 32`, same month) is broad enough to also match a genuine 1-day adjacent conflict for any month-scoped vyāpti festival (`fest_rule.timing.month_number != 0`, true for most festivals — `manvAdiH~(uttamaH~[3])` has `month_number=1`) — so it won first and unconditionally deleted-and-reassigned without ever running the real duration comparison the later clause exists for.

Concretely: both 2028-03-28 (via an earlier, unambiguous day-pair) and 2028-03-29 (via a separate day-pair's own boundary-touch match, from only ~30 minutes of trailing coverage) got flagged as candidates for the same occurrence. Since `month_number=1` (not `0`), the old clause order deleted the correct 2028-03-28 assignment and replaced it with 2028-03-29, without ever comparing their true vyāpti.

## Fix

Swapped the order: the `priority == 'vyaapti'` 1-day-gap check now runs first, since a 1-day gap can only ever be a correction of the *same* occurrence (a distinct month's occurrence is never just 1 day away). The `month_number` clause — whose own purpose is genuinely different month-to-month cleanup, historically with much larger gaps (see its own comment, referencing a ~29-day `sthAlIpAka_1` case) — now only applies once that's ruled out.

## Test plan

- [x] 2028-03-28 is now correctly assigned (was wrongly 2028-03-29).
- [x] `manvAdiH~(uttamaH~[3])` across 2020–2032 still shows clean spacing, with the legitimate adhika Chaitra double occurrence in 2029 preserved.
- [x] 2028-02-24/25 amāvāsyā tie and 2020-03-27 `uttamaH` cases (from #175) are unaffected.
- [x] `sidereal_solar_month_amAvAsyA` spacing across 2027–2029 stays clean (37 occurrences, no suspicious gaps).
- [x] Full `jyotisha_tests/temporal/festival/` suite (13 tests) passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017dBUhVnnBitghhTrN5Q7a7)_