### PR TITLE
Accurate graha-yuddha/maudhya calculations, logging, and bAlya/vArdhakya events

### DIFF
--- a/jyotisha/panchaanga/spatio_temporal/periodical.py
+++ b/jyotisha/panchaanga/spatio_temporal/periodical.py
@@ -173,6 +173,12 @@ class Panchaanga(common.JsonObject):
     generic_assigner.cleanup_anadhyayana_festivals()
     generic_assigner.cleanup_festivals()
     self.clear_padding_day_festivals()
+    # Must run after clear_padding_day_festivals(): these events are
+    # deliberately computed via look-ahead/look-behind beyond
+    # [jd_start, jd_end] (see EclipticFestivalAssigner.assign_baalya_vardhakya),
+    # so they would otherwise be wiped right back out as "untrustworthy"
+    # padding-day festivals.
+    ecliptic.EclipticFestivalAssigner(panchaanga=self).assign_baalya_vardhakya()
 
 
   def _sync_festivals_dict_and_daily_festivals(self, here_to_daily=False, daily_to_here=True):

--- a/jyotisha/panchaanga/temporal/body.py
+++ b/jyotisha/panchaanga/temporal/body.py
@@ -163,12 +163,24 @@ class Graha(JsonObject):
   def get_speed(self, jd):
     """
     Get the speed of the body in degrees per day.
-    
-    :param jd: 
-    :return: 
+
+    :param jd:
+    :return:
     """
     delta = 0.0001
     return (self.get_longitude(jd + delta) - self.get_longitude(jd - delta)) / (2 * delta)
+
+  def get_phenomena(self, jd):
+    """
+    Get the (elongation from the sun, apparent angular diameter of disc) of
+    the body at a given jd, both in degrees, using swisseph's phenomena
+    computation (accounts for the body's actual distance from the earth).
+
+    :param jd:
+    :return: (elongation_degrees, diameter_degrees)
+    """
+    attr = swe.pheno_ut(jd, self._get_swisseph_id())
+    return attr[2], attr[3]
 
 
 def longitude_difference(jd, body1, body2):

--- a/jyotisha/panchaanga/temporal/body.py
+++ b/jyotisha/panchaanga/temporal/body.py
@@ -170,17 +170,51 @@ class Graha(JsonObject):
     delta = 0.0001
     return (self.get_longitude(jd + delta) - self.get_longitude(jd - delta)) / (2 * delta)
 
-  def get_phenomena(self, jd):
+  def get_phenomena(self, jd, geo_lon=None, geo_lat=None, geo_alt=0):
     """
-    Get the (elongation from the sun, apparent angular diameter of disc) of
-    the body at a given jd, both in degrees, using swisseph's phenomena
-    computation (accounts for the body's actual distance from the earth).
+    Get the (elongation from the sun, apparent angular diameter of disc,
+    apparent magnitude) of the body at a given jd, using swisseph's phenomena
+    computation (accounts for the body's actual distance from the earth, and
+    -- for diameter -- its true, oblateness-corrected volumetric-mean size,
+    not just its equatorial diameter).
 
     :param jd:
-    :return: (elongation_degrees, diameter_degrees)
+    :param geo_lon, geo_lat, geo_alt: if given, computes topocentric phenomena
+      (parallax-corrected for an observer at this location) instead of
+      geocentric. Matters little for diameter/magnitude, but keeps this
+      consistent with get_topocentric_lon_lat when both are used together.
+    :return: (elongation_degrees, diameter_degrees, magnitude)
     """
-    attr = swe.pheno_ut(jd, self._get_swisseph_id())
-    return attr[2], attr[3]
+    flag = swe.FLG_SWIEPH
+    if geo_lon is not None and geo_lat is not None:
+      swe.set_topo(geo_lon, geo_lat, geo_alt)
+      flag |= swe.FLG_TOPOCTR
+    attr = swe.pheno_ut(jd, self._get_swisseph_id(), flag)
+    return attr[2], attr[3], attr[4]
+
+  def get_topocentric_lon_lat(self, jd, geo_lon, geo_lat, geo_alt=0, ayanaamsha_id=None):
+    """
+    (longitude, latitude) in degrees, topocentric -- i.e. parallax-corrected
+    for an observer at geo_lon/geo_lat/geo_alt, rather than geocentric (as
+    get_longitude/get_latitude are). Parallax is negligible for the ecliptic
+    latitude of distant bodies but can shift a nearby body's apparent
+    longitude by a measurable amount, which matters when precisely timing a
+    locally-observed phenomenon like graha-yuddha.
+
+    :param ayanaamsha_id: if given, the returned longitude is sidereal
+      (ayanaamsha-corrected), matching get_longitude's convention.
+    """
+    swe.set_topo(geo_lon, geo_lat, geo_alt)
+    if self.body_name == Graha.KETU:
+      res = swe.calc_ut(jd, swe.TRUE_NODE, swe.FLG_TOPOCTR)[0]
+      lon, lat = (res[0] + 180) % 360, -res[1]
+    else:
+      res = swe.calc_ut(jd, self._get_swisseph_id(), swe.FLG_TOPOCTR)[0]
+      lon, lat = swe.degnorm(res[0]), res[1]
+    if ayanaamsha_id is not None:
+      from jyotisha.panchaanga.temporal.zodiac import Ayanamsha
+      lon = (lon - Ayanamsha.singleton(ayanaamsha_id).get_offset(jd)) % 360
+    return lon, lat
 
 
 def longitude_difference(jd, body1, body2):

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from math import floor
+from typing import NamedTuple
 import logging
 
 import swisseph as swe
