### PR TITLE
Change Time.__repr__() to use get_date_str() instead of datetime

### DIFF
--- a/jyotisha/panchaanga/temporal/time.py
+++ b/jyotisha/panchaanga/temporal/time.py
@@ -281,7 +281,7 @@ class Date(BasicDate):
     return self.as_tuple()
 
   def __repr__(self):
-    return repr(self.to_datetime())
+    return self.get_date_str()
 
   def __hash__(self):
     return hash(repr(self))


### PR DESCRIPTION
## Summary
Modified the `__repr__` method of the `Time` class to return a string representation using the `get_date_str()` method instead of converting to a datetime object.

## Key Changes
- Updated `Time.__repr__()` to call `self.get_date_str()` instead of `repr(self.to_datetime())`
- This provides a more direct and domain-specific string representation of the Time object

## Implementation Details
The change simplifies the repr output by using the class's own `get_date_str()` method, which likely provides a more readable and consistent string format tailored to the jyotisha domain, rather than relying on Python's datetime representation.

https://claude.ai/code/session_01Dd4hr48GcW4NfLb6gx3rac