### PR TITLE
Add Mahamagha Utsava festival calculation

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -46,6 +46,7 @@ class SolarFestivalAssigner(FestivalAssigner):
     self.assign_ayushmad_bava_saumya_yoga()
     self.assign_anadhyayana_dvadashi_yoga()
     self.assign_vaarunii_trayodashi()
+    self.assign_mahamagha_utsava()
 
   def assign_pitr_dina(self):
     self.assign_gajachhaya_yoga()
@@ -580,6 +581,77 @@ class SolarFestivalAssigner(FestivalAssigner):
             self._assign_yoga('mahAvAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise)
         else:
             self._assign_yoga('vAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise)
+
+  def assign_mahamagha_utsava(self):
+    if 'mahAmaghOtsavaH' not in self.rules_collection.name_to_rule:
+      return
+    ayanaamsha_id = self.computation_system.ayanaamsha_id
+    SIMHA, KUMBHA, MAGHA, VRISHABHA = 5, 11, 10, 2
+
+    # guru transits siMha only once in ~12 years; narrow down within that transit before
+    # looking for the (yearly) sUrya-kumbha and (monthly) candra-maghA occurrences.
+    jupiter_finder = zodiac.AngaSpanFinder.get_cached(ayanaamsha_id=ayanaamsha_id, anga_type=zodiac.AngaType.GRAHA_RASHI[Graha.JUPITER])
+    jupiter_span = jupiter_finder.find(jd1=self.panchaanga.jd_start, jd2=self.panchaanga.jd_end, target_anga_id=SIMHA)
+    if jupiter_span is None:
+      return
+    # jd_start/jd_end may be None if the transit boundary lies outside the queried period;
+    # in that case, guru is already/still in siMha for the entire queried period.
+    jd1 = jupiter_span.jd_start if jupiter_span.jd_start is not None else self.panchaanga.jd_start
+    jd2 = jupiter_span.jd_end if jupiter_span.jd_end is not None else self.panchaanga.jd_end
+
+    sun_finder = zodiac.AngaSpanFinder.get_cached(ayanaamsha_id=ayanaamsha_id, anga_type=zodiac.AngaType.GRAHA_RASHI[Graha.SUN])
+    sun_span = sun_finder.find(jd1=jd1, jd2=jd2, target_anga_id=KUMBHA)
+    if sun_span is None:
+      # guru-siMha and sUrya-kumbha do not coincide in this period.
+      return
+    jd1 = sun_span.jd_start if sun_span.jd_start is not None else jd1
+    jd2 = sun_span.jd_end if sun_span.jd_end is not None else jd2
+
+    nakshatra_finder = zodiac.AngaSpanFinder.get_cached(ayanaamsha_id=ayanaamsha_id, anga_type=zodiac.AngaType.NAKSHATRA)
+    magha_span = nakshatra_finder.find(jd1=jd1, jd2=jd2, target_anga_id=MAGHA)
+    if magha_span is None:
+      return
+
+    jd_start = magha_span.jd_start if magha_span.jd_start is not None else jd1
+    jd_end = magha_span.jd_end if magha_span.jd_end is not None else jd2
+    if jd_start >= jd_end:
+      return
+
+    def day_of(jd):
+      fday = int(floor(jd) - floor(self.daily_panchaangas[0].julian_day_start))
+      if jd < self.daily_panchaangas[fday].jd_sunrise:
+        fday -= 1
+      return fday
+
+    fday_start, fday_end = day_of(jd_start), day_of(jd_end)
+
+    if fday_start == fday_end:
+      fday = fday_start
+    else:
+      # maghA spans two days: prefer whichever day's vRSabha-lagna overlaps with (or, failing
+      # that, lies closest to) the guru-siMha + sUrya-kumbha + candra-maghA window.
+      def vrishabha_interval(fday):
+        day_panchaanga = self.daily_panchaangas[fday]
+        lagna_start = day_panchaanga.jd_sunrise
+        for lagna_id, lagna_end in day_panchaanga.get_lagna_data(ayanaamsha_id=ayanaamsha_id):
+          if lagna_id == VRISHABHA:
+            return (lagna_start, lagna_end)
+          lagna_start = lagna_end
+        return None
+
+      candidates = []
+      for fday in (fday_start, fday_end):
+        vrishabha_span = vrishabha_interval(fday)
+        if vrishabha_span is None:
+          continue
+        overlap = min(jd_end, vrishabha_span[1]) - max(jd_start, vrishabha_span[0])
+        candidates.append((overlap, fday))
+
+      fday = max(candidates)[1] if candidates else fday_start
+
+    self.panchaanga.add_festival_instance(
+      festival_instance=FestivalInstance(name='mahAmaghOtsavaH', interval=Interval(jd_start=jd_start, jd_end=jd_end)),
+      date=self.daily_panchaangas[fday].date)
 
 # Essential for depickling to work.
 common.update_json_class_index(sys.modules[__name__])

--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -625,11 +625,19 @@ class SolarFestivalAssigner(FestivalAssigner):
 
     fday_start, fday_end = day_of(jd_start), day_of(jd_end)
 
-    if fday_start == fday_end:
-      fday = fday_start
+    # maghA's ~1.08-day duration means it can prevail at two (rarely, but possibly three)
+    # consecutive sunrises; a day only "owns" the anga if it prevails at that day's sunrise
+    # (the traditional anchor, as elsewhere in this codebase's sunrise_day_angas), so we can't
+    # just take fday_start/fday_end as the two candidates -- a day in between whose sunrise
+    # also falls within the window (as happens when maghA spans two full days) would be missed.
+    sunrise_candidates = [fday for fday in range(fday_start, fday_end + 1)
+                          if jd_start <= self.daily_panchaangas[fday].jd_sunrise <= jd_end]
+
+    if len(sunrise_candidates) <= 1:
+      fday = sunrise_candidates[0] if sunrise_candidates else fday_start
     else:
-      # maghA spans two days: prefer whichever day's vRSabha-lagna overlaps with (or, failing
-      # that, lies closest to) the guru-siMha + sUrya-kumbha + candra-maghA window.
+      # maghA prevails at more than one sunrise: prefer whichever day's vRSabha-lagna overlaps
+      # with (or, failing that, lies closest to) the guru-siMha + sUrya-kumbha + candra-maghA window.
       def vrishabha_interval(fday):
         day_panchaanga = self.daily_panchaangas[fday]
         lagna_start = day_panchaanga.jd_sunrise
@@ -640,14 +648,14 @@ class SolarFestivalAssigner(FestivalAssigner):
         return None
 
       candidates = []
-      for fday in (fday_start, fday_end):
+      for fday in sunrise_candidates:
         vrishabha_span = vrishabha_interval(fday)
         if vrishabha_span is None:
           continue
         overlap = min(jd_end, vrishabha_span[1]) - max(jd_start, vrishabha_span[0])
         candidates.append((overlap, fday))
 
-      fday = max(candidates)[1] if candidates else fday_start
+      fday = max(candidates)[1] if candidates else sunrise_candidates[0]
 
     self.panchaanga.add_festival_instance(
       festival_instance=FestivalInstance(name='mahAmaghOtsavaH', interval=Interval(jd_start=jd_start, jd_end=jd_end)),

--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -624,20 +624,26 @@ class SolarFestivalAssigner(FestivalAssigner):
       return fday
 
     fday_start, fday_end = day_of(jd_start), day_of(jd_end)
+    candidates = list(range(fday_start, fday_end + 1))
 
-    # maghA's ~1.08-day duration means it can prevail at two (rarely, but possibly three)
-    # consecutive sunrises; a day only "owns" the anga if it prevails at that day's sunrise
-    # (the traditional anchor, as elsewhere in this codebase's sunrise_day_angas), so we can't
-    # just take fday_start/fday_end as the two candidates -- a day in between whose sunrise
-    # also falls within the window (as happens when maghA spans two full days) would be missed.
-    sunrise_candidates = [fday for fday in range(fday_start, fday_end + 1)
-                          if jd_start <= self.daily_panchaangas[fday].jd_sunrise <= jd_end]
-
-    if len(sunrise_candidates) <= 1:
-      fday = sunrise_candidates[0] if sunrise_candidates else fday_start
+    if len(candidates) == 1:
+      fday = candidates[0]
     else:
-      # maghA prevails at more than one sunrise: prefer whichever day's vRSabha-lagna overlaps
-      # with (or, failing that, lies closest to) the guru-siMha + sUrya-kumbha + candra-maghA window.
+      # maghA (and hence the whole yoga) touches more than one calendar day. The snAna is
+      # traditionally best done in the afternoon, so prefer whichever day the yoga actually
+      # overlaps vRSabha-lagna on; vRSabha-lagna can miss every candidate day by just a few
+      # minutes though (it's a ~2-hour window against a multi-month-narrowed yoga), in which
+      # case fall back to whichever day's madhyAhna (early-afternoon kaala) it overlaps instead.
+      def best_by_overlap(get_interval_fn):
+        scored = []
+        for fday in candidates:
+          span = get_interval_fn(fday)
+          if span is None:
+            continue
+          overlap = min(jd_end, span[1]) - max(jd_start, span[0])
+          scored.append((overlap, fday))
+        return max(scored) if scored else None
+
       def vrishabha_interval(fday):
         day_panchaanga = self.daily_panchaangas[fday]
         lagna_start = day_panchaanga.jd_sunrise
@@ -647,15 +653,20 @@ class SolarFestivalAssigner(FestivalAssigner):
           lagna_start = lagna_end
         return None
 
-      candidates = []
-      for fday in sunrise_candidates:
-        vrishabha_span = vrishabha_interval(fday)
-        if vrishabha_span is None:
-          continue
-        overlap = min(jd_end, vrishabha_span[1]) - max(jd_start, vrishabha_span[0])
-        candidates.append((overlap, fday))
+      def madhyaahna_interval(fday):
+        madhyaahna = self.daily_panchaangas[fday].day_length_based_periods.fifteen_fold_division.madhyaahna
+        return (madhyaahna.jd_start, madhyaahna.jd_end)
 
-      fday = max(candidates)[1] if candidates else sunrise_candidates[0]
+      lagna_best = best_by_overlap(vrishabha_interval)
+      madhyaahna_best = best_by_overlap(madhyaahna_interval)
+      if lagna_best is not None and lagna_best[0] > 0:
+        fday = lagna_best[1]
+      elif madhyaahna_best is not None:
+        fday = madhyaahna_best[1]
+      elif lagna_best is not None:
+        fday = lagna_best[1]
+      else:
+        fday = fday_start
 
     self.panchaanga.add_festival_instance(
       festival_instance=FestivalInstance(name='mahAmaghOtsavaH', interval=Interval(jd_start=jd_start, jd_end=jd_end)),


### PR DESCRIPTION
## Summary
This PR adds support for calculating the Mahamagha Utsava festival, a Hindu observance that occurs when specific astronomical conditions align.

## Key Changes
- Added `assign_mahamagha_utsava()` method to the solar festival applier
- Integrated the new method into the `assign_all()` workflow
- Implemented multi-stage astronomical filtering to identify the festival occurrence:
  - Finds Jupiter's transit through Simha (Leo) rashi
  - Locates Sun's transit through Kumbha (Aquarius) rashi within Jupiter's Simha period
  - Identifies Magha nakshatra occurrence within the refined timeframe
  - Determines the optimal calendar day for the festival based on Vrishabha (Taurus) lagna and Madhyahna (afternoon) timing

## Implementation Details
- Uses cached `AngaSpanFinder` for efficient astronomical calculations across multiple celestial bodies and nakshatras
- Implements intelligent day selection logic when the festival spans multiple calendar days:
  - Prioritizes days with Vrishabha lagna overlap (traditional bathing time)
  - Falls back to Madhyahna (early afternoon) overlap if lagna is unavailable
  - Defaults to the festival start day if neither condition is met
- Gracefully handles edge cases where astronomical conditions don't align within the queried period
- Only processes if the festival rule exists in the rules collection

https://claude.ai/code/session_017sadin99NRcZmQdQ5AYCXJ