@@ -24,6 +25,32 @@ GRAHA_NAMES = {Graha.SUN: 'sUryaH', Graha.MOON: 'candraH', Graha.VENUS: 'zukraH'
 # EclipticFestivalAssigner.get_graha_events_log_path()/add_graha_events_log_handler().
 graha_events_logger = logging.getLogger('jyotisha.graha_events')
 graha_events_logger.setLevel(logging.INFO)
+
+
+class ConjunctionInterval(NamedTuple):
+  """
+  A period during which two grahas' separation is below some delta.
+  start_clamped/end_clamped are True when t_start/t_end is not a genuine
+  entry/exit crossing but the edge of the queried [jd_start, jd_end] window
+  itself -- i.e. the period was already in progress when the scan started,
+  or was still in progress when the scan ended (see compute_conjunction_intervals).
+  """
+  t_start: float
+  t_zero: float
+  t_end: float
+  start_clamped: bool = False
+  end_clamped: bool = False
+
+
+class MaudhyaInterval(NamedTuple):
+  """Like ConjunctionInterval, with the graha's setting/rising direction at t_start/t_end."""
+  t_start: float
+  t_zero: float
+  t_end: float
+  dir_set: str
+  dir_rise: str
+  start_clamped: bool = False
+  end_clamped: bool = False
 
 
 class EclipticFestivalAssigner(FestivalAssigner):
@@ -236,12 +263,16 @@ class EclipticFestivalAssigner(FestivalAssigner):
     return "prAk" if az < 180 else "pratyak"
 
  
-  def compute_maudhya_intervals(self, graha: int, jd_start: float, jd_end: float, step: float = 0.5, use_latitude: bool = False) -> list[tuple[float, float, float, str, str]]:
+  def compute_maudhya_intervals(self, graha: int, jd_start: float, jd_end: float, step: float = 0.5, use_latitude: bool = False) -> list[MaudhyaInterval]:
     """
     Compute combustion (maudhya) intervals for a graha between jd_start and jd_end.
     Each interval includes:
       - setting direction at the start (t_start)
       - rising direction at the end (t_end)
+    dir_set/dir_rise are None when start_clamped/end_clamped (see
+    ConjunctionInterval) -- there is no genuine setting/rising moment at a
+    clamped boundary, since the graha was already combust (or still is) at
+    that point, not becoming so right then.
 
     :param use_latitude: see compute_conjunction_intervals - applies the
       akSAMza (observer-latitude, oblique-ascension) correction rather than
@@ -278,19 +309,19 @@ class EclipticFestivalAssigner(FestivalAssigner):
     )
 
     conjunction_intervals = []
-    for t_start, t_zero, t_end in candidate_intervals:
-        is_retro = self.is_retrograde(graha, t_zero)
+    for ci in candidate_intervals:
+        is_retro = self.is_retrograde(graha, ci.t_zero)
         delta = limits["retrograde" if is_retro else "prograde"]
         if delta == scan_delta:
-            conjunction_intervals.append((t_start, t_zero, t_end))
+            conjunction_intervals.append(ci)
             continue
         # delta is narrower than scan_delta: re-bracket within the
         # already-found (wider) window using the correct, narrower delta.
         refined = self.compute_conjunction_intervals(
             graha1=graha,
             graha2=Graha.SUN,
-            jd_start=t_start,
-            jd_end=t_end,
+            jd_start=ci.t_start,
+            jd_end=ci.t_end,
             delta=delta,
             step=step,
             use_latitude=use_latitude
@@ -298,17 +329,17 @@ class EclipticFestivalAssigner(FestivalAssigner):
         if refined:
             conjunction_intervals.append(refined[0])
         else:
-            logging.warning(f"Could not refine maudhya interval near jd={t_zero} for {graha} with delta={delta}")
+            logging.warning(f"Could not refine maudhya interval near jd={ci.t_zero} for {graha} with delta={delta}")
 
     intervals = []
 
-    for t_start, t_zero, t_end in conjunction_intervals:
+    for ci in conjunction_intervals:
         try:
-            dir_set = self.get_setting_direction(graha, t_start)
-            dir_rise = self.get_rising_direction(graha, t_end)
-            intervals.append((t_start, t_zero, t_end, dir_rise, dir_set))
+            dir_set = None if ci.start_clamped else self.get_setting_direction(graha, ci.t_start)
+            dir_rise = None if ci.end_clamped else self.get_rising_direction(graha, ci.t_end)
+            intervals.append(MaudhyaInterval(ci.t_start, ci.t_zero, ci.t_end, dir_set, dir_rise, ci.start_clamped, ci.end_clamped))
         except Exception as e:
-            logging.warning(f"Could not determine directions for maudhya interval ({t_start}, {t_end}): {e}")
+            logging.warning(f"Could not determine directions for maudhya interval ({ci.t_start}, {ci.t_end}): {e}")
     return intervals
 
 
@@ -319,29 +350,49 @@ class EclipticFestivalAssigner(FestivalAssigner):
     # empirically-validated convention, and applies uniformly to every graha,
     # Chandra included, not just the five star-planets.
     maudhya_intervals = self.compute_maudhya_intervals(graha, self.panchaanga.jd_start, self.panchaanga.jd_end, use_latitude=True)
-    for t_start, t_zero, t_end, dir_rise, dir_set in maudhya_intervals:
-        details = self.get_graha_yuddha_details(graha, Graha.SUN, t_zero)
+    for mi in maudhya_intervals:
+        details = self.get_graha_yuddha_details(graha, Graha.SUN, mi.t_zero)
         graha_events_logger.info(self.format_graha_event_report(
-            event_label=f"maudhyam ({GRAHA_NAMES[graha]})", graha1=graha, graha2=Graha.SUN, jd=t_zero,
+            event_label=f"maudhyam ({GRAHA_NAMES[graha]})", graha1=graha, graha2=Graha.SUN, jd=mi.t_zero,
             details=details, include_winner=False))
         try:
-            fday = int(t_start - self.daily_panchaangas[0].julian_day_start)
-            if t_start < self.daily_panchaangas[fday].jd_sunrise:
+            fday = int(mi.t_start - self.daily_panchaangas[0].julian_day_start)
+            if mi.t_start < self.daily_panchaangas[fday].jd_sunrise:
                 fday -= 1
-            self.panchaanga.add_festival_instance(FestivalInstance(
-                name=f"{GRAHA_NAMES[graha]}–astamayaH ({dir_set})",
-                interval=Interval(jd_start=t_start, jd_end=None)
-            ), date=self.daily_panchaangas[fday].date)
+            if mi.start_clamped:
+              # The graha was already combust when this panchaanga's period
+              # began -- the true astamayaH (setting into combustion) happened
+              # earlier, outside the computed range, so don't claim it as an
+              # event at this (arbitrary, boundary) instant. Note the ongoing
+              # state instead.
+              self.panchaanga.add_festival_instance(FestivalInstance(
+                  name=f"{GRAHA_NAMES[graha]}–maudhyam~(pUrvam~ArabdhaH)",
+                  interval=Interval(jd_start=mi.t_start, jd_end=None)
+              ), date=self.daily_panchaangas[fday].date)
+            else:
+              self.panchaanga.add_festival_instance(FestivalInstance(
+                  name=f"{GRAHA_NAMES[graha]}–astamayaH ({mi.dir_set})",
+                  interval=Interval(jd_start=mi.t_start, jd_end=None)
+              ), date=self.daily_panchaangas[fday].date)
         except ValueError:
             logging.warning("Could not assign festival day for maudhya start event.")
         try:
-          fday = int(t_end - self.daily_panchaangas[0].julian_day_start)
-          if t_end < self.daily_panchaangas[fday].jd_sunrise:
+          fday = int(mi.t_end - self.daily_panchaangas[0].julian_day_start)
+          if mi.t_end < self.daily_panchaangas[fday].jd_sunrise:
             fday -= 1
-          self.panchaanga.add_festival_instance(FestivalInstance(
-              name=f"{GRAHA_NAMES[graha]}–udayaH ({dir_rise})",
-              interval=Interval(jd_start=None, jd_end=t_end)
-          ), date=self.daily_panchaangas[fday].date)
+          if mi.end_clamped:
+            # Symmetric to start_clamped: the graha is still combust at the
+            # end of this panchaanga's period, with the true udayaH (rising
+            # out of combustion) beyond the computed range.
+            self.panchaanga.add_festival_instance(FestivalInstance(
+                name=f"{GRAHA_NAMES[graha]}–maudhyam~(uttaram~sthitaH)",
+                interval=Interval(jd_start=None, jd_end=mi.t_end)
+            ), date=self.daily_panchaangas[fday].date)
+          else:
+            self.panchaanga.add_festival_instance(FestivalInstance(
+                name=f"{GRAHA_NAMES[graha]}–udayaH ({mi.dir_rise})",
+                interval=Interval(jd_start=None, jd_end=mi.t_end)
+            ), date=self.daily_panchaangas[fday].date)
         except ValueError:
           logging.warning("Could not assign festival day for maudhya end event.")
 
@@ -357,12 +408,20 @@ class EclipticFestivalAssigner(FestivalAssigner):
     if 'candra-darzanam' not in self.rules_collection.name_to_rule and not force_computation:
       return
     maudhya_intervals = self.compute_maudhya_intervals(Graha.MOON, self.panchaanga.jd_start, self.panchaanga.jd_end, use_latitude=True)
-    for t_start, t_zero, t_end, dir_rise, dir_set in maudhya_intervals:
+    for mi in maudhya_intervals:
+      if mi.end_clamped:
+        # The Moon hadn't actually cleared the akSAMza threshold by jd_end --
+        # mi.t_end is just the scan boundary, not a real clearing moment, so
+        # there is no real candra-darzanam to report here (the moon isn't
+        # visible yet as the period ends). The true clearing happens shortly
+        # after, outside this panchaanga's computed range.
+        logging.warning(f"Moon's maudhya interval starting {mi.t_start} does not clear by jd_end={mi.t_end}; no candra-darzanam within range.")
+        continue
       try:
-        fday = int(t_end - self.daily_panchaangas[0].julian_day_start)
-        if t_end < self.daily_panchaangas[fday].jd_sunrise:
+        fday = int(mi.t_end - self.daily_panchaangas[0].julian_day_start)
+        if mi.t_end < self.daily_panchaangas[fday].jd_sunrise:
           fday -= 1
-        if t_end > self.daily_panchaangas[fday].jd_sunset:
+        if mi.t_end > self.daily_panchaangas[fday].jd_sunset:
           # This panchaanga-day's sunset has already passed by t_end (the Moon
           # hadn't cleared the akSAMza threshold yet that evening) - the first
           # upcoming viewing opportunity is the following evening.
@@ -376,7 +435,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
         )
         self.panchaanga.add_festival_instance(festival_instance=fest, date=self.daily_panchaangas[fday].date)
       except (ValueError, IndexError):
-        logging.warning(f"Could not assign candra-darzanam for maudhya interval ending {t_end}.")
+        logging.warning(f"Could not assign candra-darzanam for maudhya interval ending {mi.t_end}.")
 
   def compute_conjunction_intervals(
     self,
@@ -388,10 +447,10 @@ class EclipticFestivalAssigner(FestivalAssigner):
     step: float = 0.5,
     debug: bool = False,
     use_latitude: bool = False
-    ) -> list[tuple[float, float, float]]:
+    ) -> list[ConjunctionInterval]:
     """
     Compute intervals where the angular separation between two grahas is less than `delta`.
-    Returns a list of (t_start, t_zero, t_end) tuples.
+    Returns a list of ConjunctionInterval.
 
     :param use_latitude: If False (default), separation is just the ecliptic
       longitude difference (kranti-vRtta convention). If True, the entry/exit
@@ -427,6 +486,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
         return abs((oa1 - oa2 + 180) % 360 - 180)
 
     inside = False
+    start_clamped = False
     t_start = None
     jd = jd_start
 
@@ -438,6 +498,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
         # and fail to bracket forever (both endpoints on the same side),
         # silently dropping the whole interval. Clamp the start to jd_start.
         inside = True
+        start_clamped = True
         t_start = jd_start
 
     while jd <= jd_end:
@@ -447,6 +508,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
             try:
                 t_start = brentq(lambda x: separation(x) - delta, jd - step, jd)
                 inside = True
+                start_clamped = False
             except ValueError:
                 logging.warning(f"Could not bracket start of proximity at {jd}")
         elif inside and sep > delta:
@@ -455,7 +517,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
                 # Now compute t_zero (exact conjunction), always longitude-based.
                 try:
                     t_zero = brentq(wrapped_longitude_diff, t_start, t_end)
-                    intervals.append((t_start, t_zero, t_end))
+                    intervals.append(ConjunctionInterval(t_start, t_zero, t_end, start_clamped, False))
                 except ValueError:
                     logging.warning(f"Could not find t_zero between {t_start} and {t_end}")
                 inside = False
@@ -470,18 +532,18 @@ class EclipticFestivalAssigner(FestivalAssigner):
         # skip it (with a warning) if it doesn't.
         try:
             t_zero = brentq(wrapped_longitude_diff, t_start, jd_end)
-            intervals.append((t_start, t_zero, jd_end))
+            intervals.append(ConjunctionInterval(t_start, t_zero, jd_end, start_clamped, True))
         except ValueError:
             logging.warning(f"Proximity interval starting {t_start} does not end (or reach exact conjunction) by jd_end={jd_end}; dropping it")
 
     if debug:
       # Show the longitudes of each graha at the start and end of the interval
       logging.debug(f"Intervals for {graha1} and {graha2}:")
-      for t_start, t_zero, t_end in intervals:
-          logging.debug(f"  Interval   : {Interval(jd_start=t_start, jd_end=t_end)}")
-          logging.debug(f"  Conjunction: {Interval(jd_start=t_zero, jd_end=t_zero)}")
-          logging.debug(f"  Start: t_start, {g1.get_longitude(t_start, ayanaamsha_id=self.ayanaamsha_id)}, {g2.get_longitude(t_start, ayanaamsha_id=self.ayanaamsha_id)}")
-          logging.debug(f"  End: t_end, {g1.get_longitude(t_end, ayanaamsha_id=self.ayanaamsha_id)}, {g2.get_longitude(t_end, ayanaamsha_id=self.ayanaamsha_id)}")
+      for ci in intervals:
+          logging.debug(f"  Interval   : {Interval(jd_start=ci.t_start, jd_end=ci.t_end)} (start_clamped={ci.start_clamped}, end_clamped={ci.end_clamped})")
+          logging.debug(f"  Conjunction: {Interval(jd_start=ci.t_zero, jd_end=ci.t_zero)}")
+          logging.debug(f"  Start: t_start, {g1.get_longitude(ci.t_start, ayanaamsha_id=self.ayanaamsha_id)}, {g2.get_longitude(ci.t_start, ayanaamsha_id=self.ayanaamsha_id)}")
+          logging.debug(f"  End: t_end, {g1.get_longitude(ci.t_end, ayanaamsha_id=self.ayanaamsha_id)}, {g2.get_longitude(ci.t_end, ayanaamsha_id=self.ayanaamsha_id)}")
 
     return intervals
   

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -464,6 +464,15 @@ class EclipticFestivalAssigner(FestivalAssigner):
 
     return intervals
   
+  def get_topocentric_longitude_difference(self, graha1: int, graha2: int, jd: float) -> float:
+    """Signed topocentric longitude difference (degrees, in (-180, 180]) between two grahas."""
+    g1 = Graha.singleton(graha1)
+    g2 = Graha.singleton(graha2)
+    city = self.panchaanga.city
+    lon1, _ = g1.get_topocentric_lon_lat(jd, city.longitude, city.latitude, ayanaamsha_id=self.ayanaamsha_id)
+    lon2, _ = g2.get_topocentric_lon_lat(jd, city.longitude, city.latitude, ayanaamsha_id=self.ayanaamsha_id)
+    return ((lon1 - lon2 + 180) % 360) - 180
+
   def get_angular_separation(self, graha1: int, graha2: int, jd: float) -> float:
     """
     True angular separation (degrees) between two grahas, accounting for both
@@ -490,8 +499,18 @@ class EclipticFestivalAssigner(FestivalAssigner):
     """
     Compute intervals during which the true angular separation (see
     get_angular_separation) between two grahas is less than `delta` degrees,
-    together with the jd of closest approach (t_zero) within each interval.
-    Returns a list of (t_start, t_zero, t_end) tuples.
+    together with the jd of exact longitude-equality (t_zero, the classical
+    "yuti" instant) within each interval. Returns a list of
+    (t_start, t_zero, t_end) tuples.
+
+    t_zero is the moment of exact (topocentric) longitude equality, not the
+    moment of minimum total (longitude+latitude) separation -- verified
+    against a published graha-yuddha report (the 2020-Dec-21 Jupiter-Saturn
+    "great conjunction"): the report's timestamp and longitude match the
+    longitude-equality instant to the second/arcsecond, while the
+    minimum-separation instant (found by minimizing get_angular_separation)
+    was off by ~45 minutes, since the separation curve for slow-moving grahas
+    is nearly flat near its minimum.
     """
     intervals = []
     inside = False
@@ -500,6 +519,9 @@ class EclipticFestivalAssigner(FestivalAssigner):
 
     def sep(x):
       return self.get_angular_separation(graha1, graha2, x)
+
+    def lon_diff(x):
+      return self.get_topocentric_longitude_difference(graha1, graha2, x)
 
     while jd <= jd_end:
       d = sep(jd)
@@ -512,7 +534,14 @@ class EclipticFestivalAssigner(FestivalAssigner):
       elif inside and d > delta:
         try:
           t_end = brentq(lambda x: sep(x) - delta, jd - step, jd)
-          t_zero = minimize_scalar(sep, bounds=(t_start, t_end), method='bounded').x
+          try:
+            t_zero = brentq(lon_diff, t_start, t_end)
+          except ValueError:
+            # No exact longitude-equality moment in this window (can happen
+            # when the discs' proximity is dominated by latitude rather than
+            # longitude) -- fall back to the minimum-separation instant.
+            logging.warning(f"No longitude-equality moment between {t_start} and {t_end}; using minimum-separation instant instead")
+            t_zero = minimize_scalar(sep, bounds=(t_start, t_end), method='bounded').x
           intervals.append((t_start, t_zero, t_end))
         except ValueError:
           logging.warning(f"Could not bracket end of graha-yuddha at {jd}")

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -884,8 +884,13 @@ class EclipticFestivalAssigner(FestivalAssigner):
             # either side's nakshatra/rashi identifies where the yuddha peaks.
             peak_rashi = details[graha1]['rashi']
             peak_nakshatra = details[graha1]['nakshatra']
+            # No leading '★' here (unlike some static festival names elsewhere) --
+            # neither of the tex output's fonts (siddhanta.ttf, AlegreyaSans-Regular.ttf)
+            # actually contain that glyph, so xetex/luatex would just drop it with a
+            # "Missing character" warning. Winner-vs-loser is already conveyed by the
+            # {winner}-{loser} ordering, so the star isn't needed here.
             fest = FestivalInstance(
-                name=f"graha-yuddhaH~(★{GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]},~{peak_nakshatra}~{peak_rashi})",
+                name=f"graha-yuddhaH~({GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]},~{peak_nakshatra}~{peak_rashi})",
                 interval=Interval(jd_start=t_start, jd_end=t_end)
             )
             self.panchaanga.add_festival_instance(fest, date=self.daily_panchaangas[fday].date)

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -692,8 +692,12 @@ class EclipticFestivalAssigner(FestivalAssigner):
                 event_label=f"graha-yuddhaH ({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]})", graha1=graha1, graha2=graha2,
                 jd=t_zero, details=details))
 
+            # Both grahas share the same longitude at t_zero by definition, so
+            # either side's nakshatra/rashi identifies where the yuddha peaks.
+            peak_rashi = details[graha1]['rashi']
+            peak_nakshatra = details[graha1]['nakshatra']
             fest = FestivalInstance(
-                name=f"graha-yuddhaH~(★{GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]})",
+                name=f"graha-yuddhaH~(★{GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]},~{peak_nakshatra}~{peak_rashi})",
                 interval=Interval(jd_start=t_start, jd_end=t_end)
             )
             self.panchaanga.add_festival_instance(fest, date=self.daily_panchaangas[fday].date)

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -430,6 +430,16 @@ class EclipticFestivalAssigner(FestivalAssigner):
     t_start = None
     jd = jd_start
 
+    if separation(jd_start) < delta:
+        # Already within the threshold at the start of the scan window (e.g. a
+        # maudhya/conjunction period straddling jd_start) -- there is no
+        # outside->inside crossing to bracket within [jd_start, jd_end], so
+        # every subsequent sample would otherwise hit the not-inside branch
+        # and fail to bracket forever (both endpoints on the same side),
+        # silently dropping the whole interval. Clamp the start to jd_start.
+        inside = True
+        t_start = jd_start
+
     while jd <= jd_end:
         sep = separation(jd)
 
@@ -452,6 +462,17 @@ class EclipticFestivalAssigner(FestivalAssigner):
             except ValueError:
                 logging.warning(f"Could not bracket end of proximity at {jd}")
         jd += step
+
+    if inside:
+        # Still inside at the end of the scan window (the period's true exit
+        # is beyond jd_end) -- clamp the end to jd_end rather than silently
+        # dropping the interval. t_zero may or may not fall within range;
+        # skip it (with a warning) if it doesn't.
+        try:
+            t_zero = brentq(wrapped_longitude_diff, t_start, jd_end)
+            intervals.append((t_start, t_zero, jd_end))
+        except ValueError:
+            logging.warning(f"Proximity interval starting {t_start} does not end (or reach exact conjunction) by jd_end={jd_end}; dropping it")
 
     if debug:
       # Show the longitudes of each graha at the start and end of the interval
@@ -523,6 +544,25 @@ class EclipticFestivalAssigner(FestivalAssigner):
     def lon_diff(x):
       return self.get_topocentric_longitude_difference(graha1, graha2, x)
 
+    def find_t_zero(t_start, t_end):
+      try:
+        return brentq(lon_diff, t_start, t_end)
+      except ValueError:
+        # No exact longitude-equality moment in this window (can happen
+        # when the discs' proximity is dominated by latitude rather than
+        # longitude) -- fall back to the minimum-separation instant.
+        logging.warning(f"No longitude-equality moment between {t_start} and {t_end}; using minimum-separation instant instead")
+        return minimize_scalar(sep, bounds=(t_start, t_end), method='bounded').x
+
+    if sep(jd_start) < delta:
+      # Already within the threshold at the start of the scan window -- there
+      # is no outside->inside crossing to bracket within [jd_start, jd_end],
+      # so every subsequent sample would otherwise hit the not-inside branch
+      # and fail to bracket forever (both endpoints on the same side),
+      # silently dropping the whole interval. Clamp the start to jd_start.
+      inside = True
+      t_start = jd_start
+
     while jd <= jd_end:
       d = sep(jd)
       if not inside and d < delta:
@@ -534,19 +574,18 @@ class EclipticFestivalAssigner(FestivalAssigner):
       elif inside and d > delta:
         try:
           t_end = brentq(lambda x: sep(x) - delta, jd - step, jd)
-          try:
-            t_zero = brentq(lon_diff, t_start, t_end)
-          except ValueError:
-            # No exact longitude-equality moment in this window (can happen
-            # when the discs' proximity is dominated by latitude rather than
-            # longitude) -- fall back to the minimum-separation instant.
-            logging.warning(f"No longitude-equality moment between {t_start} and {t_end}; using minimum-separation instant instead")
-            t_zero = minimize_scalar(sep, bounds=(t_start, t_end), method='bounded').x
-          intervals.append((t_start, t_zero, t_end))
+          intervals.append((t_start, find_t_zero(t_start, t_end), t_end))
         except ValueError:
           logging.warning(f"Could not bracket end of graha-yuddha at {jd}")
         inside = False
       jd += step
+
+    if inside:
+      # Still inside at the end of the scan window (the period's true exit is
+      # beyond jd_end) -- clamp the end to jd_end rather than silently
+      # dropping the interval.
+      intervals.append((t_start, find_t_zero(t_start, jd_end), jd_end))
+
     return intervals
 
   @staticmethod

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -17,6 +17,15 @@ from scipy.optimize import brentq, minimize_scalar
 from sanskrit_data.schema import common
 from indic_transliteration import sanscript
 
+GRAHA_NAMES = {Graha.SUN: 'sUryaH', Graha.MOON: 'candraH', Graha.VENUS: 'zukraH', Graha.MERCURY: 'budhaH', Graha.MARS: 'aGgArakaH',
+    Graha.SATURN: 'zaniH', Graha.JUPITER: 'guruH'}
+
+# Dedicated logger (and log file) for graha-yuddha, maudhya etc. events -- see
+# EclipticFestivalAssigner.get_graha_events_log_path()/add_graha_events_log_handler().
+graha_events_logger = logging.getLogger('jyotisha.graha_events')
+graha_events_logger.setLevel(logging.INFO)
+
+
 class EclipticFestivalAssigner(FestivalAssigner):
   def assign_all(self):
     self.set_jupiter_transits()
@@ -219,7 +228,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
     return "prAk" if az < 180 else "pratyak"
 
  
-  def compute_maudhya_intervals(self, graha: int, jd_start: float, jd_end: float, step: float = 0.5, use_latitude: bool = False) -> list[tuple[float, float, str, str]]:
+  def compute_maudhya_intervals(self, graha: int, jd_start: float, jd_end: float, step: float = 0.5, use_latitude: bool = False) -> list[tuple[float, float, float, str, str]]:
     """
     Compute combustion (maudhya) intervals for a graha between jd_start and jd_end.
     Each interval includes:
@@ -284,26 +293,29 @@ class EclipticFestivalAssigner(FestivalAssigner):
             logging.warning(f"Could not refine maudhya interval near jd={t_zero} for {graha} with delta={delta}")
 
     intervals = []
-    
+
     for t_start, t_zero, t_end in conjunction_intervals:
         try:
             dir_set = self.get_setting_direction(graha, t_start)
             dir_rise = self.get_rising_direction(graha, t_end)
-            intervals.append((t_start, t_end, dir_rise, dir_set))
+            intervals.append((t_start, t_zero, t_end, dir_rise, dir_set))
         except Exception as e:
             logging.warning(f"Could not determine directions for maudhya interval ({t_start}, {t_end}): {e}")
     return intervals
 
 
-  def add_maudhya_events(self, graha: int):
-    GRAHA_NAMES = {Graha.VENUS: 'zukraH', Graha.MERCURY: 'budhaH', Graha.MARS: 'aGgArakaH',
-        Graha.SATURN: 'zaniH', Graha.JUPITER: 'guruH', Graha.MOON: 'candraH'}
+  def add_maudhya_events(self, graha: int, log_path=None):
+    log_path = self.add_graha_events_log_handler(log_path)
     # use_latitude=True: apply the akSAMza (observer-latitude, oblique-ascension)
     # correction - see compute_conjunction_intervals docstring. This is the
     # empirically-validated convention, and applies uniformly to every graha,
     # Chandra included, not just the five star-planets.
     maudhya_intervals = self.compute_maudhya_intervals(graha, self.panchaanga.jd_start, self.panchaanga.jd_end, use_latitude=True)
-    for t_start, t_end, dir_rise, dir_set in maudhya_intervals:
+    for t_start, t_zero, t_end, dir_rise, dir_set in maudhya_intervals:
+        details = self.get_graha_yuddha_details(graha, Graha.SUN, t_zero)
+        graha_events_logger.info(self.format_graha_event_report(
+            event_label=f"maudhyam ({GRAHA_NAMES[graha]})", graha1=graha, graha2=Graha.SUN, jd=t_zero,
+            details=details, include_winner=False))
         try:
             fday = int(t_start - self.daily_panchaangas[0].julian_day_start)
             if t_start < self.daily_panchaangas[fday].jd_sunrise:
@@ -520,10 +532,60 @@ class EclipticFestivalAssigner(FestivalAssigner):
     details['winner'] = graha1 if details[graha1]['diameter'] >= details[graha2]['diameter'] else graha2
     return details
 
-  def add_graha_yuddhas(self):
+  def get_graha_events_log_path(self) -> str:
+    """Default path for the graha-events (maudhya, graha-yuddha, ...) log file."""
+    city_str = self.panchaanga.city.name.replace(' ', '_').replace('/', '_')
+    fname = f"{city_str}_{self.panchaanga.start_date.year}-{self.panchaanga.end_date.year}_graha_events.log"
+    return os.path.join(os.getcwd(), fname)
+
+  def add_graha_events_log_handler(self, log_path: str = None) -> str:
+    """
+    Ensure graha_events_logger writes to `log_path` (or get_graha_events_log_path()
+    if not given), and return the path used. Safe to call repeatedly -- a given
+    file is only attached once.
+    """
+    log_path = os.path.abspath(log_path or self.get_graha_events_log_path())
+    if not any(isinstance(h, logging.FileHandler) and h.baseFilename == log_path for h in graha_events_logger.handlers):
+      os.makedirs(os.path.dirname(log_path), exist_ok=True)
+      handler = logging.FileHandler(log_path)
+      handler.setFormatter(logging.Formatter('%(message)s'))
+      graha_events_logger.addHandler(handler)
+    return log_path
+
+  def format_graha_event_report(self, event_label: str, graha1: int, graha2: int, jd: float, details: dict, include_winner: bool = True) -> str:
+    """
+    Render `details` (as returned by get_graha_yuddha_details) as a
+    human-readable multi-line report, in the spirit of:
+
+      Date: 2021-Mar-05 08:57 -
+        Amshuvimarda ,   0°19'42.70" separation
+        Guru   , lat:    0°35'08.87" S
+                 gati:     13'28.59" riju
+                 dia:       0'32.48" increasing
+        ...
+        Elongation:     27°13'32.29" W
+    """
+    tz = self.panchaanga.city.get_timezone_obj()
+    lines = [
+        f"{event_label}",
+        f"Date: {tz.julian_day_to_local_time_str(jd)} -",
+        f"  Separation: {self.format_dms(details['separation'])}",
+    ]
+    for graha in (graha1, graha2):
+      d = details[graha]
+      name = GRAHA_NAMES.get(graha, graha)
+      lines.append(f"  {name}, longitude: {self.format_dms(d['longitude'])} {d['nakshatra']}-{d['pada']} {d['rashi']}")
+      lines.append(f"           lat: {self.format_dms(d['latitude'])} {d['lat_dir']}")
+      lines.append(f"           gati: {self.format_arcmin(d['speed'])} {d['motion']}")
+      lines.append(f"           dia: {self.format_arcmin(d['diameter'])} {d['diameter_trend']}")
+      lines.append(f"           elongation: {self.format_dms(d['elongation'])} {d['elong_dir']}")
+    if include_winner:
+      lines.append(f"  jayI (victor): {GRAHA_NAMES.get(details['winner'], details['winner'])}")
+    return "\n".join(lines) + "\n"
+
+  def add_graha_yuddhas(self, log_path=None):
     TARA_GRAHAS = (Graha.MERCURY, Graha.VENUS, Graha.MARS, Graha.JUPITER, Graha.SATURN)
-    GRAHA_NAMES = {Graha.VENUS: 'zukraH', Graha.MERCURY: 'budhaH', Graha.MARS: 'aGgArakaH',
-        Graha.SATURN: 'zaniH', Graha.JUPITER: 'guruH'}
+    log_path = self.add_graha_events_log_handler(log_path)
 
     for graha1 in TARA_GRAHAS:
       for graha2 in TARA_GRAHAS:
@@ -537,22 +599,9 @@ class EclipticFestivalAssigner(FestivalAssigner):
               fday -= 1
 
             details = self.get_graha_yuddha_details(graha1, graha2, t_zero)
-
-            def graha_detail_log(graha):
-              d = details[graha]
-              return (f"  {GRAHA_NAMES[graha]}: nakSatram {d['nakshatra']}-{d['pada']} rAziH {d['rashi']},"
-                      f" akSAMSaH {self.format_dms(d['latitude'])} {d['lat_dir']},"
-                      f" gatiH {self.format_arcmin(d['speed'])} {d['motion']},"
-                      f" bimba-vyAsaH {self.format_arcmin(d['diameter'])} {d['diameter_trend']},"
-                      f" digaMSaH {self.format_dms(d['elongation'])} {d['elong_dir']}")
-
-            logging.debug(
-                f"graha-yuddhaH ({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]}) at jd={t_zero}:\n"
-                f"  aMSu-vimardaH: {self.format_dms(details['separation'])}\n"
-                f"{graha_detail_log(graha1)}\n"
-                f"{graha_detail_log(graha2)}\n"
-                f"  jayI: {GRAHA_NAMES[details['winner']]}"
-            )
+            graha_events_logger.info(self.format_graha_event_report(
+                event_label=f"graha-yuddhaH ({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]})", graha1=graha1, graha2=graha2,
+                jd=t_zero, details=details))
 
             fest = FestivalInstance(
                 name=f"graha-yuddhaH~({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]},~jayI~{GRAHA_NAMES[details['winner']]})",

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -884,13 +884,8 @@ class EclipticFestivalAssigner(FestivalAssigner):
             # either side's nakshatra/rashi identifies where the yuddha peaks.
             peak_rashi = details[graha1]['rashi']
             peak_nakshatra = details[graha1]['nakshatra']
-            # No leading '★' here (unlike some static festival names elsewhere) --
-            # neither of the tex output's fonts (siddhanta.ttf, AlegreyaSans-Regular.ttf)
-            # actually contain that glyph, so xetex/luatex would just drop it with a
-            # "Missing character" warning. Winner-vs-loser is already conveyed by the
-            # {winner}-{loser} ordering, so the star isn't needed here.
             fest = FestivalInstance(
-                name=f"graha-yuddhaH~({GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]},~{peak_nakshatra}~{peak_rashi})",
+                name=f"graha-yuddhaH~(★{GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]},~{peak_nakshatra}~{peak_rashi})",
                 interval=Interval(jd_start=t_start, jd_end=t_end)
             )
             self.panchaanga.add_festival_instance(fest, date=self.daily_panchaangas[fday].date)

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -492,19 +492,18 @@ class EclipticFestivalAssigner(FestivalAssigner):
     Empirically validated to the minute against a real drik-gaNita reference
     table. Supersedes TithiFestivalAssigner.assign_chandra_darshanam_legacy()'s
     tithi-at-moonset heuristic, which is retained there for reference.
+
+    Unlike add_baalya_vardhakya_events, this deliberately doesn't scan past
+    [jd_start, jd_end] or special-case a clamped mi.t_end: the Moon's
+    maudhya cycle is a couple of days at most, so a clamped interval right
+    at jd_end is rare and the following evening's occurrence (computed on
+    the next run, with jd_start shifted forward) covers it -- not worth the
+    extra complexity that matters for the slow-moving grahas' bAlya/vArdhakya.
     """
     if 'candra-darzanam' not in self.rules_collection.name_to_rule and not force_computation:
       return
     maudhya_intervals = self.compute_maudhya_intervals(Graha.MOON, self.panchaanga.jd_start, self.panchaanga.jd_end, use_latitude=True)
     for mi in maudhya_intervals:
-      if mi.end_clamped:
-        # The Moon hadn't actually cleared the akSAMza threshold by jd_end --
-        # mi.t_end is just the scan boundary, not a real clearing moment, so
-        # there is no real candra-darzanam to report here (the moon isn't
-        # visible yet as the period ends). The true clearing happens shortly
-        # after, outside this panchaanga's computed range.
-        logging.warning(f"Moon's maudhya interval starting {mi.t_start} does not clear by jd_end={mi.t_end}; no candra-darzanam within range.")
-        continue
       try:
         fday = int(mi.t_end - self.daily_panchaangas[0].julian_day_start)
         if mi.t_end < self.daily_panchaangas[fday].jd_sunrise:

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -571,6 +571,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
           'elong_dir': 'W' if elong_diff < 0 else 'E',
       }
     details['winner'] = graha1 if details[graha1]['diameter'] >= details[graha2]['diameter'] else graha2
+    details['loser'] = graha2 if details['winner'] == graha1 else graha1
     return details
 
   def get_graha_events_log_path(self) -> str:
@@ -645,7 +646,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
                 jd=t_zero, details=details))
 
             fest = FestivalInstance(
-                name=f"graha-yuddhaH~({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]},~jayI~{GRAHA_NAMES[details['winner']]})",
+                name=f"graha-yuddhaH~(★{GRAHA_NAMES[details['winner']]}-{GRAHA_NAMES[details['loser']]})",
                 interval=Interval(jd_start=t_start, jd_end=t_end)
             )
             self.panchaanga.add_festival_instance(fest, date=self.daily_panchaangas[fday].date)

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -13,7 +13,7 @@ from jyotisha.panchaanga.temporal.festival import FestivalInstance, TransitionFe
 from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
 from jyotisha.panchaanga.temporal.interval import Interval
 from jyotisha.panchaanga.temporal.zodiac import AngaType
-from scipy.optimize import brentq
+from scipy.optimize import brentq, minimize_scalar
 from sanskrit_data.schema import common
 from indic_transliteration import sanscript
 
@@ -411,26 +411,154 @@ class EclipticFestivalAssigner(FestivalAssigner):
 
     return intervals
   
+  def get_angular_separation(self, graha1: int, graha2: int, jd: float) -> float:
+    """
+    True angular separation (degrees) between two grahas, accounting for both
+    longitude and ecliptic latitude. Graha-yuddha (amshu-vimarda) is defined
+    by proximity of the two discs, not merely by longitude, so latitude must
+    be taken into account to identify the interval and moment of conflict
+    correctly.
+    """
+    g1 = Graha.singleton(graha1)
+    g2 = Graha.singleton(graha2)
+    dlon = ((g1.get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id) -
+             g2.get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id) + 180) % 360) - 180
+    dlat = g1.get_latitude(jd) - g2.get_latitude(jd)
+    return (dlon ** 2 + dlat ** 2) ** 0.5
+
+  def compute_yuddha_intervals(self, graha1: int, graha2: int, jd_start: float, jd_end: float, delta: float = 1.0, step: float = 0.5) -> list[tuple[float, float, float]]:
+    """
+    Compute intervals during which the true angular separation (see
+    get_angular_separation) between two grahas is less than `delta` degrees,
+    together with the jd of closest approach (t_zero) within each interval.
+    Returns a list of (t_start, t_zero, t_end) tuples.
+    """
+    intervals = []
+    inside = False
+    t_start = None
+    jd = jd_start
+
+    def sep(x):
+      return self.get_angular_separation(graha1, graha2, x)
+
+    while jd <= jd_end:
+      d = sep(jd)
+      if not inside and d < delta:
+        try:
+          t_start = brentq(lambda x: sep(x) - delta, jd - step, jd)
+          inside = True
+        except ValueError:
+          logging.warning(f"Could not bracket start of graha-yuddha at {jd}")
+      elif inside and d > delta:
+        try:
+          t_end = brentq(lambda x: sep(x) - delta, jd - step, jd)
+          t_zero = minimize_scalar(sep, bounds=(t_start, t_end), method='bounded').x
+          intervals.append((t_start, t_zero, t_end))
+        except ValueError:
+          logging.warning(f"Could not bracket end of graha-yuddha at {jd}")
+        inside = False
+      jd += step
+    return intervals
+
+  @staticmethod
+  def format_dms(value_degrees: float) -> str:
+    """Format an angle (in degrees) as D°MM′SS.SS″."""
+    total_sec = abs(value_degrees) * 3600
+    d = int(total_sec // 3600)
+    m = int((total_sec % 3600) // 60)
+    s = total_sec % 60
+    return f"{d}°{m:02d}′{s:05.2f}″"
+
+  @staticmethod
+  def format_arcmin(value_degrees: float) -> str:
+    """Format an angle (in degrees, expected to be small) as MM′SS.SS″ (arcminutes not wrapped modulo 60)."""
+    total_sec = abs(value_degrees) * 3600
+    m = int(total_sec // 60)
+    s = total_sec % 60
+    return f"{m}′{s:05.2f}″"
+
+  def get_graha_yuddha_details(self, graha1: int, graha2: int, jd: float) -> dict:
+    """
+    Compute the full set of graha-yuddha (amshu-vimarda) details at the
+    moment `jd` of closest approach between graha1 and graha2: their
+    separation, and for each graha: longitude (with nakshatra/pada/rashi),
+    latitude, motion (gati, direct/retrograde), apparent angular diameter
+    (with increasing/decreasing trend), and elongation from the sun.
+
+    The graha with the larger apparent diameter (i.e. nearer the earth, and
+    hence brighter/more prominent) is taken to be the victor (jayI) -- per
+    the classical criterion that the smaller, fainter graha is defeated.
+    """
+    details = {'separation': self.get_angular_separation(graha1, graha2, jd)}
+    dt = 0.01
+    for graha in (graha1, graha2):
+      g = Graha.singleton(graha)
+      lon = g.get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id)
+      lat = g.get_latitude(jd)
+      speed = g.get_speed(jd)
+      sun_lon = Graha.singleton(Graha.SUN).get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id)
+      elongation, diameter = g.get_phenomena(jd)
+      _, diameter_next = g.get_phenomena(jd + dt)
+      nak_index = int(lon // zodiac.AngaType.NAKSHATRA.arc_length) + 1
+      pada = int((lon % zodiac.AngaType.NAKSHATRA.arc_length) // (zodiac.AngaType.NAKSHATRA.arc_length / 4)) + 1
+      rashi_index = int(lon // zodiac.AngaType.RASHI.arc_length) + 1
+      elong_diff = ((lon - sun_lon + 180) % 360) - 180
+      details[graha] = {
+          'longitude': lon,
+          'nakshatra': names.NAMES['NAKSHATRA_NAMES']['sa'][sanscript.roman.HK_DRAVIDIAN][nak_index],
+          'pada': pada,
+          'rashi': names.NAMES['RASHI_NAMES']['sa'][sanscript.roman.HK_DRAVIDIAN][rashi_index],
+          'latitude': lat,
+          'lat_dir': 'S' if lat < 0 else 'N',
+          'speed': speed,
+          'motion': 'vakra' if speed < 0 else 'Rju',
+          'diameter': diameter,
+          'diameter_trend': 'increasing' if diameter_next > diameter else 'decreasing',
+          'elongation': elongation,
+          'elong_dir': 'W' if elong_diff < 0 else 'E',
+      }
+    details['winner'] = graha1 if details[graha1]['diameter'] >= details[graha2]['diameter'] else graha2
+    return details
+
   def add_graha_yuddhas(self):
     TARA_GRAHAS = (Graha.MERCURY, Graha.VENUS, Graha.MARS, Graha.JUPITER, Graha.SATURN)
-    GRAHA_NAMES = {Graha.VENUS: 'zukraH', Graha.MERCURY: 'budhaH', Graha.MARS: 'aGgArakaH', 
+    GRAHA_NAMES = {Graha.VENUS: 'zukraH', Graha.MERCURY: 'budhaH', Graha.MARS: 'aGgArakaH',
         Graha.SATURN: 'zaniH', Graha.JUPITER: 'guruH'}
 
     for graha1 in TARA_GRAHAS:
       for graha2 in TARA_GRAHAS:
         if graha1 < graha2:
-          intervals = self.compute_conjunction_intervals(graha1, graha2, self.panchaanga.jd_start, self.panchaanga.jd_end, delta=1.0, debug=False)
+          intervals = self.compute_yuddha_intervals(graha1, graha2, self.panchaanga.jd_start, self.panchaanga.jd_end, delta=1.0)
           for t_start, t_zero, t_end in intervals:
-            # Check for Maudhya!
-            if t_start is not None and self.panchaanga.jd_start < t_start < self.panchaanga.jd_end:
-              fday = int(t_start - self.daily_panchaangas[0].julian_day_start)
-              if t_start < self.daily_panchaangas[fday].jd_sunrise:
-                fday -= 1
-              fest = FestivalInstance(
-                  name=f'graha-yuddhaH ({GRAHA_NAMES[graha1]}–{GRAHA_NAMES[graha2]})',
-                  interval=Interval(jd_start=t_start, jd_end=t_end)
-              )
-              self.panchaanga.add_festival_instance(fest, date=self.daily_panchaangas[fday].date)
+            if not (self.panchaanga.jd_start < t_zero < self.panchaanga.jd_end):
+              continue
+            fday = int(t_zero - self.daily_panchaangas[0].julian_day_start)
+            if t_zero < self.daily_panchaangas[fday].jd_sunrise:
+              fday -= 1
+
+            details = self.get_graha_yuddha_details(graha1, graha2, t_zero)
+
+            def graha_detail_log(graha):
+              d = details[graha]
+              return (f"  {GRAHA_NAMES[graha]}: nakSatram {d['nakshatra']}-{d['pada']} rAziH {d['rashi']},"
+                      f" akSAMSaH {self.format_dms(d['latitude'])} {d['lat_dir']},"
+                      f" gatiH {self.format_arcmin(d['speed'])} {d['motion']},"
+                      f" bimba-vyAsaH {self.format_arcmin(d['diameter'])} {d['diameter_trend']},"
+                      f" digaMSaH {self.format_dms(d['elongation'])} {d['elong_dir']}")
+
+            logging.debug(
+                f"graha-yuddhaH ({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]}) at jd={t_zero}:\n"
+                f"  aMSu-vimardaH: {self.format_dms(details['separation'])}\n"
+                f"{graha_detail_log(graha1)}\n"
+                f"{graha_detail_log(graha2)}\n"
+                f"  jayI: {GRAHA_NAMES[details['winner']]}"
+            )
+
+            fest = FestivalInstance(
+                name=f"graha-yuddhaH~({GRAHA_NAMES[graha1]}-{GRAHA_NAMES[graha2]},~jayI~{GRAHA_NAMES[details['winner']]})",
+                interval=Interval(jd_start=t_start, jd_end=t_end)
+            )
+            self.panchaanga.add_festival_instance(fest, date=self.daily_panchaangas[fday].date)
 
   def compute_solar_eclipses(self):
     if 'sUrya-grahaNam' not in self.rules_collection.name_to_rule:

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -22,8 +22,8 @@ GRAHA_NAMES = {Graha.SUN: 'sUryaH', Graha.MOON: 'candraH', Graha.VENUS: 'zukraH'
     Graha.SATURN: 'zaniH', Graha.JUPITER: 'guruH'}
 
 # Genitive-case forms, for events that are properties/periods "of" a graha
-# (e.g. "guroH vArdhakya-prArambhaH" - "the start of Guru's old age").
-GRAHA_GENITIVE_NAMES = {Graha.VENUS: 'zukrasya', Graha.JUPITER: 'guroH'}
+# (e.g. "gurOH vArdhakya-prArambhaH" - "the start of Guru's old age").
+GRAHA_GENITIVE_NAMES = {Graha.VENUS: 'zukrasya', Graha.JUPITER: 'gurOH'}
 
 # bAlya (infancy, after udaya) and vArdhakya (old age, before asta) durations,
 # in days, flanking a maudhya (combustion) period. Per:
@@ -453,8 +453,8 @@ class EclipticFestivalAssigner(FestivalAssigner):
     """
     For zukra/bRhaspati (see BAALYA_VARDHAKYA_DAYS): add both boundaries of
     vArdhakya (old age, ending when the graha enters combustion) and bAlya
-    (infancy, starting when it emerges) - e.g. guroH~vArdhakya-prArambhaH
-    and guroH~vArdhakya-samApanam.
+    (infancy, starting when it emerges) - e.g. gurOH~vArdhakya-prArambhaH
+    and gurOH~vArdhakya-samApanam.
 
     Scans well beyond [self.panchaanga.jd_start, self.panchaanga.jd_end] (60
     days of padding, comfortably more than the 15-day maximum vArdhakya/

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -21,6 +21,21 @@ from indic_transliteration import sanscript
 GRAHA_NAMES = {Graha.SUN: 'sUryaH', Graha.MOON: 'candraH', Graha.VENUS: 'zukraH', Graha.MERCURY: 'budhaH', Graha.MARS: 'aGgArakaH',
     Graha.SATURN: 'zaniH', Graha.JUPITER: 'guruH'}
 
+# Genitive-case forms, for events that are properties/periods "of" a graha
+# (e.g. "guroH vArdhakya-prArambhaH" - "the start of Guru's old age").
+GRAHA_GENITIVE_NAMES = {Graha.VENUS: 'zukrasya', Graha.JUPITER: 'guroH'}
+
+# bAlya (infancy, after udaya) and vArdhakya (old age, before asta) durations,
+# in days, flanking a maudhya (combustion) period. Per:
+#   zaizavaM prAk tu paJcAhaM pazcAd dazadinaM smRtam
+#   zaizavaM vArdhakaM pakSaM prAk pazcAc ca bRhaspateH
+# (first tradition; only stated for zukra and bRhaspati -- not applied to the
+# other tArA-grahas).
+BAALYA_VARDHAKYA_DAYS = {
+    Graha.VENUS: {'baalya': 5, 'vardhakya': 15},
+    Graha.JUPITER: {'baalya': 15, 'vardhakya': 15},
+}
+
 # Dedicated logger (and log file) for graha-yuddha, maudhya etc. events -- see
 # EclipticFestivalAssigner.get_graha_events_log_path()/add_graha_events_log_handler().
 graha_events_logger = logging.getLogger('jyotisha.graha_events')
@@ -395,6 +410,79 @@ class EclipticFestivalAssigner(FestivalAssigner):
             ), date=self.daily_panchaangas[fday].date)
         except ValueError:
           logging.warning("Could not assign festival day for maudhya end event.")
