### PR TITLE
Replace vyaapti's delete-and-reassign with a look-ahead deferral

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -170,12 +170,7 @@ class RuleLookupAssigner(FestivalAssigner):
         # Example where False should be returned: Suppose festival is on tithi 27 of solar sidereal month 10; last day of month 9 could have tithi 27, but not day 1 of month 10; though a much later day of month 10 has tithi 27.
         return False
 
-    # vyaapti is deliberately not guarded here the way puurvaviddha is: a boundary-touch match on an adjacent
-    # day can't be trusted or distrusted just from its own pairwise decide_vyaapti() result (it may be a
-    # spurious re-detection of an occurrence's tail/lead that an adjacent day-pair already resolved, or it may
-    # be the correct day). apply_month_anga_events settles any such adjacent-day conflict itself, by directly
-    # comparing true vyaapti duration between the two specific candidate days -- see there.
-    return priority != 'puurvaviddha' or \
+    return priority not in ('puurvaviddha', 'vyaapti') or \
                       (p_fday.date - 1 not in self.festival_id_to_days[fest_rule.id])
 
 
@@ -209,6 +204,19 @@ class RuleLookupAssigner(FestivalAssigner):
       target_anga = Anga.get_cached(index=fest_rule.timing.anga_number, anga_type_id=anga_type_str.upper())
       decision = priority_decision.decide(p0=panchaangas[1], p1=panchaangas[2], target_anga=target_anga, kaala=kaala, ayanaamsha_id=self.ayanaamsha_id, priority=priority)
 
+      if decision is not None and priority == 'vyaapti' and decision.fday == 1:
+        # decide_vyaapti() picked today (panchaangas[2]) over yesterday based on just this pair. Since an
+        # anga can never touch 3 consecutive days' kaalas (max anga duration < 2x kaala spacing), a look
+        # at tomorrow settles whether today's win is final: if tomorrow's kaala doesn't touch target_anga
+        # at all, today can't lose to it later, so commit now. If tomorrow does touch, today's boundary
+        # match may just be tomorrow's leading edge bleeding backwards -- defer entirely and let the
+        # (today, tomorrow) pairing in the next iteration make the definitive call.
+        tomorrow = self.panchaanga.date_str_to_panchaanga.get((date + 1).get_date_str(), None)
+        if tomorrow is not None:
+          (_, tomorrow_angas) = get_2_day_interval_boundary_angas(kaala=kaala, anga_type=target_anga.get_type(), p0=panchaangas[2], p1=tomorrow)
+          if tomorrow_angas.start == target_anga or tomorrow_angas.end == target_anga:
+            decision = None
+
       if decision is not None:
         p_fday = decision.day_panchaanga
         assign_festival = self._should_assign_festival(p_fday=p_fday, fest_rule=fest_rule)
@@ -221,21 +229,6 @@ class RuleLookupAssigner(FestivalAssigner):
             # Plus, a gap of not much more than 1 month is desirable for monthly festivals even otherwise - https://github.com/jyotisham/jyotisha/issues/54#issuecomment-735355325 .
             if fest_rule.timing.month_number != 0 and p_fday.date - previous_fest_day <= 32 and p_previous_fday.get_date(month_type=month_type).month == month:
               self.panchaanga.delete_festival_date(fest_id=fest_id, date=previous_fest_day)
-            elif priority == 'vyaapti' and abs(p_fday.date - previous_fest_day) == 1:
-              # previous_fest_day and p_fday.date are adjacent candidates for the same vyaapti-priority
-              # occurrence. Neither day's own pairwise decide_vyaapti() result can be trusted here on its
-              # own -- a boundary-touch match can be a spurious re-detection of the tail/lead of an
-              # occurrence the other, adjacent day-pair already resolved. Settle it directly: whichever of
-              # the two specific days has the greater true anga-duration overlap with the kaala wins.
-              earlier, later = (p_previous_fday, p_fday) if previous_fest_day < p_fday.date else (p_fday, p_previous_fday)
-              (earlier_angas, later_angas) = get_2_day_interval_boundary_angas(kaala=kaala, anga_type=target_anga.get_type(), p0=earlier, p1=later)
-              later_wins = priority_decision.compare_vyaapti_duration(d0_angas=earlier_angas, d1_angas=later_angas, target_anga=target_anga, ayanaamsha_id=self.ayanaamsha_id) == 1
-              new_day_is_later = p_fday.date > previous_fest_day
-              if later_wins == new_day_is_later:
-                self.panchaanga.delete_festival_date(fest_id=fest_id, date=previous_fest_day)
-              else:
-                # The already-assigned day wins the direct comparison; discard this candidate.
-                assign_festival = False
           # TODO : Set intervals for preceeding_arunodaya differently?
 
           if assign_festival:

