### PR TITLE
Fix panchaanga festival comparison by converting sets to lists

### DIFF
--- a/jyotisha_tests/spatio_temporal/test_annual.py
+++ b/jyotisha_tests/spatio_temporal/test_annual.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import os
 
-from sanskrit_data import testing
+from sanskrit_data import collection_helper, testing
 from timebudget import timebudget
 
 from jyotisha.panchaanga.spatio_temporal import City, annual
@@ -34,6 +34,11 @@ def panchaanga_json_comparer(city, year):
   panchaanga = annual.get_panchaanga_for_civil_year(city=city, year=year, computation_system=test_computation_system,
                                                     allow_precomputed=False)
   timebudget.report(reset=True)
+  # collection_helper.assert_approx_equals() does not apply floating_point_precision rounding to
+  # values nested inside sets (only dicts/lists/JsonObjects), so festival_id_to_days (a dict of sets)
+  # must be converted to sorted lists first, else tiny cross-environment float noise in slow-moving
+  # festivals (e.g. vArdhakya-prArambhaH) spuriously fails the comparison.
+  panchaanga.festival_id_to_days = collection_helper.sets_to_lists(panchaanga.festival_id_to_days)
   testing.json_compare(actual_object=panchaanga, expected_content_path=expected_content_path)
 
 


### PR DESCRIPTION
## Summary
Fixed a test comparison issue in `panchaanga_json_comparer` where floating-point precision rounding was not being applied to festival data nested within sets, causing spurious test failures due to minor cross-environment float variations.

## Changes
- Added import of `collection_helper` from `sanskrit_data` module
- Convert `panchaanga.festival_id_to_days` from a dict of sets to a dict of sorted lists before JSON comparison
- This ensures that floating-point precision rounding is properly applied to all festival date values

## Implementation Details
The `collection_helper.assert_approx_equals()` function only applies floating-point precision rounding to values nested in dicts, lists, and JsonObjects—not to values within sets. Since `festival_id_to_days` is a dictionary of sets, the rounding was being skipped, leading to test failures from tiny floating-point noise in slow-moving festivals (e.g., vArdhakya-prArambhaH). Converting these sets to sorted lists before comparison resolves this issue while maintaining the same data semantics.

https://claude.ai/code/session_01UYZzWKWDsDtKqopcvZXnJg