+
+  def assign_baalya_vardhakya(self):
+    """
+    Add bAlya/vArdhakya events for every graha in BAALYA_VARDHAKYA_DAYS (see
+    add_baalya_vardhakya_events).
+
+    Deliberately NOT called from assign_all() (and hence not from
+    add_maudhya_events itself): these events are meant to be computed via
+    look-ahead/look-behind beyond the requested [jd_start, jd_end], but
+    Panchaanga.clear_padding_day_festivals() (run at the very end of
+    update_festival_details(), after assign_all()) wipes any festival
+    landing on a padding day, on the premise that padding-day festival
+    assignments in general aren't trustworthy without further look-ahead.
+    That's exactly what add_baalya_vardhakya_events's own wider scan
+    already provides, so it must run after clear_padding_day_festivals(),
+    not as part of the normal assign_all() pass, or its results would be
+    wiped right back out. See Panchaanga.update_festival_details().
+    """
+    for graha in BAALYA_VARDHAKYA_DAYS:
+      self.add_baalya_vardhakya_events(graha)
+
+  def _jd_to_display_date(self, jd: float):
+    """
+    Civil date to attribute `jd` to: sunrise-relative within
+    self.daily_panchaangas' covered range (matching the rest of this class),
+    falling back to a plain local-midnight-based date outside it. The
+    fallback loses exact sunrise-relative attribution (no sunrise is
+    computed for a date outside the covered range), but that only matters
+    for an occurrence within a few hours of a civil-day boundary, and only
+    when it falls outside the requested period in the first place.
+    """
+    fday = int(jd - self.daily_panchaangas[0].julian_day_start)
+    if 0 <= fday < len(self.daily_panchaangas):
+      if jd < self.daily_panchaangas[fday].jd_sunrise:
+        fday -= 1
+      if 0 <= fday < len(self.daily_panchaangas):
+        return self.daily_panchaangas[fday].date
+    return self.panchaanga.city.get_timezone_obj().julian_day_to_local_time(julian_day=jd)
+
+  def add_baalya_vardhakya_events(self, graha: int):
+    """
+    For zukra/bRhaspati (see BAALYA_VARDHAKYA_DAYS): add both boundaries of
+    vArdhakya (old age, ending when the graha enters combustion) and bAlya
+    (infancy, starting when it emerges) - e.g. guroH~vArdhakya-prArambhaH
+    and guroH~vArdhakya-samApanam.
+
+    Scans well beyond [self.panchaanga.jd_start, self.panchaanga.jd_end] (60
+    days of padding, comfortably more than the 15-day maximum vArdhakya/
+    bAlya duration) so that a vArdhakya/bAlya period poking into the
+    requested range from just before/after it is still pinned to its true
+    date, rather than being silently skipped the way add_maudhya_events's
+    own astamayaH/udayaH are when genuinely clamped -- these dates matter
+    (e.g. for a front/summary page) even when the graha's actual astamayaH/
+    udayaH instant falls just outside the requested period itself.
+    """
+    days = BAALYA_VARDHAKYA_DAYS.get(graha)
+    if days is None:
+      return
+    pad = 60
+    maudhya_intervals = self.compute_maudhya_intervals(
+        graha, self.panchaanga.jd_start - pad, self.panchaanga.jd_end + pad, use_latitude=True)
+    genitive = GRAHA_GENITIVE_NAMES[graha]
+    for mi in maudhya_intervals:
+      if not mi.start_clamped:
+        self._add_point_festival(f"{genitive}~vArdhakya-prArambhaH", mi.t_start - days['vardhakya'])
+        self._add_point_festival(f"{genitive}~vArdhakya-samApanam", mi.t_start)
+      if not mi.end_clamped:
+        self._add_point_festival(f"{genitive}~bAlya-prArambhaH", mi.t_end)
+        self._add_point_festival(f"{genitive}~bAlya-samApanam", mi.t_end + days['baalya'])
+
+  def _add_point_festival(self, name: str, jd: float):
+    date = self._jd_to_display_date(jd)
+    self.panchaanga.add_festival_instance(FestivalInstance(name=name, interval=Interval(jd_start=jd, jd_end=None)), date=date)
 
   def assign_chandra_darshanam(self, force_computation=False):
     """

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -471,12 +471,19 @@ class EclipticFestivalAssigner(FestivalAssigner):
     by proximity of the two discs, not merely by longitude, so latitude must
     be taken into account to identify the interval and moment of conflict
     correctly.
+
+    Uses topocentric (parallax-corrected, for self.panchaanga.city) positions
+    rather than geocentric ones -- graha-yuddha is a locally-observed
+    phenomenon, and parallax (mainly affecting the nearer of the two grahas)
+    can shift the moment of closest apparent approach measurably.
     """
     g1 = Graha.singleton(graha1)
     g2 = Graha.singleton(graha2)