--- a/jyotisha/panchaanga/temporal/festival/priority_decision.py
+++ b/jyotisha/panchaanga/temporal/festival/priority_decision.py
@@ -110,11 +110,6 @@ def compare_vyaapti_duration(d0_angas, d1_angas, target_anga, ayanaamsha_id):
   """ Compares the target anga's true duration overlap with d0's vs d1's kaala, for cases where boundary
   sampling alone can't distinguish the two (eg. both fully cover their kaala, or the anga only touches the
   shared boundary between the two kaalas). Returns 0 or 1 (the day with the greater overlap).
-
-  Also used directly by RuleLookupAssigner.apply_month_anga_events to settle conflicts between a new
-  candidate day and an already-assigned adjacent day for priority='vyaapti' festivals -- see there for why
-  that's necessary (a boundary-touch match can be a spurious re-detection of an occurrence's tail/lead that
-  an adjacent day-pair already resolved, so it can't be trusted just because decide_vyaapti() returned it).
   """
   if d0_angas.interval.name == 'अपराह्णः' and d0_angas.start == target_anga and d0_angas.end == target_anga and d1_angas.start == target_anga and d1_angas.end == target_anga:
     # Both d0 and d1 fully cover aparaahna -- an unusually long-duration anga spanning both days' kaalas

--- a/jyotisha_tests/temporal/festival/applier/vyaapti_test.py
+++ b/jyotisha_tests/temporal/festival/applier/vyaapti_test.py
@@ -23,9 +23,9 @@ def test_compare_vyaapti_duration_aparaahna_full_coverage_always_picks_day2():
 def test_vyaapti_moves_to_day2_when_both_days_fully_cover_kaala():
   # 2028, Chennai: the amAvAsyA tithi is unusually long (~26.7 hours) and fully covers aparaahna on
   # both 2028-02-24 and 2028-02-25. Per the rule above (aparaahna, both days fully covering -> always
-  # day 2), the assignment must land on 2028-02-25, not on 2028-02-24 merely because that day was
-  # reached first in the day-by-day scan (see _should_assign_festival's former unconditional
-  # "yesterday already assigned" guard for priority='vyaapti').
+  # day 2), the assignment must land on 2028-02-25. apply_month_anga_events's look-ahead defers
+  # committing 2028-02-24 (decide_vyaapti((23,24)) picks 24, but 25 also touches the anga, so
+  # commitment is deferred) until the (24, 25) pairing settles it definitively in favour of 25.
   computation_system = ComputationSystem.DEFAULT
   panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2028, 2, 20), end_date=Date(2028, 2, 28), computation_system=computation_system)
 
@@ -45,11 +45,10 @@ def test_vyaapti_does_not_shift_onto_spurious_tail_bleed():
   # covers -> decide_vyaapti unambiguously picks 2020-03-27, no tiebreak needed). 2020-03-28's aparaahna
   # is already fully into tithi 4 -- decide_vyaapti((2020-03-27, 2020-03-28)) correctly re-confirms
   # 2020-03-27 on its own (2020-03-27 fully covers its own kaala while 2020-03-28 doesn't touch tithi 3
-  # at all), so this specific date doesn't exercise apply_month_anga_events's adjacent-conflict
-  # resolution -- decide_vyaapti's own branches already agree end-to-end. Kept as an end-to-end sanity
-  # check (a hypothetical case with a genuine "partial touch mistaken for a claim" boundary pattern
-  # would instead need the conflict resolution in apply_month_anga_events, exercised more directly by
-  # test_compare_vyaapti_duration_aparaahna_full_coverage_always_picks_day2 for the full-coverage case).
+  # at all), so this specific date doesn't need apply_month_anga_events's look-ahead deferral to kick in
+  # -- decide_vyaapti's own branches already agree end-to-end. Kept as an end-to-end sanity check (the
+  # look-ahead deferral itself is exercised more directly by
+  # test_vyaapti_does_not_prematurely_commit_when_next_day_also_touches, below).
   computation_system = ComputationSystem.DEFAULT
   panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2020, 3, 20), end_date=Date(2020, 4, 1), computation_system=computation_system)
 