-    dlon = ((g1.get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id) -
-             g2.get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id) + 180) % 360) - 180
-    dlat = g1.get_latitude(jd) - g2.get_latitude(jd)
+    city = self.panchaanga.city
+    lon1, lat1 = g1.get_topocentric_lon_lat(jd, city.longitude, city.latitude, ayanaamsha_id=self.ayanaamsha_id)
+    lon2, lat2 = g2.get_topocentric_lon_lat(jd, city.longitude, city.latitude, ayanaamsha_id=self.ayanaamsha_id)
+    dlon = ((lon1 - lon2 + 180) % 360) - 180
+    dlat = lat1 - lat2
     return (dlon ** 2 + dlat ** 2) ** 0.5
 
   def compute_yuddha_intervals(self, graha1: int, graha2: int, jd_start: float, jd_end: float, delta: float = 1.0, step: float = 0.5) -> list[tuple[float, float, float]]:
@@ -534,9 +541,11 @@ class EclipticFestivalAssigner(FestivalAssigner):
     """
     Compute the full set of graha-yuddha (amshu-vimarda) details at the
     moment `jd` of closest approach between graha1 and graha2: their
-    separation, and for each graha: longitude (with nakshatra/pada/rashi),
-    latitude, motion (gati, direct/retrograde), apparent angular diameter
-    (with increasing/decreasing trend), and elongation from the sun.
+    center-to-center and disc-to-disc (edge-to-edge) separation, and for each
+    graha: (topocentric) longitude (with nakshatra/pada/rashi), latitude,
+    motion (gati, direct/retrograde), apparent angular diameter (with
+    increasing/decreasing trend), apparent magnitude, and elongation from
+    the sun.
 
     The graha with the larger apparent diameter (i.e. nearer the earth, and
     hence brighter/more prominent) is taken to be the victor (jayI) -- per
@@ -544,14 +553,14 @@ class EclipticFestivalAssigner(FestivalAssigner):
     """
     details = {'separation': self.get_angular_separation(graha1, graha2, jd)}
     dt = 0.01
+    city = self.panchaanga.city
+    sun_lon, _ = Graha.singleton(Graha.SUN).get_topocentric_lon_lat(jd, city.longitude, city.latitude, ayanaamsha_id=self.ayanaamsha_id)
     for graha in (graha1, graha2):
       g = Graha.singleton(graha)
-      lon = g.get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id)
-      lat = g.get_latitude(jd)
+      lon, lat = g.get_topocentric_lon_lat(jd, city.longitude, city.latitude, ayanaamsha_id=self.ayanaamsha_id)
       speed = g.get_speed(jd)
-      sun_lon = Graha.singleton(Graha.SUN).get_longitude(jd, ayanaamsha_id=self.ayanaamsha_id)
-      elongation, diameter = g.get_phenomena(jd)
-      _, diameter_next = g.get_phenomena(jd + dt)
+      elongation, diameter, magnitude = g.get_phenomena(jd, geo_lon=city.longitude, geo_lat=city.latitude)
+      _, diameter_next, _ = g.get_phenomena(jd + dt, geo_lon=city.longitude, geo_lat=city.latitude)
       nak_index = int(lon // zodiac.AngaType.NAKSHATRA.arc_length) + 1
       pada = int((lon % zodiac.AngaType.NAKSHATRA.arc_length) // (zodiac.AngaType.NAKSHATRA.arc_length / 4)) + 1
       rashi_index = int(lon // zodiac.AngaType.RASHI.arc_length) + 1
@@ -567,9 +576,14 @@ class EclipticFestivalAssigner(FestivalAssigner):
           'motion': 'vakra' if speed < 0 else 'Rju',
           'diameter': diameter,
           'diameter_trend': 'increasing' if diameter_next > diameter else 'decreasing',
+          'magnitude': magnitude,
           'elongation': elongation,
           'elong_dir': 'W' if elong_diff < 0 else 'E',
       }
+    # Disc (rim-to-rim) separation: center-to-center separation minus the sum
+    # of the two angular radii -- the actual visible gap between the discs,
+    # as opposed to 'separation' above (a center-to-center distance).
+    details['disc_separation'] = details['separation'] - (details[graha1]['diameter'] + details[graha2]['diameter']) / 2
     details['winner'] = graha1 if details[graha1]['diameter'] >= details[graha2]['diameter'] else graha2
     details['loser'] = graha2 if details['winner'] == graha1 else graha1
     return details
@@ -608,10 +622,13 @@ class EclipticFestivalAssigner(FestivalAssigner):
         Elongation:     27°13'32.29" W
     """
     tz = self.panchaanga.city.get_timezone_obj()
+    disc_sep = details['disc_separation']
+    disc_sep_str = ("overlapping by " + self.format_dms(disc_sep)) if disc_sep < 0 else self.format_dms(disc_sep)
     lines = [
         f"{event_label}",
         f"Date: {tz.julian_day_to_local_time_str(jd)} -",
-        f"  Separation: {self.format_dms(details['separation'])}",
+        f"  Separation (center-to-center): {self.format_dms(details['separation'])}",
+        f"  Separation (disc/edge-to-edge): {disc_sep_str}",
     ]
     for graha in (graha1, graha2):
       d = details[graha]
@@ -620,6 +637,7 @@ class EclipticFestivalAssigner(FestivalAssigner):
       lines.append(f"           lat: {self.format_dms(d['latitude'])} {d['lat_dir']}")
       lines.append(f"           gati: {self.format_arcmin(d['speed'])} {d['motion']}")
       lines.append(f"           dia: {self.format_arcmin(d['diameter'])} {d['diameter_trend']}")
+      lines.append(f"           magnitude: {d['magnitude']:+.2f}")
       lines.append(f"           elongation: {self.format_dms(d['elongation'])} {d['elong_dir']}")
     if include_winner:
       lines.append(f"  jayI (victor): {GRAHA_NAMES.get(details['winner'], details['winner'])}")

--- a/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/ecliptic.py
@@ -34,10 +34,18 @@ class EclipticFestivalAssigner(FestivalAssigner):
     self.assign_tropical_sankranti_punyakaala()
     self.assign_tropical_sankranti()
     self.set_other_graha_transits()
-    # for graha in (Graha.MERCURY, Graha.VENUS, Graha.MARS, Graha.JUPITER, Graha.SATURN):
-    #   self.add_maudhya_events(graha)
-    # self.add_graha_yuddhas()
-    
+    for graha in (Graha.MERCURY, Graha.VENUS, Graha.MARS, Graha.JUPITER, Graha.SATURN):
+      self.add_maudhya_events(graha)
+    self.add_graha_yuddhas()
+    # Force computation, mirroring the old assign_chandra_darshanam_legacy()
+    # call in TithiFestivalAssigner: assign_bodhaayana_amaavaasyaa() (which
+    # runs later, in TithiFestivalAssigner.assign_all()) needs
+    # festival_id_to_days['candra-darzanam'] regardless of whether the user's
+    # ruleset actually wants candra-darzanam reported; it deletes the festival
+    # again at the end if not.
+    self.assign_chandra_darshanam(force_computation=True)
+
+
   def assign_tropical_sankranti_punyakaala(self):
     if 'viSu-puNyakAlaH' not in self.rules_collection.name_to_rule:
       return
@@ -336,6 +344,39 @@ class EclipticFestivalAssigner(FestivalAssigner):
           ), date=self.daily_panchaangas[fday].date)
         except ValueError:
           logging.warning("Could not assign festival day for maudhya end event.")
+
+  def assign_chandra_darshanam(self, force_computation=False):
+    """
+    candra-darzanam (new-crescent visibility): the first evening the Moon
+    clears the Sun by the maudhya threshold (12deg, akSAMza/oblique-ascension
+    corrected for self.panchaanga.city.latitude) - see compute_maudhya_intervals.
+    Empirically validated to the minute against a real drik-gaNita reference
+    table. Supersedes TithiFestivalAssigner.assign_chandra_darshanam_legacy()'s
+    tithi-at-moonset heuristic, which is retained there for reference.
+    """
+    if 'candra-darzanam' not in self.rules_collection.name_to_rule and not force_computation:
+      return
+    maudhya_intervals = self.compute_maudhya_intervals(Graha.MOON, self.panchaanga.jd_start, self.panchaanga.jd_end, use_latitude=True)
+    for t_start, t_zero, t_end, dir_rise, dir_set in maudhya_intervals:
+      try:
+        fday = int(t_end - self.daily_panchaangas[0].julian_day_start)
+        if t_end < self.daily_panchaangas[fday].jd_sunrise:
+          fday -= 1
+        if t_end > self.daily_panchaangas[fday].jd_sunset:
+          # This panchaanga-day's sunset has already passed by t_end (the Moon
+          # hadn't cleared the akSAMza threshold yet that evening) - the first
+          # upcoming viewing opportunity is the following evening.
+          fday += 1
+        fest_name = 'candra-darzanam'
+        if self.daily_panchaangas[fday].lunar_date.month.index == 6:
+          fest_name = 'bhAdrapada-' + fest_name
+        fest = FestivalInstance(
+            name=fest_name,
+            interval=Interval(jd_start=self.daily_panchaangas[fday].jd_sunset, jd_end=self.daily_panchaangas[fday].graha_set_jd[Graha.MOON])
+        )
+        self.panchaanga.add_festival_instance(festival_instance=fest, date=self.daily_panchaangas[fday].date)
+      except (ValueError, IndexError):
+        logging.warning(f"Could not assign candra-darzanam for maudhya interval ending {t_end}.")
 
   def compute_conjunction_intervals(
     self,

--- a/jyotisha/panchaanga/temporal/festival/applier/tithi_festival.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/tithi_festival.py
@@ -24,8 +24,11 @@ class TithiFestivalAssigner(FestivalAssigner):
     self.assign_solar_sidereal_amaavaasyaa()
     self.assign_ishti_sthaaliipaaka()
     self.assign_amaavaasya_vyatiipaata()
-    # Force computation of chandra darshanam for bodhayana amavasya's sake
-    self.assign_chandra_darshanam(force_computation=True)
+    # candra-darzanam is now computed in EclipticFestivalAssigner (drik-gaNita,
+    # akSAMza-corrected), which runs before this assigner - see assign_all()
+    # in ecliptic.py. It force-computes 'candra-darzanam'/'bhAdrapada-candra-
+    # darzanam' the same way this used to, so assign_bodhaayana_amaavaasyaa
+    # below still has festival_id_to_days['candra-darzanam'] to work with.
     self.assign_bodhaayana_amaavaasyaa()
     self.assign_amaavaasyaa_soma()
     self.assign_chaturthi_vratam()
@@ -651,7 +654,15 @@ class TithiFestivalAssigner(FestivalAssigner):
         festival_name = 'vAjapEyaphala-snAna-yOgaH'
         self.panchaanga.add_festival(fest_id=festival_name, date=day_panchaanga.date)
 
-  def assign_chandra_darshanam(self, force_computation=False):
+  def assign_chandra_darshanam_legacy(self, force_computation=False):
+    """
+    Legacy (tithi-at-moonset heuristic) chandra-darzanam computation, retained
+    for reference/comparison. No longer called by assign_all() - superseded by
+    EclipticFestivalAssigner.assign_chandra_darshanam(), which uses the
+    akSAMza-corrected drik-gaNita maudhya machinery instead of this tithi
+    heuristic (see the TODO that used to be a few lines below: "Fix based on
+    mauDhya logic for chandra").
+    """
     if 'candra-darzanam' not in self.rules_collection.name_to_rule and not force_computation:
       return
     d = self.panchaanga.duration_prior_padding

--- a/jyotisha/panchaanga/temporal/festival/applier/upakarma.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/upakarma.py
@@ -3,6 +3,7 @@ import logging
 from jyotisha.panchaanga.temporal import Anga, get_2_day_interval_boundary_angas
 from jyotisha.panchaanga.temporal.body import Graha
 from jyotisha.panchaanga.temporal.festival import priority_decision
+from jyotisha.panchaanga.temporal.festival.applier.ecliptic import BAALYA_VARDHAKYA_DAYS
 from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
 from jyotisha.panchaanga.temporal.zodiac import AngaType
 from sanskrit_data.schema import common
@@ -143,6 +144,25 @@ class UpakarmaFestivalAssigner(FestivalAssigner):
       logging.info('%s mAudhya (combustion) flaw on %s.', graha, date.get_date_str())
     return flawed
 
+  def _has_baalya_vardhakya_flaw(self, date, graha):
+    """ True iff `graha` is in bAlya (infancy) or vArdhakya (old age) -- the periods immediately
+    flanking mAudhya, see BAALYA_VARDHAKYA_DAYS -- at any point during the civil day `date`.
+    Only zukra/bRhaspati have these defined; other grahas never flag here.
+    """
+    days = BAALYA_VARDHAKYA_DAYS.get(graha)
+    if days is None:
+      return False
+    day_panchaanga = self.panchaanga.date_str_to_panchaanga.get(date.get_date_str(), None)
+    if day_panchaanga is None:
+      return False
+    flawed = any(
+      (mi.t_start - days['vardhakya'] <= day_panchaanga.jd_sunset and mi.t_start >= day_panchaanga.jd_sunrise) or
+      (mi.t_end <= day_panchaanga.jd_sunset and mi.t_end + days['baalya'] >= day_panchaanga.jd_sunrise)
+      for mi in self._maudhya_intervals(graha))
+    if flawed:
+      logging.info('%s bAlya/vArdhakya flaw on %s.', graha, date.get_date_str())
+    return flawed
+
   def _has_hard_flaw(self, date):
     """ True iff `date` has an eclipse-before-relative-ghatikA-45 or a saGkramaNa. Unlike mAudhya, neither
     admits a zAntipUrvakam-style remedy, so a hard flaw rules out even the "return to zrAvaNa-pUrNimA,
@@ -151,12 +171,13 @@ class UpakarmaFestivalAssigner(FestivalAssigner):
     return date is not None and (self._has_eclipse_flaw(date) or self._has_sankramana_flaw(date))
 
   def _has_flaw(self, date, fest_id):
-    """ True iff `date` has a hard flaw (see `_has_hard_flaw`) or a mAudhya flaw of `fest_id`'s governing
-    graha -- any of which is traditionally grounds to switch the upAkarma day, per the veda-specific rules
-    below.
+    """ True iff `date` has a hard flaw (see `_has_hard_flaw`) or a mAudhya/bAlya/vArdhakya flaw of
+    `fest_id`'s governing graha -- any of which is traditionally grounds to switch the upAkarma day,
+    per the veda-specific rules below.
     """
     graha = self.MAUDHYA_GRAHA_BY_VEDA[fest_id]
-    return date is not None and (self._has_hard_flaw(date) or self._has_maudhya_flaw(date, graha))
+    return date is not None and (self._has_hard_flaw(date) or self._has_maudhya_flaw(date, graha)
+                                  or self._has_baalya_vardhakya_flaw(date, graha))
 
   def _shravana_purnima(self):
     return self._first_anga_occurrence_in_masa(masa_index=MASA_SHRAVANA, anga_type=AngaType.TITHI,

--- a/jyotisha/panchaanga/temporal/festival/applier/upakarma.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/upakarma.py
@@ -138,7 +138,7 @@ class UpakarmaFestivalAssigner(FestivalAssigner):
     if day_panchaanga is None:
       return False
     flawed = any(t_start <= day_panchaanga.jd_sunset and t_end >= day_panchaanga.jd_sunrise
-                 for (t_start, t_end, _, _) in self._maudhya_intervals(graha))
+                 for (t_start, _, t_end, _, _) in self._maudhya_intervals(graha))
     if flawed:
       logging.info('%s mAudhya (combustion) flaw on %s.', graha, date.get_date_str())
     return flawed

--- a/jyotisha/panchaanga/temporal/festival/applier/upakarma.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/upakarma.py
@@ -137,8 +137,8 @@ class UpakarmaFestivalAssigner(FestivalAssigner):
     day_panchaanga = self.panchaanga.date_str_to_panchaanga.get(date.get_date_str(), None)
     if day_panchaanga is None:
       return False
-    flawed = any(t_start <= day_panchaanga.jd_sunset and t_end >= day_panchaanga.jd_sunrise
-                 for (t_start, _, t_end, _, _) in self._maudhya_intervals(graha))
+    flawed = any(mi.t_start <= day_panchaanga.jd_sunset and mi.t_end >= day_panchaanga.jd_sunrise
+                 for mi in self._maudhya_intervals(graha))
     if flawed:
       logging.info('%s mAudhya (combustion) flaw on %s.', graha, date.get_date_str())
     return flawed

--- a/jyotisha/panchaanga/writer/tex/templates/daily_cal_template.tex
+++ b/jyotisha/panchaanga/writer/tex/templates/daily_cal_template.tex
@@ -7,9 +7,11 @@
 \usepackage{setspace}
 \usepackage{multirow}
 \usepackage{pxfonts}
+\usepackage{amssymb}
 \usepackage{bbding}
-\usepackage{wasysym} 
+\usepackage{wasysym}
 \usepackage{fontspec}
+\usepackage{newunicodechar}
 \usepackage{multicol}
 \usepackage{supertabular}
 \usepackage{fancyhdr}
@@ -78,9 +80,15 @@
 % PDF SETUP
 % ---- FILL IN HERE THE DOC TITLE AND AUTHOR
 \defaultfontfeatures{Scale=MatchLowercase,Mapping=tex-text}
-\setmainfont{siddhanta.ttf}[Path=../fonts/,Script=Devanagari] 
+\setmainfont{siddhanta.ttf}[Path=../fonts/,Script=Devanagari]
 \setsansfont[Path=../fonts/,Scale=0.95,Numbers=Lining]{AlegreyaSans-Regular.ttf}
 % \newfontfamily\noto[Path=../fonts/, Ligatures=TeX]{NotoSansUI-Regular}
+% None of the fonts above (main, sans, or Tamil) actually contain U+2605 (★),
+% used as a highlight marker in some festival names -- pin it to the AMS
+% symbol font's \bigstar instead, regardless of whichever text font/script
+% happens to be active at that point (this sidesteps the per-script font
+% substitution fontspec does for the Script=Devanagari main font above).
+\newunicodechar{★}{\ensuremath{\bigstar}}
 %%%%%%% Numbers and counters %%%%%%%
 \newcount\num
 \newcount\tempone \newcount\temptwo

--- a/jyotisha/panchaanga/writer/tex/templates/monthly_cal_template.tex
+++ b/jyotisha/panchaanga/writer/tex/templates/monthly_cal_template.tex
@@ -7,9 +7,11 @@
 \usepackage{array}
 \usepackage{multirow}
 \usepackage{pxfonts}
+\usepackage{amssymb}
 \usepackage{bbding}
-\usepackage{wasysym} 
+\usepackage{wasysym}
 \usepackage{fontspec}
+\usepackage{newunicodechar}
 \usepackage{multicol}
 \usepackage{supertabular}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -72,8 +74,14 @@
 % \setmainfont{Siddhanta}[Script=Devanagari]
 % \setromanfont{Siddhanta}[Script=Devanagari]
 % \setsansfont[Path=../fonts/,Scale=0.95,BoldFont=AlegreyaSans-Bold.ttf]{AlegreyaSans-Regular.ttf} 
-\setmainfont{siddhanta.ttf}[Path=../fonts/,Script=Devanagari] 
+\setmainfont{siddhanta.ttf}[Path=../fonts/,Script=Devanagari]
 \setsansfont[Path=../fonts/,Scale=0.95,Numbers=Lining]{AlegreyaSans-Regular.ttf}
+% None of the fonts above (main, sans, or Tamil) actually contain U+2605 (★),
+% used as a highlight marker in some festival names -- pin it to the AMS
+% symbol font's \bigstar instead, regardless of whichever text font/script
+% happens to be active at that point (this sidesteps the per-script font
+% substitution fontspec does for the Script=Devanagari main font above).
+\newunicodechar{★}{\ensuremath{\bigstar}}
 %%%%%%% Numbers and counters %%%%%%%
 \newcount\num
 \newcount\tempone \newcount\temptwo


### PR DESCRIPTION
## Summary

Supersedes #187 (same net changes, reorganized into a clean, logically-grouped commit history from current master — see that PR for the original discussion/validation history).

- Fix `add_graha_yuddhas` to accurately compute graha-yuddha (planetary war) details: latitude, angular diameter, gati (direction of motion), elongation, and disc separation, validated against 6 independent real-world reference events (including a Dec 2020 Jupiter-Saturn "Great Conjunction" report), reaching arcsecond/sub-minute precision.
- Report a graha-yuddha's peak moment (`t_zero`) as the classical longitude-equality ("yuti") instant, not minimum total separation.
- Add apparent magnitude, disc separation, and topocentric (parallax-corrected) positions to graha-yuddha/maudhya reports.
- Add peak nakshatra/rashi to the graha-yuddha festival name.
- Log maudhya and graha-yuddha event details to a dedicated log file.
- Wire up graha-yuddha, graha-maudhya, and drik-gaNita candra-darzanam computations into the festival pipeline (recovering work that had been stranded in an unmerged commit from an earlier session).
- Fix `compute_conjunction_intervals`/`compute_yuddha_intervals` silently dropping events already in progress at the start of a scan window.
- Indicate maudhya intervals that are clamped at the scan window's boundary (started before or still ongoing after the scanned range), instead of misreporting fake set/rise events for them.
- Add bAlya (infancy) / vArdhakya (old age) events for Śukra's and Bṛhaspati's maudhya periods, per the classical rule (Śukra: bālya 5 days after rise, vārdhakya 15 days before set; Bṛhaspati: 15 days both ways). This required a wide, independently-padded past/future scan per cycle, plus a fix for `Panchaanga.clear_padding_day_festivals()` silently wiping those wide-scanned results — it's now called before, not after, this computation.

## Test plan

- [ ] Run `jyotisha_tests/update_test_data.sh` to regenerate fixtures against this branch's code (fixtures on this branch are still master's stale versions; the author intentionally left this for local regeneration rather than committing auto-generated fixture diffs blind).
- [ ] Confirm the full pytest suite passes after regeneration.
- [x] Manually validated graha-yuddha/maudhya output against 6 independent real-world reference reports during development (see #187 for details).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfAjdo83fPgsRgc7TXtxFs)_