@@ -58,3 +57,23 @@ def test_vyaapti_does_not_shift_onto_spurious_tail_bleed():
 
   day28 = panchaanga.date_str_to_panchaanga[Date(2020, 3, 28).get_date_str()]
   assert festival_name not in day28.festival_id_to_instance
+
+
+def test_vyaapti_does_not_prematurely_commit_when_next_day_also_touches():
+  # 2028, Chennai: manvAdiH~(uttamaH~[3]) (priority='vyaapti', kaala='aparaahna', tithi 3).
+  # 2028-03-28's aparaahna fully covers tithi 3; 2028-03-29's aparaahna only touches tithi 3 briefly at
+  # its very start (~30 min) before moving into tithi 4. decide_vyaapti((27, 28)) picks 28 outright, but
+  # since 29 also touches the anga, apply_month_anga_events must defer committing 28 rather than
+  # assigning it immediately -- otherwise a later, unrelated pairing (29, 30), which sees 29 touching
+  # tithi 3 at its start and 30 having moved fully into tithi 4, would independently (and wrongly) also
+  # want to claim the festival for 29, displacing the correct assignment on 28 via the generic
+  # delete-previous-and-reassign cleanup. The (28, 29) pairing settles it: since 28 fully covers its
+  # kaala while 29 only briefly touches it, compare_vyaapti_duration correctly favours 28.
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2028, 3, 24), end_date=Date(2028, 4, 2), computation_system=computation_system)
+
+  festival_name = 'manvAdiH~(uttamaH~[3])'
+  assert panchaanga.festival_id_to_days[festival_name] == {Date(2028, 3, 28)}
+
+  day29 = panchaanga.date_str_to_panchaanga[Date(2028, 3, 29).get_date_str()]
+  assert festival_name not in day29.festival_id_to_instance


### PR DESCRIPTION
## Summary

Supersedes #176, which patched a symptom (branch ordering) of a deeper issue. This PR replaces the underlying mechanism instead.

`priority='vyaapti'` festivals were previously assigned by committing a day as soon as `decide_vyaapti()` favoured it, then reconciling conflicts after the fact: if a later day-pair also claimed the festival, the generic "delete previous, commit new" cleanup would delete the earlier commitment. That after-the-fact reconciliation could delete the *correct* day in favour of a spurious re-detection — concretely, `manvAdiH~(uttamaH~[3])` in 2028 was landing on March 29 instead of the correct March 28, because 2028-03-29's aparaahna briefly touches the target tithi at its very start (~30 min, a trailing bleed of the occurrence already correctly resolved to March 28), and the generic cleanup couldn't tell that apart from a genuine new occurrence.

The fix: since an anga can never touch 3 consecutive days' kaalas (max anga duration is under 2x kaala spacing), a 1-day look-ahead is always sufficient to know whether a candidate day's win is final. When `decide_vyaapti(yesterday, today)` picks today, peek at tomorrow before committing — if tomorrow also touches the anga, defer entirely and let the `(today, tomorrow)` pairing settle it definitively on the next iteration, instead of committing now and possibly un-committing later. This also closes a guard gap: `vyaapti` lacked the same "yesterday already claimed this festival" protection that `puurvaviddha` has, which is needed because a later day-pair can otherwise independently re-derive an adjacent spurious day regardless of the look-ahead.

Verified against real ephemeris data (Chennai) for the three known cases discussed in earlier PRs:
- 2028-02-24/25 (māgha amāvāsyā — genuine full/full duration tie, must land on day 2)
- 2020-03-27/28 (`manvAdiH~(uttamaH~[3])` — spurious tail bleed, must stay on day 1, unaffected by this change)
- 2028-03-28/29 (`manvAdiH~(uttamaH~[3])` — the bug this PR fixes, must land on day 1 not day 2)

`paraviddha` has an analogous unguarded-deletion-pass issue but is intentionally left untouched — out of scope for this PR.

## Test plan
- [x] `jyotisha_tests/temporal/festival/` (14 tests, including a new regression test for the 2028-03-28/29 case) — all pass
- [x] Multi-year sanity check: `manvAdiH~(uttamaH~[3])` 2020–2032, one occurrence per year (two in 2029, the adhika+nija Chaitra year, as configured) with correct dates
- [x] Multi-year sanity check: māgha amāvāsyā 2027–2029, correct single-day assignments
- [x] Broader suite (`jyotisha_tests/`, excluding an unrelated pre-existing `yamldown` import failure): two pre-existing 2018 golden-data failures confirmed unrelated (reproduce identically on `master`, unaffected by this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_017dBUhVnnBitghhTrN5Q7a7)_