### PR TITLE
Make ICS DTSTAMP overridable for deterministic golden-file comparison

### DIFF
--- a/jyotisha/panchaanga/writer/ics/__init__.py
+++ b/jyotisha/panchaanga/writer/ics/__init__.py
@@ -30,12 +30,19 @@ logging.basicConfig(
 CODE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
-def compute_calendar(panchaanga, languages=None, scripts=None, set_sequence=True, festivals_only=False):
-
+def compute_calendar(panchaanga, languages=None, scripts=None, set_sequence=True, festivals_only=False, dtstamp=None):
+  """
+  :param dtstamp: the DTSTAMP (RFC 5545: "the instant the calendar information was created")
+    stamped on every event. Defaults to datetime.now() at call time when not given -- the correct
+    behavior for real calendar generation. Pass a fixed datetime for reproducible output (e.g. in
+    tests comparing against a golden .ics file byte-for-byte, instead of skipping DTSTAMP lines).
+  """
   if scripts is None:
     scripts = [sanscript.DEVANAGARI]
   if languages is None:
     languages = ["sa"]
+  if dtstamp is None:
+    dtstamp = datetime.now()
   ics_calendar = Calendar()
 
   set_calendar_metadata(ics_calendar, panchaanga=panchaanga, set_sequence=set_sequence)
@@ -45,9 +52,9 @@ def compute_calendar(panchaanga, languages=None, scripts=None, set_sequence=True
     if daily_panchaanga.date < panchaanga.start_date or daily_panchaanga.date > panchaanga.end_date:
       continue
     if not festivals_only:
-      event = get_day_summary_event(d=day_index, panchaanga=panchaanga, script=scripts[0])
+      event = get_day_summary_event(d=day_index, panchaanga=panchaanga, script=scripts[0], dtstamp=dtstamp)
       ics_calendar.add_component(event)
-    add_festival_events(day_index=day_index, ics_calendar=ics_calendar, panchaanga=panchaanga, scripts=scripts, languages=languages)
+    add_festival_events(day_index=day_index, ics_calendar=ics_calendar, panchaanga=panchaanga, scripts=scripts, languages=languages, dtstamp=dtstamp)
 
   return ics_calendar
 

--- a/jyotisha/panchaanga/writer/ics/day_details.py
+++ b/jyotisha/panchaanga/writer/ics/day_details.py
@@ -24,7 +24,7 @@ def writeDailyICS(panchaanga, script=sanscript.DEVANAGARI):
   return ics_calendar
 
 
-def get_day_summary_event(d, panchaanga, script):
+def get_day_summary_event(d, panchaanga, script, dtstamp=None):
   daily_panchaanga = panchaanga.daily_panchaangas_sorted()[d]
   event = Event()
   (title, details) = day_summary(d=d, panchaanga=panchaanga, script=script, subsection_md="##")
@@ -32,7 +32,7 @@ def get_day_summary_event(d, panchaanga, script):
   event.add('description', details)
   tz = daily_panchaanga.city.get_timezone_obj()
   dt_start = tz.julian_day_to_local_datetime(jd=daily_panchaanga.jd_sunrise)
-  event.add('dtstamp', datetime.now())
+  event.add('dtstamp', dtstamp if dtstamp is not None else datetime.now())
   # logging.debug(daily_panchaanga.date)
   event.add('dtstart', dt_start)
   event.add('dtend', tz.julian_day_to_local_datetime(jd=daily_panchaanga.jd_next_sunrise))

--- a/jyotisha/panchaanga/writer/ics/festival_event.py
+++ b/jyotisha/panchaanga/writer/ics/festival_event.py
@@ -74,7 +74,7 @@ def get_full_festival_instance(festival_instance, daily_panchaangas, day_index):
     return full_festival_instance
 
 
-def festival_instance_to_event(festival_instance, languages, scripts, panchaanga, all_day=False):
+def festival_instance_to_event(festival_instance, languages, scripts, panchaanga, all_day=False, dtstamp=None):
   rules_collection = rules.RulesCollection.get_cached(
     repos_tuple=tuple(panchaanga.computation_system.festival_options.repos), julian_handling=panchaanga.computation_system.festival_options.julian_handling)
   fest_details_dict = rules_collection.name_to_rule
@@ -85,7 +85,7 @@ def festival_instance_to_event(festival_instance, languages, scripts, panchaanga
   event.add('summary', fest_name)
   desc = get_description(festival_instance=festival_instance, script=scripts[0], fest_details_dict=fest_details_dict, header_md="##")
   event.add('description', desc.strip().replace('\n', '<br/>'))
-  event.add('dtstamp', datetime.now())
+  event.add('dtstamp', dtstamp if dtstamp is not None else datetime.now())
 
   if all_day or not festival_instance._show_interval():
     t1 = panchaanga.city.get_timezone_obj().julian_day_to_local_datetime(jd=festival_instance.interval.jd_start)
@@ -121,7 +121,7 @@ def set_interval(daily_panchaanga, festival_instance):
     festival_instance.interval.jd_end = daily_panchaanga.julian_day_start + 1
 
 
-def add_festival_events(day_index, ics_calendar, panchaanga, languages, scripts):
+def add_festival_events(day_index, ics_calendar, panchaanga, languages, scripts, dtstamp=None):
   daily_panchaanga = panchaanga.daily_panchaangas_sorted()[day_index]
   for festival_instance_in in sorted(daily_panchaanga.festival_id_to_instance.values()):
     festival_instance = deepcopy(festival_instance_in)
@@ -131,7 +131,7 @@ def add_festival_events(day_index, ics_calendar, panchaanga, languages, scripts)
       all_day = True
     elif default_if_none(festival_instance.interval.get_jd_length(), 0) > 0.75:
       all_day = True
-      
+
 
     set_interval(daily_panchaanga, festival_instance)
     if fest_id.find('samApanam') != -1:
@@ -140,9 +140,9 @@ def add_festival_events(day_index, ics_calendar, panchaanga, languages, scripts)
                                                           daily_panchaangas=panchaanga.daily_panchaangas_sorted(), day_index=day_index)
       if full_festival_instance is not None:
         event = festival_instance_to_event(festival_instance=full_festival_instance, languages=languages, scripts=scripts,
-                                           panchaanga=panchaanga, all_day=True)
+                                           panchaanga=panchaanga, all_day=True, dtstamp=dtstamp)
         ics_calendar.add_component(event)
 
     event = festival_instance_to_event(festival_instance=festival_instance, languages=languages, scripts=scripts, panchaanga=panchaanga,
-                                       all_day=all_day)
+                                       all_day=all_day, dtstamp=dtstamp)
     ics_calendar.add_component(event)

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
@@ -13,7 +13,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-26  \,Tulā-Svātī🌛🌌  \,  Dhanuḥ-P
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190101T063447
 DTEND;TZID=Asia/Calcutta:20190102T063513
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190101_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-11\, Islamic: 1440-04-23 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -71,7 +71,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190101T093255
 DTEND;TZID=Asia/Calcutta:20190101T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-01-01T09:32:55.679983+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -87,7 +87,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-saphalā-ēkādaśī
 DTSTART;VALUE=DATE:20190101
 DTEND;VALUE=DATE:20190102
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sarva-saphalā-ēkādaśī_2019-01-01T06:34:47.999994+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of mārgaśīrṣa month is known 
  as saphalā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are 
@@ -182,7 +182,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190102T012839
 DTEND;TZID=Asia/Calcutta:20190102T063513
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-01-02T01:28:39.360016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -201,7 +201,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190101T201736
 DTEND;TZID=Asia/Calcutta:20190101T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-01-01T20:17:36.960015+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -219,7 +219,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-27  \,Vr̥ścikaḥ-Viśākhā🌛🌌  \,
  udhaḥ
 DTSTART;TZID=Asia/Calcutta:20190102T063513
 DTEND;TZID=Asia/Calcutta:20190103T063539
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190102_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-12\, Islamic: 1440-04-24 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -276,7 +276,7 @@ BEGIN:VEVENT
 SUMMARY:budhānurādhā-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190102T093723
 DTEND;TZID=Asia/Calcutta:20190102T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:budhānurādhā-yōgaḥ_2019-01-02T09:37:23.520011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/budhAnu
@@ -295,7 +295,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190101T235957
 DTEND;TZID=Asia/Calcutta:20190102T073625
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-01-01T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -314,7 +314,7 @@ SUMMARY:kāñcī 68 jagadguru-śrī-candraśēkharēndra-sarasvatī-7-ār
  ādhanā #25
 DTSTART;VALUE=DATE:20190102
 DTEND;VALUE=DATE:20190103
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī68jagadguru-śrī-candraśēkharēndra-sarasvatī-7-ārādhan
  ā#25_2019-01-02T06:35:13.919990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -339,7 +339,7 @@ BEGIN:VEVENT
 SUMMARY:pakṣavardhinī-mahādvādaśī
 DTSTART;VALUE=DATE:20190102
 DTEND;VALUE=DATE:20190103
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pakṣavardhinī-mahādvādaśī_2019-01-02T06:35:13.919990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/pakS
@@ -361,7 +361,7 @@ BEGIN:VEVENT
 SUMMARY:Undu Madakkaḷiṟṟan
 DTSTART;VALUE=DATE:20190102
 DTEND;VALUE=DATE:20190103
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:UnduMadakkaḷiṟṟan_2019-01-02T06:35:13.919990+05:30
 DESCRIPTION:Observed on day 18 of Dhanuḥ (sidereal solar) month (Sūryō
  dayaḥ/puurvaviddha). <br/><br/>Offer naivedyam of chitrānnam (tamarind 
@@ -383,7 +383,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-28  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,
  Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190103T063539
 DTEND;TZID=Asia/Calcutta:20190104T063557
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190103_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-13\, Islamic: 1440-04-25 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -440,7 +440,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190103T175052
 DTEND;TZID=Asia/Calcutta:20190104T063557
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-03T17:50:52.800004+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -461,7 +461,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190103T175052
 DTEND;TZID=Asia/Calcutta:20190103T192629
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-01-03T17:50:52.800004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -481,7 +481,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-29  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \
  , Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190104T063557
 DTEND;TZID=Asia/Calcutta:20190105T063614
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190104_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-14\, Islamic: 1440-04-26 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -538,7 +538,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190104
 DTEND;VALUE=DATE:20190105
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-04T06:35:57.119997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -578,7 +578,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190104
 DTEND;VALUE=DATE:20190105
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-01-04T06:35:57.119997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -598,7 +598,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190104
 DTEND;VALUE=DATE:20190105
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-01-04T06:35:57.119997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -617,7 +617,7 @@ BEGIN:VEVENT
 SUMMARY:Toṇḍaraḍippoḍiyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190104
 DTEND;VALUE=DATE:20190105
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:ToṇḍaraḍippoḍiyāḻvārTirunakṣattiram_2019-01-04T06:35:57.
  119997+05:30
 DESCRIPTION:Observed on Jyēṣṭhā nakshatra of Dhanuḥ (sidereal sola
@@ -639,7 +639,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-30  \,Dhanuḥ-Mūlā🌛🌌  \,  Dhanuḥ-
  Pūrvāṣāḍhā-09-21🌞🌌  \,  Tapaḥ-11-15🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190105T063614
 DTEND;TZID=Asia/Calcutta:20190106T063640
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190105_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-15\, Islamic: 1440-04-27 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -695,7 +695,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -731,7 +731,7 @@ SUMMARY:kāñcī 14 jagadguru-śrī-vidyāghanēndra-sarasvatī-ārādhan
  ā #1702
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī14jagadguru-śrī-vidyāghanēndra-sarasvatī-ārādhanā#1702
  _2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -757,7 +757,7 @@ SUMMARY:kāñcī 34 jagadguru-śrī-candraśēkharēndra-sarasvatī-2-ār
  ādhanā #1309
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī34jagadguru-śrī-candraśēkharēndra-sarasvatī-2-ārādhan
  ā#1309_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -782,7 +782,7 @@ BEGIN:VEVENT
 SUMMARY:kamalā-jayantī
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kamalā-jayantī_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Mārgaśīrṣaḥ (lunar) mo
  nth (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Kamala is 10th of the D
@@ -802,7 +802,7 @@ BEGIN:VEVENT
 SUMMARY:khyēcimāvasa pōṣta/khicaḍī-amāvāsyā
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:khyēcimāvasapōṣta/khicaḍī-amāvāsyā_2019-01-05T06:36:14.4000
  08+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -825,7 +825,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -846,7 +846,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -865,7 +865,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-mārgaśīrṣa-amāvāsyā
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sarva-mārgaśīrṣa-amāvāsyā_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:amāvāsyā of mārgaśīrṣa lunar month.<br/><br/>## Detail
  s<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/mas
@@ -884,7 +884,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-hanūmat-jayantī
 DTSTART;VALUE=DATE:20190105
 DTEND;VALUE=DATE:20190106
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:śrī-hanūmat-jayantī_2019-01-05T06:36:14.400008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Dhanuḥ (sidereal solar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>āśvinasyāsitē pakṣē bh
@@ -908,7 +908,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-30  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \
  , Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190106T063640
 DTEND;TZID=Asia/Calcutta:20190107T063657
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190106_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-16\, Islamic: 1440-04-28 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -965,7 +965,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-06T06:36:40.320004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -1011,7 +1011,7 @@ BEGIN:VEVENT
 SUMMARY:Chākkiya Nāyanmār (34) Gurupūjai
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:ChākkiyaNāyanmār(34)Gurupūjai_2019-01-06T06:36:40.320004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -1034,7 +1034,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-01-06T06:36:40.320004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -1053,7 +1053,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-māsa-samāpanam
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-māsa-samāpanam_2019-01-06T06:36:40.320004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Mārgaśīrṣaḥ (lunar) mo
  nth (Sūryōdayaḥ/paraviddha). <br/><br/>mārgaśīrṣa-māsaḥ ends t
@@ -1073,7 +1073,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-01-06T06:36:40.320004
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -1099,7 +1099,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-01-06T06:36:40.320004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -1120,7 +1120,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190107
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-01-06T06:36:40.320004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -1143,7 +1143,7 @@ SUMMARY:Pauṣaḥ-10-01  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  Dhan
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190107T063657
 DTEND;TZID=Asia/Calcutta:20190108T063714
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190107_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-17\, Islamic: 1440-04-29 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -1199,7 +1199,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190107
 DTEND;VALUE=DATE:20190108
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-07T06:36:57.600015+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -1245,7 +1245,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190107T162704
 DTEND;TZID=Asia/Calcutta:20190107T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-01-07T16:27:04.320017+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Jan-07 16:27. At this moment budhaḥ is at mūlā-3 dhanuḥ
@@ -1264,7 +1264,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190107T175311
 DTEND;TZID=Asia/Calcutta:20190107T190126
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-01-07T17:53:11.040011+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -1283,7 +1283,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190107
 DTEND;VALUE=DATE:20190108
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-māsa-ārambhaḥ_2019-01-07T06:36:57.600015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/10/01/pauSa-mAs
@@ -1305,7 +1305,7 @@ BEGIN:VEVENT
 SUMMARY:sōmaśravaṇa-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190107T203335
 DTEND;TZID=Asia/Calcutta:20190107T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sōmaśravaṇa-yōgaḥ_2019-01-07T20:33:35.999995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmazra
@@ -1326,7 +1326,7 @@ SUMMARY:Pauṣaḥ-10-02  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Dhanuḥ-
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190108T063714
 DTEND;TZID=Asia/Calcutta:20190109T063732
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190108_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-18\, Islamic: 1440-05-01 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1382,7 +1382,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190108
 DTEND;VALUE=DATE:20190109
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-01-08T06:37:14.879985+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -1403,7 +1403,7 @@ SUMMARY:Pauṣaḥ-10-03  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Dhanu
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190109T063732
 DTEND;TZID=Asia/Calcutta:20190110T063749
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190109_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-19\, Islamic: 1440-05-02 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1460,7 +1460,7 @@ BEGIN:VEVENT
 SUMMARY:pravāsi-bhāratīya-divasam #16
 DTSTART;VALUE=DATE:20190108
 DTEND;VALUE=DATE:20190109
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pravāsi-bhāratīya-divasam#16_2019-01-08T23:59:57.120005+05:30
 DESCRIPTION:Event occured on 2003-01-09 (gregorian). <br/><br/>The date wa
  s originally picked to coincide with MK Gandhi's return from Africa in 191
@@ -1481,7 +1481,7 @@ SUMMARY:Pauṣaḥ-10-04  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Dhanuḥ-
  Pūrvāṣāḍhā-09-26🌞🌌  \,  Tapaḥ-11-20🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190110T063749
 DTEND;TZID=Asia/Calcutta:20190111T063758
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190110_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-20\, Islamic: 1440-05-03 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1537,7 +1537,7 @@ BEGIN:VEVENT
 SUMMARY:mahādhanurvyatīpāta-snānam
 DTSTART;VALUE=DATE:20190110
 DTEND;VALUE=DATE:20190111
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:mahādhanurvyatīpāta-snānam_2019-01-10T06:37:49.440007+05:30
 DESCRIPTION:Observed on Vyatīpātaḥ yoga of Dhanuḥ (sidereal solar) m
  onth (Prāktanāruṇōdayaḥ/puurvaviddha). <br/><br/>Special snānam on
@@ -1562,7 +1562,7 @@ BEGIN:VEVENT
 SUMMARY:mahādhanurvyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190110
 DTEND;VALUE=DATE:20190111
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:mahādhanurvyatīpāta-śrāddham_2019-01-10T06:37:49.440007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/description_only/mahAdhanurvyatIpAta-
@@ -1584,7 +1584,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190110
 DTEND;VALUE=DATE:20190111
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-01-10T06:37:49.440007+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -1606,7 +1606,7 @@ SUMMARY:Pauṣaḥ-10-05  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌  \,
  Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190111T063758
 DTEND;TZID=Asia/Calcutta:20190112T063815
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190111_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-21\, Islamic: 1440-05-04 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1663,7 +1663,7 @@ BEGIN:VEVENT
 SUMMARY:Kūḍāravallī
 DTSTART;VALUE=DATE:20190111
 DTEND;VALUE=DATE:20190112
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:Kūḍāravallī_2019-01-11T06:37:58.079993+05:30
 DESCRIPTION:Observed on day 27 of Dhanuḥ (sidereal solar) month (Sūryō
  dayaḥ/puurvaviddha). <br/><br/>Offer naivedyam of guḍānnam to Vishnu\
@@ -1686,7 +1686,7 @@ SUMMARY:Pauṣaḥ-10-06  \,Mīnaḥ-Pūrvaprōṣṭhapadā🌛🌌  \,
  Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190112T063815
 DTEND;TZID=Asia/Calcutta:20190113T063823
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190112_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-22\, Islamic: 1440-05-05 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1742,7 +1742,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190112
 DTEND;VALUE=DATE:20190113
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-01-12T06:38:15.360003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -1763,7 +1763,7 @@ BEGIN:VEVENT
 SUMMARY:Kaṟavaigaḷ Pinchenṟu
 DTSTART;VALUE=DATE:20190112
 DTEND;VALUE=DATE:20190113
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:KaṟavaigaḷPinchenṟu_2019-01-12T06:38:15.360003+05:30
 DESCRIPTION:Observed on day 28 of Dhanuḥ (sidereal solar) month (Sūryō
  dayaḥ/puurvaviddha). <br/><br/>Offer naivedyam of dadhyōdanam to Vishnu
@@ -1786,7 +1786,7 @@ SUMMARY:Pauṣaḥ-10-07  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \,
  hānuḥ
 DTSTART;TZID=Asia/Calcutta:20190113T063823
 DTEND;TZID=Asia/Calcutta:20190114T063841
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190113_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-23\, Islamic: 1440-05-06 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1842,7 +1842,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190113T175629
 DTEND;TZID=Asia/Calcutta:20190114T063841
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-13T17:56:29.759995+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -1863,7 +1863,7 @@ BEGIN:VEVENT
 SUMMARY:vijayā-bhānusaptamī
 DTSTART;VALUE=DATE:20190113
 DTEND;VALUE=DATE:20190114
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:vijayā-bhānusaptamī_2019-01-13T06:38:23.999989+05:30
 DESCRIPTION:saptamī tithi on a Sunday is as sacred as a solar eclipse. Pa
  rticularly good for worshipping Surya. When śukla saptamī is present at 
@@ -1887,7 +1887,7 @@ SUMMARY:Pauṣaḥ-10-08  \,Mīnaḥ-Rēvatī🌛🌌  \,  Dhanuḥ-Uttar
  āṣāḍhā-09-30🌞🌌  \,  Tapaḥ-11-24🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190114T063841
 DTEND;TZID=Asia/Calcutta:20190115T063849
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190114_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-24\, Islamic: 1440-05-07 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -1944,7 +1944,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190114
 DTEND;VALUE=DATE:20190115
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-14T06:38:41.280000+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -1979,7 +1979,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190114
 DTEND;VALUE=DATE:20190115
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-14T06:38:41.280000+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -2004,7 +2004,7 @@ BEGIN:VEVENT
 SUMMARY:Bhōgi
 DTSTART;VALUE=DATE:20190114
 DTEND;VALUE=DATE:20190115
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:Bhōgi_2019-01-14T06:38:41.280000+05:30
 DESCRIPTION:Bhogi\, the first day of the Tamil Poṅgal festival\, observe
  d on the day before Makara Saṅkramaṇa\; old and unwanted belongings ar
@@ -2025,7 +2025,7 @@ BEGIN:VEVENT
 SUMMARY:dhanurmāsa-uṣaḥkāla-pūjā-samāpanam
 DTSTART;VALUE=DATE:20190114
 DTEND;VALUE=DATE:20190115
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:dhanurmāsa-uṣaḥkāla-pūjā-samāpanam_2019-01-14T06:38:41.280000
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -2048,7 +2048,7 @@ BEGIN:VEVENT
 SUMMARY:Vāyilār Nāyanmār (51) Gurupūjai
 DTSTART;VALUE=DATE:20190114
 DTEND;VALUE=DATE:20190115
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:VāyilārNāyanmār(51)Gurupūjai_2019-01-14T06:38:41.280000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -2072,7 +2072,7 @@ SUMMARY:Pauṣaḥ-10-09  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Makaraḥ-Utt
  arāṣāḍhā-10-01🌞🌌  \,  Tapaḥ-11-25🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190115T063849
 DTEND;TZID=Asia/Calcutta:20190116T063858
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190115_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-25\, Islamic: 1440-05-08 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -2128,7 +2128,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190115T063849
 DTEND;TZID=Asia/Calcutta:20190115T175738
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-15T06:38:49.919985+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -2150,7 +2150,7 @@ BEGIN:VEVENT
 SUMMARY:bhaumāśvinī-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190114T235957
 DTEND;TZID=Asia/Calcutta:20190115T135400
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:bhaumāśvinī-yōgaḥ_2019-01-14T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/bhaumAz
@@ -2170,7 +2170,7 @@ SUMMARY:Madhurai Mīnākṣī Kōyilil Kal Yānaikku Karumbu Kōḍutta L
  īlai
 DTSTART;VALUE=DATE:20190115
 DTEND;VALUE=DATE:20190116
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:MadhuraiMīnākṣīKōyililKalYānaikkuKarumbuKōḍuttaLīlai_2019-0
  1-15T06:38:49.919985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -2195,7 +2195,7 @@ BEGIN:VEVENT
 SUMMARY:makara-jyōtiḥ
 DTSTART;VALUE=DATE:20190115
 DTEND;VALUE=DATE:20190116
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:makara-jyōtiḥ_2019-01-15T06:38:49.919985+05:30
 DESCRIPTION:Observed on day 1 of Makaraḥ (sidereal solar) month (Sūryō
  dayaḥ/puurvaviddha). <br/><br/>Darshan of Makara Jyoti in Sabarimala Ayy
@@ -2216,7 +2216,7 @@ BEGIN:VEVENT
 SUMMARY:makara-saṅkramaṇa-puṇyakālaḥ
 DTSTART;VALUE=DATE:20190114
 DTEND;VALUE=DATE:20190115
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:makara-saṅkramaṇa-puṇyakālaḥ_2019-01-14T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/makara-saGk
@@ -2238,7 +2238,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190115T063849
 DTEND;TZID=Asia/Calcutta:20190115T121814
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-01-15T06:38:49.9
  19985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -2260,7 +2260,7 @@ SUMMARY:Pauṣaḥ-10-10  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Makara
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190116T063858
 DTEND;TZID=Asia/Calcutta:20190117T063907
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190116_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-26\, Islamic: 1440-05-09 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -2317,7 +2317,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190116T175813
 DTEND;TZID=Asia/Calcutta:20190117T063907
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-16T17:58:13.440020+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -2338,7 +2338,7 @@ BEGIN:VEVENT
 SUMMARY:indra-pūjā/gō-pūjā
 DTSTART;VALUE=DATE:20190116
 DTEND;VALUE=DATE:20190117
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:indra-pūjā/gō-pūjā_2019-01-16T06:38:58.560010+05:30
 DESCRIPTION:Worship of Indra and/or cattle (Go-pūjā)\, performed on the 
  day after Makara Saṅkramaṇa\; corresponds to Māṭṭu Poṅgal in Ta
@@ -2359,7 +2359,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190116
 DTEND;VALUE=DATE:20190117
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-01-16T06:38:58.560010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -2380,7 +2380,7 @@ BEGIN:VEVENT
 SUMMARY:Kanup Poṅgal
 DTSTART;VALUE=DATE:20190116
 DTEND;VALUE=DATE:20190117
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:KanupPoṅgal_2019-01-16T06:38:58.560010+05:30
 DESCRIPTION:Kanu Pongal is observed on the morning after Thai Pongal\, the
   day of Makara Saṅkramaṇa. At dawn\, women and girls lay turmeric leav
@@ -2403,7 +2403,7 @@ BEGIN:VEVENT
 SUMMARY:sāmba-daśamī (sūryapūjā)
 DTSTART;VALUE=DATE:20190116
 DTEND;VALUE=DATE:20190117
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sāmba-daśamī(sūryapūjā)_2019-01-16T06:38:58.560010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Odisha/lunar_month/tithi/10/10/sAmba-daza
@@ -2428,7 +2428,7 @@ SUMMARY:Pauṣaḥ-10-11  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Makara
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190117T063907
 DTEND;TZID=Asia/Calcutta:20190118T063915
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190117_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-27\, Islamic: 1440-05-10 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -2484,7 +2484,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190117
 DTEND;VALUE=DATE:20190118
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-17T06:39:07.199996+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -2508,7 +2508,7 @@ SUMMARY:kāñcī 55 jagadguru-śrī-candracūḍēndra-sarasvatī-3-ārād
  hanā #495
 DTSTART;VALUE=DATE:20190117
 DTEND;VALUE=DATE:20190118
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī55jagadguru-śrī-candracūḍēndra-sarasvatī-3-ārādhanā#
  495_2019-01-17T06:39:07.199996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -2533,7 +2533,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(cākṣuṣaḥ-[6])
 DTSTART;VALUE=DATE:20190117
 DTEND;VALUE=DATE:20190118
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(cākṣuṣaḥ-[6])_2019-01-17T06:39:07.199996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/10/11/manvA
@@ -2555,7 +2555,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-pauṣa-putradā-ēkādaśī
 DTSTART;VALUE=DATE:20190117
 DTEND;VALUE=DATE:20190118
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sarva-pauṣa-putradā-ēkādaśī_2019-01-17T06:39:07.199996+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of pauṣa month is known as pauṣ
  a-putradā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are g
@@ -2650,7 +2650,7 @@ BEGIN:VEVENT
 SUMMARY:makara-śravaṇa-kārttikōtsavaḥ
 DTSTART;VALUE=DATE:20190117
 DTEND;VALUE=DATE:20190118
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:makara-śravaṇa-kārttikōtsavaḥ_2019-01-17T06:39:07.199996+05:30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Makaraḥ (sidereal solar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>सूर्ये मक
@@ -2680,7 +2680,7 @@ SUMMARY:Pauṣaḥ-10-12  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Makara
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190118T063915
 DTEND;TZID=Asia/Calcutta:20190119T063915
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190118_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-28\, Islamic: 1440-05-11 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -2737,7 +2737,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṭtilā-dvādaśī
 DTSTART;VALUE=DATE:20190118
 DTEND;VALUE=DATE:20190119
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṭtilā-dvādaśī_2019-01-18T06:39:15.839981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/10/12/SaTtilA-dvAdazI.t
@@ -2758,7 +2758,7 @@ BEGIN:VEVENT
 SUMMARY:jayantī-mahādvādaśī
 DTSTART;VALUE=DATE:20190118
 DTEND;VALUE=DATE:20190119
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:jayantī-mahādvādaśī_2019-01-18T06:39:15.839981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/jaya
@@ -2780,7 +2780,7 @@ BEGIN:VEVENT
 SUMMARY:taittirīya-utsargō rōhiṇyām
 DTSTART;VALUE=DATE:20190118
 DTEND;VALUE=DATE:20190119
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:taittirīya-utsargōrōhiṇyām_2019-01-18T06:39:15.839981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/Apastamba/lunar_month/nakshatra/10/04/taitt
@@ -2801,7 +2801,7 @@ BEGIN:VEVENT
 SUMMARY:Tai Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190118
 DTEND;VALUE=DATE:20190119
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:TaiVeḷḷikkiḻamai_2019-01-18T06:39:15.839981+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of tai are special for propitiating Shakti Devi. At homes\, there is
@@ -2822,7 +2822,7 @@ BEGIN:VEVENT
 SUMMARY:śaniḥ–udayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190117T235957
 DTEND;TZID=Asia/Calcutta:20190118T124426
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:śaniḥ–udayaḥ(prāk)_2019-01-17T23:59:57.120005+05:30
 DESCRIPTION:śaniḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Jan-18 12:44. At this moment śaniḥ is at pūrvāṣāḍh
@@ -2843,7 +2843,7 @@ SUMMARY:Pauṣaḥ-10-13  \,Mithunam-Mr̥gaśīrṣam🌛🌌  \,  Makara
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190119T063915
 DTEND;TZID=Asia/Calcutta:20190120T063924
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190119_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-29\, Islamic: 1440-05-12 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -2900,7 +2900,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190119T175948
 DTEND;TZID=Asia/Calcutta:20190120T063924
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-19T17:59:48.480020+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -2922,7 +2922,7 @@ BEGIN:VEVENT
 SUMMARY:Arivāṭṭāya Nāyanmār (13) Gurupūjai
 DTSTART;VALUE=DATE:20190119
 DTEND;VALUE=DATE:20190120
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:ArivāṭṭāyaNāyanmār(13)Gurupūjai_2019-01-19T06:39:15.839981+05
  :30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -2946,7 +2946,7 @@ BEGIN:VEVENT
 SUMMARY:Kaṇṇappa Nāyanmār (10) Gurupūjai
 DTSTART;VALUE=DATE:20190119
 DTEND;VALUE=DATE:20190120
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:KaṇṇappaNāyanmār(10)Gurupūjai_2019-01-19T06:39:15.839981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -2969,7 +2969,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Teppōtsavam
 DTSTART;VALUE=DATE:20190119
 DTEND;VALUE=DATE:20190120
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:KapālīTeppōtsavam_2019-01-19T06:39:15.839981+05:30
 DESCRIPTION:First day of the teppotsavam (float festival) at the Kapālī
  śvarar temple\, Mylapore\, held the day before Taippūcam\; the deities a
@@ -2990,7 +2990,7 @@ BEGIN:VEVENT
 SUMMARY:śanivāra-śukla-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190119T175948
 DTEND;TZID=Asia/Calcutta:20190119T193442
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:śanivāra-śukla-pradōṣa-vratam_2019-01-19T17:59:48.480020+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/zani
@@ -3010,7 +3010,7 @@ SUMMARY:Pauṣaḥ-10-14  \,Mithunam-Ārdrā🌛🌌  \,  Makaraḥ-Uttar
  āṣāḍhā-10-06🌞🌌  \,  Tapasyaḥ-12-01🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190120T063924
 DTEND;TZID=Asia/Calcutta:20190121T063924
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190120_day_summary
 DESCRIPTION:- Indian civil date: 1940-10-30\, Islamic: 1440-05-13 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -3067,7 +3067,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -3107,7 +3107,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -3132,7 +3132,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190120T205253
 DTEND;TZID=Asia/Calcutta:20190120T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-01-20T20:52:53.760000+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -3148,7 +3148,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-10
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-10_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Pauṣaḥ (lunar) month (
  Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config
@@ -3168,7 +3168,7 @@ SUMMARY:kāñcī 8 jagadguru-śrī-kaivalyānandayōgēndra-sarasvatī-ār
  ādhanā #1990
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī8jagadguru-śrī-kaivalyānandayōgēndra-sarasvatī-ārādhan
  ā#1990_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -3193,7 +3193,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Teppōtsavam
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:KapālīTeppōtsavam_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Second\, principal day of the teppotsavam (float festival) at 
  the Kapālīśvarar temple\, Mylapore\, coinciding with Taippūcam.<br/><b
@@ -3213,7 +3213,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -3234,7 +3234,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -3258,7 +3258,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -3277,7 +3277,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190120T121949
 DTEND;TZID=Asia/Calcutta:20190120T180023
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-01-20T12:
  19:49.439991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -3298,7 +3298,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190120T080531
 DTEND;TZID=Asia/Calcutta:20190120T180023
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-viṣṇupadī-puṇyakālaḥ_2019-01-20T08:05:31.200001+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -3318,7 +3318,7 @@ BEGIN:VEVENT
 SUMMARY:makara-puṣyōtsavaḥ
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:makara-puṣyōtsavaḥ_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:Observed on Puṣyaḥ nakshatra of Makaraḥ (sidereal solar)
   month (Rātrimānam/puurvaviddha). <br/><br/>सूर्ये मकर
@@ -3344,7 +3344,7 @@ BEGIN:VEVENT
 SUMMARY:tapasya-māsaḥ
 DTSTART;TZID=Asia/Calcutta:20190120T142934
 DTEND;TZID=Asia/Calcutta:20190120T235957
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:tapasya-māsaḥ_2019-01-20T14:29:34.080004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -3363,7 +3363,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190120
 DTEND;VALUE=DATE:20190121
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-01-20T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -3387,7 +3387,7 @@ SUMMARY:Pauṣaḥ-10-15  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Makaraḥ
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190121T063924
 DTEND;TZID=Asia/Calcutta:20190122T063933
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:20190121_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-01\, Islamic: 1440-05-14 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -3444,7 +3444,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -3479,7 +3479,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -3525,7 +3525,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -3548,7 +3548,7 @@ BEGIN:VEVENT
 SUMMARY:badarī jyōtirmaṭha-pratiṣṭhāpana-jayantī #2504
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:badarījyōtirmaṭha-pratiṣṭhāpana-jayantī#2504_2019-01-21T06:3
  9:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Pauṣaḥ (lunar) month (
@@ -3572,7 +3572,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Teppōtsavam
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:KapālīTeppōtsavam_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Third and concluding day of the teppotsavam (float festival) a
  t the Kapālīśvarar temple\, Mylapore\, held the day after Taippūcam.<b
@@ -3592,7 +3592,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-01-21T06:39:
  24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -3619,7 +3619,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -3638,7 +3638,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115603Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -3658,7 +3658,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -3679,7 +3679,7 @@ BEGIN:VEVENT
 SUMMARY:taittirīya-utsargaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:taittirīya-utsargaḥpaurṇamāsyām_2019-01-21T06:39:24.480007+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -3702,7 +3702,7 @@ SUMMARY:tuṅgabhadrā śr̥ṅgagiri śāradāmaṭha-pratiṣṭhāpana-
  jayantī #2502
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tuṅgabhadrāśr̥ṅgagiriśāradāmaṭha-pratiṣṭhāpana-jayant
  ī#2502_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Pauṣaḥ (lunar) month (
@@ -3726,7 +3726,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-01-21T06:39:24.4800
  07+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -3749,7 +3749,7 @@ BEGIN:VEVENT
 SUMMARY:śākambharī-jayantī
 DTSTART;VALUE=DATE:20190121
 DTEND;VALUE=DATE:20190122
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śākambharī-jayantī_2019-01-21T06:39:24.480007+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Pauṣaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/>वनपूर्णिमा इ
@@ -3785,7 +3785,7 @@ SUMMARY:Pauṣaḥ-10-16  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Makara
  ṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190122T063933
 DTEND;TZID=Asia/Calcutta:20190123T063933
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190122_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-02\, Islamic: 1440-05-15 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -3843,7 +3843,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190122
 DTEND;VALUE=DATE:20190123
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-22T06:39:33.119992+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -3866,7 +3866,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190122
 DTEND;VALUE=DATE:20190123
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-01-22T06:39:33.119992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -3888,7 +3888,7 @@ SUMMARY:kāñcī 37 jagadguru-śrī-vidyāghanēndra-sarasvatī-3-ārādha
  nā #1231
 DTSTART;VALUE=DATE:20190122
 DTEND;VALUE=DATE:20190123
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī37jagadguru-śrī-vidyāghanēndra-sarasvatī-3-ārādhanā#12
  31_2019-01-22T06:39:33.119992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -3914,7 +3914,7 @@ SUMMARY:kāñcī 62 jagadguru-śrī-candraśēkharēndra-sarasvatī-4-ār
  ādhanā #236
 DTSTART;VALUE=DATE:20190122
 DTEND;VALUE=DATE:20190123
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī62jagadguru-śrī-candraśēkharēndra-sarasvatī-4-ārādhan
  ā#236_2019-01-22T06:39:33.119992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -3940,7 +3940,7 @@ SUMMARY:Pauṣaḥ-10-18  \,Siṁhaḥ-Maghā🌛🌌  \,  Makaraḥ-Uttar
  āṣāḍhā-10-09🌞🌌  \,  Tapasyaḥ-12-04🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190123T063933
 DTEND;TZID=Asia/Calcutta:20190124T063933
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190123_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-03\, Islamic: 1440-05-16 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -3996,7 +3996,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190123
 DTEND;VALUE=DATE:20190124
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-23T06:39:33.119992+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -4019,7 +4019,7 @@ BEGIN:VEVENT
 SUMMARY:Tirumaḻichaiyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190123
 DTEND;VALUE=DATE:20190124
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TirumaḻichaiyāḻvārTirunakṣattiram_2019-01-23T06:39:33.119992+0
  5:30
 DESCRIPTION:Observed on Maghā nakshatra of Makaraḥ (sidereal solar) mon
@@ -4042,7 +4042,7 @@ SUMMARY:Pauṣaḥ-10-19  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Makara
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190124T063933
 DTEND;TZID=Asia/Calcutta:20190125T063933
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190124_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-04\, Islamic: 1440-05-17 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4099,7 +4099,7 @@ BEGIN:VEVENT
 SUMMARY:lambōdara-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20190124
 DTEND;VALUE=DATE:20190125
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:lambōdara-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-01-24
  T06:39:33.119992+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -4128,7 +4128,7 @@ SUMMARY:Pauṣaḥ-10-20  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Makaraḥ-
  Śravaṇaḥ-10-11🌞🌌  \,  Tapasyaḥ-12-06🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190125T063933
 DTEND;TZID=Asia/Calcutta:20190126T063933
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190125_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-05\, Islamic: 1440-05-18 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4185,7 +4185,7 @@ BEGIN:VEVENT
 SUMMARY:Chaṇḍēśvara Nāyanmār (20) Gurupūjai
 DTSTART;VALUE=DATE:20190125
 DTEND;VALUE=DATE:20190126
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ChaṇḍēśvaraNāyanmār(20)Gurupūjai_2019-01-25T06:39:33.119992+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -4209,7 +4209,7 @@ BEGIN:VEVENT
 SUMMARY:Tai Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190125
 DTEND;VALUE=DATE:20190126
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TaiVeḷḷikkiḻamai_2019-01-25T06:39:33.119992+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of tai are special for propitiating Shakti Devi. At homes\, there is
@@ -4230,7 +4230,7 @@ BEGIN:VEVENT
 SUMMARY:tyāgarāja-ārādhanā/bahula-pañcamī #172
 DTSTART;VALUE=DATE:20190125
 DTEND;VALUE=DATE:20190126
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tyāgarāja-ārādhanā/bahula-pañcamī#172_2019-01-25T06:39:33.11999
  2+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Pauṣaḥ (lunar) 
@@ -4254,7 +4254,7 @@ SUMMARY:Pauṣaḥ-10-21  \,Kanyā-Hastaḥ🌛🌌  \,  Makaraḥ-Śrava
  ṇaḥ-10-12🌞🌌  \,  Tapasyaḥ-12-07🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190126T063933
 DTEND;TZID=Asia/Calcutta:20190127T063924
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190126_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-06\, Islamic: 1440-05-19 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4310,7 +4310,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190126T180315
 DTEND;TZID=Asia/Calcutta:20190127T063924
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-26T18:03:15.839989+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -4331,7 +4331,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190126T161926
 DTEND;TZID=Asia/Calcutta:20190127T063924
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-01-26T16:19:26.399990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -4351,7 +4351,7 @@ SUMMARY:Pauṣaḥ-10-22  \,Tulā-Citrā🌛🌌  \,  Makaraḥ-Śravaṇa
  ḥ-10-13🌞🌌  \,  Tapasyaḥ-12-08🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190127T063924
 DTEND;TZID=Asia/Calcutta:20190128T063924
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190127_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-07\, Islamic: 1440-05-20 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4407,7 +4407,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190127
 DTEND;VALUE=DATE:20190128
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -4432,7 +4432,7 @@ BEGIN:VEVENT
 SUMMARY:bhānusaptamī
 DTSTART;VALUE=DATE:20190127
 DTEND;VALUE=DATE:20190128
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:bhānusaptamī_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:saptamī tithi on a Sunday is as sacred as a solar eclipse. Pa
  rticularly good for worshipping Surya.<br/><br/>amāvāsyā tu sōmēna sa
@@ -4454,7 +4454,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190127T063924
 DTEND;TZID=Asia/Calcutta:20190127T142248
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -4473,7 +4473,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190127
 DTEND;VALUE=DATE:20190128
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -4492,7 +4492,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-aṣṭakā-pūrvēdyuḥ
 DTSTART;VALUE=DATE:20190127
 DTEND;VALUE=DATE:20190128
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-aṣṭakā-pūrvēdyuḥ_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/relative_event/pauSa-aSTakA-zrAddham/
@@ -4514,7 +4514,7 @@ BEGIN:VEVENT
 SUMMARY:vivēkānanda-janmadinam #157
 DTSTART;VALUE=DATE:20190127
 DTEND;VALUE=DATE:20190128
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vivēkānanda-janmadinam#157_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Saptamī tithi of Pauṣaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). The event occurred in 4963 (Kali era).
@@ -4536,7 +4536,7 @@ SUMMARY:Pauṣaḥ-10-23  \,Tulā-Svātī🌛🌌  \,  Makaraḥ-Śravaṇ
  aḥ-10-14🌞🌌  \,  Tapasyaḥ-12-09🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190128T063924
 DTEND;TZID=Asia/Calcutta:20190129T063915
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190128_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-08\, Islamic: 1440-05-21 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4592,7 +4592,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190128
 DTEND;VALUE=DATE:20190129
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-28T06:39:24.480007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -4627,7 +4627,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190128
 DTEND;VALUE=DATE:20190129
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-28T06:39:24.480007+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -4652,7 +4652,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-aṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20190128
 DTEND;VALUE=DATE:20190129
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-aṣṭakā-śrāddham_2019-01-28T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/10/23/pauSa-aSTakA-
@@ -4674,7 +4674,7 @@ SUMMARY:Pauṣaḥ-10-24  \,Tulā-Viśākhā🌛🌌  \,  Makaraḥ-Śrava
  ṇaḥ-10-15🌞🌌  \,  Tapasyaḥ-12-10🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190129T063915
 DTEND;TZID=Asia/Calcutta:20190130T063915
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190129_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-09\, Islamic: 1440-05-22 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4731,7 +4731,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190129
 DTEND;VALUE=DATE:20190130
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-01-29T06:39:15.839981+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -4756,7 +4756,7 @@ BEGIN:VEVENT
 SUMMARY:bhīṣma-jayantī
 DTSTART;VALUE=DATE:20190129
 DTEND;VALUE=DATE:20190130
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:bhīṣma-jayantī_2019-01-29T06:39:15.839981+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Pauṣaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Re
@@ -4777,7 +4777,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-anvaṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20190129
 DTEND;VALUE=DATE:20190130
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-anvaṣṭakā-śrāddham_2019-01-29T06:39:15.839981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/relative_event/pauSa-aSTakA-zrAddham/
@@ -4799,7 +4799,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunīlakaṇṭha Nāyanmār (2) Gurupūjai
 DTSTART;VALUE=DATE:20190129
 DTEND;VALUE=DATE:20190130
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TirunīlakaṇṭhaNāyanmār(2)Gurupūjai_2019-01-29T06:39:15.839981+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -4823,7 +4823,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190129T231007
 DTEND;TZID=Asia/Calcutta:20190129T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-01-29T23:10:07.680014+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -4840,7 +4840,7 @@ SUMMARY:Pauṣaḥ-10-25  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Makara
  ḥ-Śravaṇaḥ-10-16🌞🌌  \,  Tapasyaḥ-12-11🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190130T063915
 DTEND;TZID=Asia/Calcutta:20190131T063907
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190130_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-10\, Islamic: 1440-05-23 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4896,7 +4896,7 @@ BEGIN:VEVENT
 SUMMARY:budhānurādhā-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190129T235957
 DTEND;TZID=Asia/Calcutta:20190130T163818
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budhānurādhā-yōgaḥ_2019-01-29T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/budhAnu
@@ -4915,7 +4915,7 @@ BEGIN:VEVENT
 SUMMARY:trailōkya-gaurī-vratam
 DTSTART;VALUE=DATE:20190130
 DTEND;VALUE=DATE:20190131
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:trailōkya-gaurī-vratam_2019-01-30T06:39:15.839981+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Daśamī tithi of Pauṣaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -4936,7 +4936,7 @@ SUMMARY:Pauṣaḥ-10-26  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Makar
  aḥ-Śravaṇaḥ-10-17🌞🌌  \,  Tapasyaḥ-12-12🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190131T063907
 DTEND;TZID=Asia/Calcutta:20190201T063858
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190131_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-11\, Islamic: 1440-05-24 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -4993,7 +4993,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-ṣaṭtilā-ēkādaśī
 DTSTART;VALUE=DATE:20190131
 DTEND;VALUE=DATE:20190201
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sarva-ṣaṭtilā-ēkādaśī_2019-01-31T06:39:07.199996+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of pauṣa month is known as ṣa
  ṭtilā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are gre
@@ -5089,7 +5089,7 @@ SUMMARY:Pauṣaḥ-10-27  \,Dhanuḥ-Mūlā🌛🌌  \,  Makaraḥ-Śrava
  ṇaḥ-10-18🌞🌌  \,  Tapasyaḥ-12-13🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190201T063858
 DTEND;TZID=Asia/Calcutta:20190202T063849
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190201_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-12\, Islamic: 1440-05-25 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -5145,7 +5145,7 @@ BEGIN:VEVENT
 SUMMARY:sēṅgālipuram-muttaṇṇāvāḷ-ārādhanā #126
 DTSTART;VALUE=DATE:20190201
 DTEND;VALUE=DATE:20190202
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sēṅgālipuram-muttaṇṇāvāḷ-ārādhanā#126_2019-02-01T06:38:
  58.560010+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Makaraḥ (siderea
@@ -5168,7 +5168,7 @@ BEGIN:VEVENT
 SUMMARY:Tai Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190201
 DTEND;VALUE=DATE:20190202
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TaiVeḷḷikkiḻamai_2019-02-01T06:38:58.560010+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of tai are special for propitiating Shakti Devi. At homes\, there is
@@ -5191,7 +5191,7 @@ SUMMARY:Pauṣaḥ-10-28  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Makar
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190202T063849
 DTEND;TZID=Asia/Calcutta:20190203T063832
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190202_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-13\, Islamic: 1440-05-26 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -5247,7 +5247,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190202T180625
 DTEND;TZID=Asia/Calcutta:20190203T063832
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-02T18:06:25.919988+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -5268,7 +5268,7 @@ BEGIN:VEVENT
 SUMMARY:gōvinda-dāmōdara-svāminaḥ ārādhanā #15
 DTSTART;VALUE=DATE:20190202
 DTEND;VALUE=DATE:20190203
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:gōvinda-dāmōdara-svāminaḥārādhanā#15_2019-02-02T06:38:49.9199
  85+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -5293,7 +5293,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190202
 DTEND;VALUE=DATE:20190203
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-02-02T06:38:49.919985+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -5313,7 +5313,7 @@ BEGIN:VEVENT
 SUMMARY:śani-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190202T180625
 DTEND;TZID=Asia/Calcutta:20190202T194027
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śani-pradōṣa-vratam_2019-02-02T18:06:25.919988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/zani
@@ -5333,7 +5333,7 @@ SUMMARY:Pauṣaḥ-10-29  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  Maka
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190203T063832
 DTEND;TZID=Asia/Calcutta:20190204T063823
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190203_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-14\, Islamic: 1440-05-27 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -5389,7 +5389,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190203
 DTEND;VALUE=DATE:20190204
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-03T06:38:32.640014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -5429,7 +5429,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190203
 DTEND;VALUE=DATE:20190204
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-02-03T06:38:32.640014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -5448,7 +5448,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-yama-tarpaṇam
 DTSTART;VALUE=DATE:20190203
 DTEND;VALUE=DATE:20190204
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-yama-tarpaṇam_2019-02-03T06:38:32.640014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/10/29/pauSa-yama-ta
@@ -5470,7 +5470,7 @@ SUMMARY:Pauṣaḥ-10-30  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Makaraḥ
  -Śravaṇaḥ-10-21🌞🌌  \,  Tapasyaḥ-12-16🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190204T063823
 DTEND;TZID=Asia/Calcutta:20190205T063815
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190204_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-15\, Islamic: 1440-05-28 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -5526,7 +5526,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -5561,7 +5561,7 @@ BEGIN:VEVENT
 SUMMARY:mahōdaya-puṇyakālaḥ
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:mahōdaya-puṇyakālaḥ_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:A rare combination of Pausha masa\, Shravana nakshatra\, Vyati
  pata yoga and Monday.<br/><br/>## Details<br/>- [Edit config file](https:/
@@ -5580,7 +5580,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -5601,7 +5601,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -5620,7 +5620,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-māsaḥ
 DTSTART;VALUE=DATE:20190106
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-māsaḥ_2019-01-06T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/pauSa-mAsaH.toml
@@ -5642,7 +5642,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-māsa-samāpanam
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-māsa-samāpanam_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Pauṣaḥ (lunar) month (Sū
  ryōdayaḥ/paraviddha). <br/><br/>pauṣa-māsaḥ ends today<br/><br/>##
@@ -5662,7 +5662,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -5683,7 +5683,7 @@ BEGIN:VEVENT
 SUMMARY:sōmavatī amāvāsyā
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sōmavatīamāvāsyā_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/amAvAsyA/description_only/sOma
@@ -5704,7 +5704,7 @@ BEGIN:VEVENT
 SUMMARY:sōmaśravaṇa-yōgaḥ
 DTSTART;VALUE=DATE:20190203
 DTEND;VALUE=DATE:20190204
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sōmaśravaṇa-yōgaḥ_2019-02-03T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmazra
@@ -5726,7 +5726,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-mauni (pauṣa/makara) amāvāsyā (alabhyam–puṣkalā)
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sarva-mauni(pauṣa/makara)amāvāsyā(alabhyam–puṣkalā)_2019-02-
  04T06:38:23.999989+05:30
 DESCRIPTION:amāvāsyā of pauṣa month\, which also coincides with the s
@@ -5756,7 +5756,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunelvēli Nellaiyappar Patra Dīpa Tiruviḻā
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TirunelvēliNellaiyapparPatraDīpaTiruviḻā_2019-02-04T06:38:23.9999
  89+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Makaraḥ (sidereal solar) mo
@@ -5777,7 +5777,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -5799,7 +5799,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190205
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-02-04T06:38:23.999989+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -5820,7 +5820,7 @@ SUMMARY:Māghaḥ-11-01  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Makara
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190205T063815
 DTEND;TZID=Asia/Calcutta:20190206T063758
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190205_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-16\, Islamic: 1440-05-29 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -5877,7 +5877,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190205T231828
 DTEND;TZID=Asia/Calcutta:20190205T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-02-05T23:18:28.800007+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -5893,7 +5893,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190205
 DTEND;VALUE=DATE:20190206
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-05T06:38:15.360003+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -5939,7 +5939,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190205
 DTEND;VALUE=DATE:20190206
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-02-05T06:38:15.360003+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -5958,7 +5958,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190206T051536
 DTEND;TZID=Asia/Calcutta:20190206T063758
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-02-06T05:15:36.000019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -5977,7 +5977,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190205
 DTEND;VALUE=DATE:20190206
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsa-ārambhaḥ_2019-02-05T06:38:15.360003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/11/01/mAgha-mAs
@@ -5999,7 +5999,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190205
 DTEND;VALUE=DATE:20190206
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-02-05T06:38:15.360003
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -6025,7 +6025,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190205
 DTEND;VALUE=DATE:20190206
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-02-05T06:38:15.360003+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -6046,7 +6046,7 @@ BEGIN:VEVENT
 SUMMARY:śyāmalānavarātra-ārambhaḥ
 DTSTART;VALUE=DATE:20190205
 DTEND;VALUE=DATE:20190206
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śyāmalānavarātra-ārambhaḥ_2019-02-05T06:38:15.360003+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Māghaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/>Shyamala Devi specially blesses m
@@ -6068,7 +6068,7 @@ SUMMARY:Māghaḥ-11-02  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,  Makara
  ḥ-Śravaṇaḥ-10-23🌞🌌  \,  Tapasyaḥ-12-18🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190206T063758
 DTEND;TZID=Asia/Calcutta:20190207T063740
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190206_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-17\, Islamic: 1440-05-30 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Makaraḥ\, तं- Tai\, म- Mak
@@ -6124,7 +6124,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190206T180800
 DTEND;TZID=Asia/Calcutta:20190206T192311
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-02-06T18:08:00.959988+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -6144,7 +6144,7 @@ SUMMARY:Māghaḥ-11-02  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Makaraḥ-
  Śraviṣṭhā-10-24🌞🌌  \,  Tapasyaḥ-12-19🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190207T063740
 DTEND;TZID=Asia/Calcutta:20190208T063732
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190207_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-18\, Islamic: 1440-06-01 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Makaraḥ\, तं- Tai\
@@ -6201,7 +6201,7 @@ BEGIN:VEVENT
 SUMMARY:Appūdiyaḍigaḷ Nāyanmār (25) Gurupūjai
 DTSTART;VALUE=DATE:20190207
 DTEND;VALUE=DATE:20190208
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:AppūdiyaḍigaḷNāyanmār(25)Gurupūjai_2019-02-07T06:37:40.799982+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -6225,7 +6225,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190207T095934
 DTEND;TZID=Asia/Calcutta:20190207T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-02-07T09:59:34.080004+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -6243,7 +6243,7 @@ SUMMARY:Māghaḥ-11-03  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌  \,
  Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190208T063732
 DTEND;TZID=Asia/Calcutta:20190209T063714
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190208_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-19\, Islamic: 1440-06-02 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Makaraḥ\, तं- Tai\
@@ -6300,7 +6300,7 @@ BEGIN:VEVENT
 SUMMARY:Tai Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190208
 DTEND;VALUE=DATE:20190209
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TaiVeḷḷikkiḻamai_2019-02-08T06:37:32.159996+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of tai are special for propitiating Shakti Devi. At homes\, there is
@@ -6321,7 +6321,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā Toḍakkam
 DTSTART;VALUE=DATE:20190208
 DTEND;VALUE=DATE:20190209
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻāToḍakkam_2019-02-08T06:37:32.
  159996+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -6346,7 +6346,7 @@ BEGIN:VEVENT
 SUMMARY:śāntā varakunda-caturthī
 DTSTART;VALUE=DATE:20190208
 DTEND;VALUE=DATE:20190209
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śāntāvarakunda-caturthī_2019-02-08T06:37:32.159996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/gaNapati/lunar_month/tithi/11/04/varakunda
@@ -6367,7 +6367,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190208
 DTEND;VALUE=DATE:20190209
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-02-08T06:37:32.159996+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -6389,7 +6389,7 @@ SUMMARY:Māghaḥ-11-04  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \,  M
  Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190209T063714
 DTEND;TZID=Asia/Calcutta:20190210T063657
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190209_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-20\, Islamic: 1440-06-03 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Makaraḥ\, तं- Tai\
@@ -6445,7 +6445,7 @@ BEGIN:VEVENT
 SUMMARY:māghī-sarasvatī-pūjā
 DTSTART;VALUE=DATE:20190209
 DTEND;VALUE=DATE:20190210
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māghī-sarasvatī-pūjā_2019-02-09T06:37:14.879985+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Māghaḥ (lunar) month 
  (Madhyāhnaḥ/puurvaviddha). <br/><br/>Sarasvati Puja\, especially in Eas
@@ -6467,7 +6467,7 @@ BEGIN:VEVENT
 SUMMARY:mārkaṇḍēya-jayantī
 DTSTART;VALUE=DATE:20190209
 DTEND;VALUE=DATE:20190210
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:mārkaṇḍēya-jayantī_2019-02-09T06:37:14.879985+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Māghaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refere
@@ -6488,7 +6488,7 @@ BEGIN:VEVENT
 SUMMARY:prōklas-janma #1607
 DTSTART;VALUE=DATE:20190208
 DTEND;VALUE=DATE:20190209
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:prōklas-janma#1607_2019-02-08T23:59:57.120005+05:30
 DESCRIPTION:Event occured on 0412-02-09 (gregorian). Julian date was conve
  rted to Gregorian in this reckoning. <br/><br/>Roman Polytheist Platonist 
@@ -6508,7 +6508,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 2M Nāḷ
 DTSTART;VALUE=DATE:20190209
 DTEND;VALUE=DATE:20190210
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā2MNāḷ_2019-02-09T06:37:14.87
  9985+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -6532,7 +6532,7 @@ BEGIN:VEVENT
 SUMMARY:vasanta-pañcamī/śrī-pañcamī/madana-pañcamī
 DTSTART;VALUE=DATE:20190209
 DTEND;VALUE=DATE:20190210
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vasanta-pañcamī/śrī-pañcamī/madana-pañcamī_2019-02-09T06:37:14
  .879985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -6555,7 +6555,7 @@ BEGIN:VEVENT
 SUMMARY:śaṅkarabhagavatpādasya kailāsāt punarāgamanam
 DTSTART;VALUE=DATE:20190209
 DTEND;VALUE=DATE:20190210
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śaṅkarabhagavatpādasyakailāsātpunarāgamanam_2019-02-09T06:37:14
  .879985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -6578,7 +6578,7 @@ BEGIN:VEVENT
 SUMMARY:śrīrāma-vanavāsa-gamanam
 DTSTART;VALUE=DATE:20190209
 DTEND;VALUE=DATE:20190210
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śrīrāma-vanavāsa-gamanam_2019-02-09T06:37:14.879985+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Māghaḥ (lunar) month 
  (Madhyāhnaḥ/puurvaviddha). <br/><br/>Afternoon Shri Raama started to go
@@ -6599,7 +6599,7 @@ SUMMARY:Māghaḥ-11-05  \,Mīnaḥ-Rēvatī🌛🌌  \,  Makaraḥ-Śravi
  ṣṭhā-10-27🌞🌌  \,  Tapasyaḥ-12-22🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190210T063657
 DTEND;TZID=Asia/Calcutta:20190211T063640
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190210_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-21\, Islamic: 1440-06-04 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Makaraḥ\, तं- Tai\
@@ -6656,7 +6656,7 @@ BEGIN:VEVENT
 SUMMARY:Kalikkamba Nāyanmār (43) Gurupūjai
 DTSTART;VALUE=DATE:20190210
 DTEND;VALUE=DATE:20190211
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KalikkambaNāyanmār(43)Gurupūjai_2019-02-10T06:36:57.600015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -6679,7 +6679,7 @@ BEGIN:VEVENT
 SUMMARY:sarpa-pūjā
 DTSTART;VALUE=DATE:20190210
 DTEND;VALUE=DATE:20190211
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sarpa-pūjā_2019-02-10T06:36:57.600015+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Māghaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vishnu's boon to AdiSesha that hu
@@ -6700,7 +6700,7 @@ SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 3M Nāḷ—Murugan Bha
  vani
 DTSTART;VALUE=DATE:20190210
 DTEND;VALUE=DATE:20190211
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā3MNāḷ—MuruganBhavani_2019-
  02-10T06:36:57.600015+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -6727,7 +6727,7 @@ SUMMARY:Māghaḥ-11-06  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Makaraḥ-Śra
  viṣṭhā-10-28🌞🌌  \,  Tapasyaḥ-12-23🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190211T063640
 DTEND;TZID=Asia/Calcutta:20190212T063614
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190211_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-22\, Islamic: 1440-06-05 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Makaraḥ\, तं- Tai\
@@ -6783,7 +6783,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190211
 DTEND;VALUE=DATE:20190212
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-02-11T06:36:40.320004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -6804,7 +6804,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190211T180953
 DTEND;TZID=Asia/Calcutta:20190212T063614
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-11T18:09:53.279998+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -6825,7 +6825,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 4M Nāḷ
 DTSTART;VALUE=DATE:20190211
 DTEND;VALUE=DATE:20190212
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā4MNāḷ_2019-02-11T06:36:40.32
  0004+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -6849,7 +6849,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunelvēli Nellaiyappar Nellukku Vēli Kaṭṭiya Līlai
 DTSTART;VALUE=DATE:20190211
 DTEND;VALUE=DATE:20190212
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TirunelvēliNellaiyapparNellukkuVēliKaṭṭiyaLīlai_2019-02-11T06:3
  6:40.320004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -6875,7 +6875,7 @@ SUMMARY:Māghaḥ-11-07  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Makaraḥ
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190212T063614
 DTEND;TZID=Asia/Calcutta:20190213T063557
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190212_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-23\, Islamic: 1440-06-06 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Makaraḥ\, तं- Tai\
@@ -6932,7 +6932,7 @@ BEGIN:VEVENT
 SUMMARY:acalā-saptamī-vratam
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:acalā-saptamī-vratam_2019-02-12T06:36:14.400008+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Māghaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/>Upadesha of this vrata was done by
@@ -6953,7 +6953,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190212T181010
 DTEND;TZID=Asia/Calcutta:20190213T063557
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-12T18:10:10.560009+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -6975,7 +6975,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-12T06:36:14.400008+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -6998,7 +6998,7 @@ BEGIN:VEVENT
 SUMMARY:dvārakā-maṭha-pratiṣṭhāpana-jayantī #2509
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dvārakā-maṭha-pratiṣṭhāpana-jayantī#2509_2019-02-12T06:36:14
  .400008+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Māghaḥ (lunar) month (
@@ -7021,7 +7021,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(sūrya-sāvarṇiḥ-[8])
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(sūrya-sāvarṇiḥ-[8])_2019-02-12T06:36:14.400008+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -7045,7 +7045,7 @@ BEGIN:VEVENT
 SUMMARY:narmadā-jayantī
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:narmadā-jayantī_2019-02-12T06:36:14.400008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/nadI/lunar_month/tithi/11/07/narmadA~jayan
@@ -7066,7 +7066,7 @@ BEGIN:VEVENT
 SUMMARY:ratha-saptamī
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ratha-saptamī_2019-02-12T06:36:14.400008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/graha/lunar_month/tithi/11/07/ratha-saptam
@@ -7087,7 +7087,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 5M Nāḷ
 DTSTART;VALUE=DATE:20190212
 DTEND;VALUE=DATE:20190213
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā5MNāḷ_2019-02-12T06:36:14.40
  0008+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -7113,7 +7113,7 @@ SUMMARY:Māghaḥ-11-08  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Kumbha
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190213T063557
 DTEND;TZID=Asia/Calcutta:20190214T063539
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190213_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-24\, Islamic: 1440-06-07 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -7170,7 +7170,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -7205,7 +7205,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -7230,7 +7230,7 @@ BEGIN:VEVENT
 SUMMARY:bhīṣmāṣṭamī
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:bhīṣmāṣṭamī_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/xatra/lunar_month/tithi/11/08/bhISmAS
@@ -7253,7 +7253,7 @@ BEGIN:VEVENT
 SUMMARY:budhāṣṭamī
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budhāṣṭamī_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:aṣṭamī tithi on a Wednesday is as sacred as a solar eclip
  se.<br/><br/>amāvāsyā tu sōmēna saptamī bhānunā saha।  <br/>catu
@@ -7275,7 +7275,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -7296,7 +7296,7 @@ BEGIN:VEVENT
 SUMMARY:kaliyugāntaḥ
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kaliyugāntaḥ_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:The day on which Kumbha sankranti happens is also the Kaliyuga
  nta day. Shraadhams offered on this day beget endless fruit.<br/><br/>hēm
@@ -7322,7 +7322,7 @@ BEGIN:VEVENT
 SUMMARY:khōḍiyāra-mātā-jayantī
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:khōḍiyāra-mātā-jayantī_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Māghaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refe
@@ -7343,7 +7343,7 @@ BEGIN:VEVENT
 SUMMARY:kumbha-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190213T063557
 DTEND;TZID=Asia/Calcutta:20190213T145354
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kumbha-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ_2019-02-13T0
  6:35:57.119997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -7364,7 +7364,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190213T063557
 DTEND;TZID=Asia/Calcutta:20190213T122316
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-02-13T06:35:57.1
  19997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -7385,7 +7385,7 @@ SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 6M Nāḷ—Veḷḷit
  Tēr Bhavani
 DTSTART;VALUE=DATE:20190213
 DTEND;VALUE=DATE:20190214
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā6MNāḷ—VeḷḷitTērBhavan
  i_2019-02-13T06:35:57.119997+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -7412,7 +7412,7 @@ SUMMARY:Māghaḥ-11-09  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Kumbha
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190214T063539
 DTEND;TZID=Asia/Calcutta:20190215T063513
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190214_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-25\, Islamic: 1440-06-08 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -7470,7 +7470,7 @@ SUMMARY:kāñcī 11 jagadguru-śrī-śivānanda-cidghanēndra-sarasvatī-
  ārādhanā #1847
 DTSTART;VALUE=DATE:20190214
 DTEND;VALUE=DATE:20190215
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī11jagadguru-śrī-śivānanda-cidghanēndra-sarasvatī-ārādh
  anā#1847_2019-02-14T06:35:39.839986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -7495,7 +7495,7 @@ BEGIN:VEVENT
 SUMMARY:madhva-navamī
 DTSTART;VALUE=DATE:20190214
 DTEND;VALUE=DATE:20190215
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:madhva-navamī_2019-02-14T06:35:39.839986+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Māghaḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/>dehatyAga of madhvAchArya.<br/><br/
@@ -7516,7 +7516,7 @@ SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 7M Nāḷ—Urugu Cha
  ṭṭach Chēvai/Chigappu Chātti Alaṅkāram
 DTSTART;VALUE=DATE:20190214
 DTEND;VALUE=DATE:20190215
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā7MNāḷ—UruguChaṭṭachCh
  ēvai/ChigappuChāttiAlaṅkāram_2019-02-14T06:35:39.839986+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -7542,7 +7542,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190214
 DTEND;VALUE=DATE:20190215
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-02-14T06:35:39.839986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -7564,7 +7564,7 @@ BEGIN:VEVENT
 SUMMARY:śyāmalānavarātraḥ
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190215
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śyāmalānavarātraḥ_2019-02-04T23:59:57.120005+05:30
 DESCRIPTION:Shyamala Devi specially blesses musicians\; honour musicians i
  n this period.<br/><br/>## Details<br/>- References<br/>  - Vaidikasri Feb
@@ -7584,7 +7584,7 @@ BEGIN:VEVENT
 SUMMARY:śyāmalānavarātra-samāpanam
 DTSTART;VALUE=DATE:20190214
 DTEND;VALUE=DATE:20190215
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śyāmalānavarātra-samāpanam_2019-02-14T06:35:39.839986+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Māghaḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -7606,7 +7606,7 @@ SUMMARY:Māghaḥ-11-10  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛🌌  \,  Ku
  ukraḥ
 DTSTART;TZID=Asia/Calcutta:20190215T063513
 DTEND;TZID=Asia/Calcutta:20190216T063447
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190215_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-26\, Islamic: 1440-06-09 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -7664,7 +7664,7 @@ SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 8M Nāḷ—Pachchai Ch
  ātti Alaṅkāram
 DTSTART;VALUE=DATE:20190215
 DTEND;VALUE=DATE:20190216
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā8MNāḷ—PachchaiChāttiAla
  ṅkāram_2019-02-15T06:35:13.919990+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -7691,7 +7691,7 @@ SUMMARY:Māghaḥ-11-11  \,Mithunam-Ārdrā🌛🌌  \,  Kumbhaḥ-Śravi
  ṣṭhā-11-04🌞🌌  \,  Tapasyaḥ-12-28🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190216T063447
 DTEND;TZID=Asia/Calcutta:20190217T063430
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190216_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-27\, Islamic: 1440-06-10 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -7747,7 +7747,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-bhaimī-ēkādaśī
 DTSTART;VALUE=DATE:20190216
 DTEND;VALUE=DATE:20190217
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sarva-bhaimī-ēkādaśī_2019-02-16T06:34:47.999994+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of māgha month is known as bhaimī
  -ēkādaśī. If this coincides with the nakshatram Punarvasu\, the tithi 
@@ -7850,7 +7850,7 @@ SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 9M Nāḷ—Taṅga Kai
  lācha Vāhanam
 DTSTART;VALUE=DATE:20190216
 DTEND;VALUE=DATE:20190217
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā9MNāḷ—TaṅgaKailāchaVāh
  anam_2019-02-16T06:34:47.999994+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -7876,7 +7876,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190216T190401
 DTEND;TZID=Asia/Calcutta:20190217T063430
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-02-16T19:04:01.919991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -7896,7 +7896,7 @@ SUMMARY:Māghaḥ-11-12  \,Mithunam-Punarvasuḥ🌛🌌  \,  Kumbhaḥ-Ś
  raviṣṭhā-11-05🌞🌌  \,  Tapasyaḥ-12-29🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190217T063430
 DTEND;TZID=Asia/Calcutta:20190218T063404
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190217_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-28\, Islamic: 1440-06-11 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -7953,7 +7953,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190217T181136
 DTEND;TZID=Asia/Calcutta:20190218T063404
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-17T18:11:36.959983+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -7974,7 +7974,7 @@ BEGIN:VEVENT
 SUMMARY:bhīṣma-dvādaśī
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:bhīṣma-dvādaśī_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Māghaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -7994,7 +7994,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -8015,7 +8015,7 @@ BEGIN:VEVENT
 SUMMARY:jayā-mahādvādaśī
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:jayā-mahādvādaśī_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/jayA
@@ -8037,7 +8037,7 @@ BEGIN:VEVENT
 SUMMARY:Kulaśēkhara Āḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KulaśēkharaĀḻvārTirunakṣattiram_2019-02-17T06:34:30.719983+05:
  30
 DESCRIPTION:Observed on Punarvasuḥ nakshatra of Kumbhaḥ (sidereal sola
@@ -8058,7 +8058,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsa-antimatrayatithi-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsa-antimatrayatithi-vrata-ārambhaḥ_2019-02-17T06:34:30.71
  9983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -8081,7 +8081,7 @@ BEGIN:VEVENT
 SUMMARY:ravipuṣya-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190217T164429
 DTEND;TZID=Asia/Calcutta:20190217T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ravipuṣya-yōgaḥ_2019-02-17T16:44:29.760011+05:30
 DESCRIPTION:When Pushya nakshatra falls on a Sunday\, it is a special yōg
  aḥ\, on which it is important to propitiate Surya Bhagavan.<br/><br/>ād
@@ -8101,7 +8101,7 @@ BEGIN:VEVENT
 SUMMARY:ravivāra-śukla-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190217T181136
 DTEND;TZID=Asia/Calcutta:20190217T194421
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ravivāra-śukla-pradōṣa-vratam_2019-02-17T18:11:36.959983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/ravi
@@ -8120,7 +8120,7 @@ BEGIN:VEVENT
 SUMMARY:tilapadma-dvādaśī/tilōtpatti
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tilapadma-dvādaśī/tilōtpatti_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/11/12/tilapadma-dvAdazI
@@ -8141,7 +8141,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Māchit Tiruviḻā 10M Nāḷ—Tēr
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganMāchitTiruviḻā10MNāḷ—Tēr_2019-02-17T06:
  34:30.719983+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
@@ -8166,7 +8166,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190217T063430
 DTEND;TZID=Asia/Calcutta:20190217T081016
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -8185,7 +8185,7 @@ BEGIN:VEVENT
 SUMMARY:varāha-dvādaśī
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:varāha-dvādaśī_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Māghaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -8205,7 +8205,7 @@ BEGIN:VEVENT
 SUMMARY:varāha-kalpādiḥ
 DTSTART;VALUE=DATE:20190217
 DTEND;VALUE=DATE:20190218
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:varāha-kalpādiḥ_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/11/13/varAh
@@ -8227,7 +8227,7 @@ SUMMARY:Māghaḥ-11-14  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Kumbhaḥ-
  Śraviṣṭhā-11-06🌞🌌  \,  Tapasyaḥ-12-30🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190218T063404
 DTEND;TZID=Asia/Calcutta:20190219T063338
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190218_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-29\, Islamic: 1440-06-12 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -8283,7 +8283,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -8323,7 +8323,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -8348,7 +8348,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-11
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-11_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Māghaḥ (lunar) mont
  h (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit con
@@ -8367,7 +8367,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsa-antimatrayatithi-vratam
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsa-antimatrayatithi-vratam_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/11/14/mAgha-mAsa-antima
@@ -8389,7 +8389,7 @@ BEGIN:VEVENT
 SUMMARY:madhu-māsaḥ/vasantar̥tuḥ
 DTSTART;TZID=Asia/Calcutta:20190219T043359
 DTEND;TZID=Asia/Calcutta:20190218T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:madhu-māsaḥ/vasantar̥tuḥ_2019-02-19T04:33:59.039996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -8408,7 +8408,7 @@ BEGIN:VEVENT
 SUMMARY:Naṭarājar Mahābhiṣēkam
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:NaṭarājarMahābhiṣēkam_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/sidereal_solar_month/tithi/11/14/na
@@ -8429,7 +8429,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -8448,7 +8448,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Teppam
 DTSTART;VALUE=DATE:20190218
 DTEND;VALUE=DATE:20190219
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganTeppam_2019-02-18T06:34:04.799986+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Masi each year is very special
  \, wherein all the three temple chariots are dragged and the festival is c
@@ -8473,7 +8473,7 @@ SUMMARY:Māghaḥ-11-15  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Kumbha
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190219T063338
 DTEND;TZID=Asia/Calcutta:20190220T063312
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190219_day_summary
 DESCRIPTION:- Indian civil date: 1940-11-30\, Islamic: 1440-06-13 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -8532,7 +8532,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -8567,7 +8567,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190219T063338
 DTEND;TZID=Asia/Calcutta:20190219T181211
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -8589,7 +8589,7 @@ BEGIN:VEVENT
 SUMMARY:lalitā-jayantī
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:lalitā-jayantī_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Māghaḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/>Devi Lalita is 3rd of the Dasha Mah
@@ -8609,7 +8609,7 @@ BEGIN:VEVENT
 SUMMARY:Māchi Chevvāy
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:MāchiChevvāy_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Do upavāsam (at least do not take salt) and pray to Bhagavan 
  Shiva (Vaidyanatha Swami).<br/><br/>## Details<br/>- [Edit config file](ht
@@ -8628,7 +8628,7 @@ BEGIN:VEVENT
 SUMMARY:kumbhamāghōtsavaḥ
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kumbhamāghōtsavaḥ_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/sidereal_solar_month/nakshatra/11/10/mAci
@@ -8649,7 +8649,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsaḥantimatrayatithi-vratam
 DTSTART;VALUE=DATE:20190216
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsaḥantimatrayatithi-vratam_2019-02-16T23:59:57.120005+05:3
  0
 DESCRIPTION:
@@ -8666,7 +8666,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsa-antimatrayatithi-vrata-samāpanam
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsa-antimatrayatithi-vrata-samāpanam_2019-02-19T06:33:38.879
  990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -8689,7 +8689,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-pūrṇimā
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-pūrṇimā_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Māghaḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/>nirṇayasindhau bhaviṣyē---  <b
@@ -8711,7 +8711,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-pūrṇimā-snānam
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-pūrṇimā-snānam_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/11/15/mAgha-pUrNimA-snA
@@ -8732,7 +8732,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -8753,7 +8753,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -8777,7 +8777,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-02-19T06:33:38.879990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -8797,7 +8797,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190219T063338
 DTEND;TZID=Asia/Calcutta:20190219T181211
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ṣaḍaśīti-puṇyakālaḥ_2019-02-19T06:33:38.879990+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -8817,7 +8817,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190219T063338
 DTEND;TZID=Asia/Calcutta:20190219T105753
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-02-19T06:33:38.879990
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -8836,7 +8836,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190219T063338
 DTEND;TZID=Asia/Calcutta:20190219T122250
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-02-19T06
  :33:38.879990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -8857,7 +8857,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Māchit Tiruviḻā Niṟaivu
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMāchitTiruviḻāNiṟaivu_2019-02-19T06:33:38.879990+0
  5:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Kumbhaḥ (sidereal solar)
@@ -8882,7 +8882,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190219
 DTEND;VALUE=DATE:20190220
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-02-19T06:33:38.8799
  90+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -8906,7 +8906,7 @@ SUMMARY:Māghaḥ-11-16  \,Siṁhaḥ-Maghā🌛🌌  \,  Kumbhaḥ-Śatab
  hiṣak-11-08🌞🌌  \,  Madhuḥ-01-02🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190220T063312
 DTEND;TZID=Asia/Calcutta:20190221T063238
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190220_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-01\, Islamic: 1440-06-14 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -8966,7 +8966,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190220
 DTEND;VALUE=DATE:20190221
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-20T06:33:12.959994+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -9013,7 +9013,7 @@ SUMMARY:kāñcī 51 jagadguru-śrī-vidyātīrthēndra-sarasvatī-ārādha
  nā #634
 DTSTART;VALUE=DATE:20190220
 DTEND;VALUE=DATE:20190221
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī51jagadguru-śrī-vidyātīrthēndra-sarasvatī-ārādhanā#63
  4_2019-02-20T06:33:12.959994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -9038,7 +9038,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190220
 DTEND;VALUE=DATE:20190221
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-02-20T06:33:
  12.959994+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -9065,7 +9065,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190220
 DTEND;VALUE=DATE:20190221
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-02-20T06:33:12.959994+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -9084,7 +9084,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190220
 DTEND;VALUE=DATE:20190221
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-02-20T06:33:12.959994+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -9106,7 +9106,7 @@ SUMMARY:Māghaḥ-11-17  \,Siṁhaḥ-Uttaraphalgunī🌛🌌  \,  Kumbha
  ḥ-Śatabhiṣak-11-09🌞🌌  \,  Madhuḥ-01-03🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190221T063238
 DTEND;TZID=Asia/Calcutta:20190222T063212
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190221_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-02\, Islamic: 1440-06-15 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9165,7 +9165,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–udayaḥ (prāk)
 DTSTART;VALUE=DATE:20190220
 DTEND;VALUE=DATE:20190222
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–udayaḥ(prāk)_2019-02-20T23:59:57.120005+05:30
 DESCRIPTION:budhaḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Feb-22 05:55. At this moment budhaḥ is at pūrvaprōṣṭh
@@ -9188,7 +9188,7 @@ SUMMARY:Māghaḥ-11-18  \,Kanyā-Hastaḥ🌛🌌  \,  Kumbhaḥ-Śatabhi
  ṣak-11-10🌞🌌  \,  Madhuḥ-01-04🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190222T063212
 DTEND;TZID=Asia/Calcutta:20190223T063146
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190222_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-03\, Islamic: 1440-06-16 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9247,7 +9247,7 @@ BEGIN:VEVENT
 SUMMARY:dvijapriya-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20190222
 DTEND;VALUE=DATE:20190223
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dvijapriya-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-02-22
  T06:32:12.480016+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -9275,7 +9275,7 @@ BEGIN:VEVENT
 SUMMARY:Eṟipatta Nāyanmār (8) Gurupūjai
 DTSTART;VALUE=DATE:20190222
 DTEND;VALUE=DATE:20190223
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:EṟipattaNāyanmār(8)Gurupūjai_2019-02-22T06:32:12.480016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -9299,7 +9299,7 @@ SUMMARY:Māghaḥ-11-19  \,Kanyā-Citrā🌛🌌  \,  Kumbhaḥ-Śatabhi
  ṣak-11-11🌞🌌  \,  Madhuḥ-01-05🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190223T063146
 DTEND;TZID=Asia/Calcutta:20190224T063120
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190223_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-04\, Islamic: 1440-06-17 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9359,7 +9359,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190223
 DTEND;VALUE=DATE:20190224
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-02-23T06:31:46.559980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -9381,7 +9381,7 @@ SUMMARY:Māghaḥ-11-21  \,Tulā-Svātī🌛🌌  \,  Kumbhaḥ-Śatabhi
  ṣak-11-12🌞🌌  \,  Madhuḥ-01-06🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190224T063120
 DTEND;TZID=Asia/Calcutta:20190225T063046
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190224_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-05\, Islamic: 1440-06-18 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9440,7 +9440,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190224T181311
 DTEND;TZID=Asia/Calcutta:20190225T063046
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-24T18:13:11.999982+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -9461,7 +9461,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190225T050430
 DTEND;TZID=Asia/Calcutta:20190225T063046
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-02-25T05:04:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -9480,7 +9480,7 @@ BEGIN:VEVENT
 SUMMARY:yaśōdā-jayantī
 DTSTART;VALUE=DATE:20190224
 DTEND;VALUE=DATE:20190225
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:yaśōdā-jayantī_2019-02-24T06:31:20.639984+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ṣaṣṭhī tithi of Māghaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -9501,7 +9501,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190224T223023
 DTEND;TZID=Asia/Calcutta:20190224T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-02-24T22:30:23.040001+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -9518,7 +9518,7 @@ SUMMARY:Māghaḥ-11-22  \,Tulā-Viśākhā🌛🌌  \,  Kumbhaḥ-Śatabh
  iṣak-11-13🌞🌌  \,  Madhuḥ-01-07🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190225T063046
 DTEND;TZID=Asia/Calcutta:20190226T063020
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190225_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-06\, Islamic: 1440-06-19 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9577,7 +9577,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190225
 DTEND;VALUE=DATE:20190226
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-25T06:30:46.080002+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -9602,7 +9602,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190225T083829
 DTEND;TZID=Asia/Calcutta:20190225T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-02-25T08:38:29.760019+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -9618,7 +9618,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-aṣṭakā-pūrvēdyuḥ
 DTSTART;VALUE=DATE:20190225
 DTEND;VALUE=DATE:20190226
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-aṣṭakā-pūrvēdyuḥ_2019-02-25T06:30:46.080002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/relative_event/mAgha-aSTakA-zrAddham/
@@ -9640,7 +9640,7 @@ BEGIN:VEVENT
 SUMMARY:nikṣubhārka-saptamī
 DTSTART;VALUE=DATE:20190225
 DTEND;VALUE=DATE:20190226
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:nikṣubhārka-saptamī_2019-02-25T06:30:46.080002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/11/22/nikSubhArka-sapta
@@ -9664,7 +9664,7 @@ SUMMARY:Māghaḥ-11-23  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Kumbha
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190226T063020
 DTEND;TZID=Asia/Calcutta:20190227T062945
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190226_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-07\, Islamic: 1440-06-20 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9723,7 +9723,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-26T06:30:20.160006+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -9758,7 +9758,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-26T06:30:20.160006+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -9784,7 +9784,7 @@ SUMMARY:kāñcī 66 jagadguru-śrī-candraśēkharēndra-sarasvatī-6-ār
  ādhanā #112
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī66jagadguru-śrī-candraśēkharēndra-sarasvatī-6-ārādhan
  ā#112_2019-02-26T06:30:20.160006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -9809,7 +9809,7 @@ BEGIN:VEVENT
 SUMMARY:Māchi Chevvāy
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:MāchiChevvāy_2019-02-26T06:30:20.160006+05:30
 DESCRIPTION:Do upavāsam (at least do not take salt) and pray to Bhagavan 
  Shiva (Vaidyanatha Swami).<br/><br/>## Details<br/>- [Edit config file](ht
@@ -9828,7 +9828,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-aṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-aṣṭakā-śrāddham_2019-02-26T06:30:20.160006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/11/23/mAgha-aSTakA-
@@ -9850,7 +9850,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-02-26T06:30:20.160006+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -9870,7 +9870,7 @@ SUMMARY:Māghaḥ-11-24  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Kumbha
  ḥ-Śatabhiṣak-11-15🌞🌌  \,  Madhuḥ-01-09🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190227T062945
 DTEND;TZID=Asia/Calcutta:20190228T062911
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190227_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-08\, Islamic: 1440-06-21 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -9928,7 +9928,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190227
 DTEND;VALUE=DATE:20190228
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-02-27T06:29:45.599984+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -9953,7 +9953,7 @@ BEGIN:VEVENT
 SUMMARY:kāśi-viśvanātha-mandira-sthāpanam #434
 DTSTART;VALUE=DATE:20190226
 DTEND;VALUE=DATE:20190227
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāśi-viśvanātha-mandira-sthāpanam#434_2019-02-26T23:59:57.120005+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -9975,7 +9975,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-anvaṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20190227
 DTEND;VALUE=DATE:20190228
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-anvaṣṭakā-śrāddham_2019-02-27T06:29:45.599984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/relative_event/mAgha-aSTakA-zrAddham/
@@ -9998,7 +9998,7 @@ SUMMARY:Māghaḥ-11-24  \,Dhanuḥ-Mūlā🌛🌌  \,  Kumbhaḥ-Śatabhi
  ṣak-11-16🌞🌌  \,  Madhuḥ-01-10🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190228T062911
 DTEND;TZID=Asia/Calcutta:20190301T062836
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190228_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-09\, Islamic: 1440-06-22 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10058,7 +10058,7 @@ SUMMARY:Māghaḥ-11-25  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Kumbha
  ḥ-Śatabhiṣak-11-17🌞🌌  \,  Madhuḥ-01-11🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190301T062836
 DTEND;TZID=Asia/Calcutta:20190302T062810
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190301_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-10\, Islamic: 1440-06-23 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10117,7 +10117,7 @@ BEGIN:VEVENT
 SUMMARY:Kāri Nāyanmār (48) Gurupūjai
 DTSTART;VALUE=DATE:20190301
 DTEND;VALUE=DATE:20190302
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KāriNāyanmār(48)Gurupūjai_2019-03-01T06:28:36.479981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -10140,7 +10140,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190301
 DTEND;VALUE=DATE:20190302
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-03-01T06:28:36.479981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -10163,7 +10163,7 @@ SUMMARY:Māghaḥ-11-26  \,Dhanuḥ-Uttarāṣāḍhā🌛🌌  \,  Kumbha
  ḥ-Śatabhiṣak-11-18🌞🌌  \,  Madhuḥ-01-12🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190302T062810
 DTEND;TZID=Asia/Calcutta:20190303T062736
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190302_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-11\, Islamic: 1440-06-24 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10222,7 +10222,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-vijayā-ēkādaśī
 DTSTART;VALUE=DATE:20190302
 DTEND;VALUE=DATE:20190303
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sarva-vijayā-ēkādaśī_2019-03-02T06:28:10.559985+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of māgha month is known as vijay
  ā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatly e
@@ -10317,7 +10317,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;VALUE=DATE:20190302
 DTEND;VALUE=DATE:20190303
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-03-02T11:04:39.360008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -10340,7 +10340,7 @@ SUMMARY:Māghaḥ-11-27  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  Kumbh
  aḥ-Śatabhiṣak-11-19🌞🌌  \,  Madhuḥ-01-13🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190303T062736
 DTEND;TZID=Asia/Calcutta:20190304T062701
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190303_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-12\, Islamic: 1440-06-25 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10399,7 +10399,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190304T022313
 DTEND;TZID=Asia/Calcutta:20190303T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-03-04T02:23:13.920006+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Mar-04 02:23. At this moment budhaḥ is at uttaraprōṣṭh
@@ -10419,7 +10419,7 @@ SUMMARY:kāñcī 70 jagadguru-śrī-śaṅkara-vijayēndra-sarasvatī-jaya
  ntī #51
 DTSTART;VALUE=DATE:20190303
 DTEND;VALUE=DATE:20190304
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī70jagadguru-śrī-śaṅkara-vijayēndra-sarasvatī-jayantī#5
  1_2019-03-03T06:27:36.000003+05:30
 DESCRIPTION:Observed on Uttarāṣāḍhā nakshatra of Kumbhaḥ (siderea
@@ -10444,7 +10444,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190303T181429
 DTEND;TZID=Asia/Calcutta:20190303T194604
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-03-03T18:14:29.760011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -10462,7 +10462,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190303T062736
 DTEND;TZID=Asia/Calcutta:20190303T085804
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-03-03T06:27:36.000003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -10481,7 +10481,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-mahādvādaśī
 DTSTART;VALUE=DATE:20190303
 DTEND;VALUE=DATE:20190304
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-mahādvādaśī_2019-03-03T06:27:36.000003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/zrav
@@ -10503,7 +10503,7 @@ SUMMARY:Māghaḥ-11-28  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Kumbhaḥ-
  Śatabhiṣak-11-20🌞🌌  \,  Madhuḥ-01-14🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190304T062701
 DTEND;TZID=Asia/Calcutta:20190305T062626
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190304_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-13\, Islamic: 1440-06-26 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10563,7 +10563,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190304T181438
 DTEND;TZID=Asia/Calcutta:20190305T062626
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-04T18:14:38.399996+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -10584,7 +10584,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190304
 DTEND;VALUE=DATE:20190305
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-03-04T06:27:01.439981+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -10604,7 +10604,7 @@ BEGIN:VEVENT
 SUMMARY:mahāśivarātriḥ
 DTSTART;VALUE=DATE:20190304
 DTEND;VALUE=DATE:20190305
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:mahāśivarātriḥ_2019-03-04T06:27:01.439981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shaiva/lunar_month/tithi/11/29/mahAzivarAt
@@ -10625,7 +10625,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190304
 DTEND;VALUE=DATE:20190305
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-03-04T06:27:01.439981+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -10644,7 +10644,7 @@ BEGIN:VEVENT
 SUMMARY:sōmaśravaṇa-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190303T235957
 DTEND;TZID=Asia/Calcutta:20190304T120826
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sōmaśravaṇa-yōgaḥ_2019-03-03T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmazra
@@ -10663,7 +10663,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190304
 DTEND;VALUE=DATE:20190305
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-03-04T06:27:01.439981+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -10684,7 +10684,7 @@ SUMMARY:Māghaḥ-11-29  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,  Kumbha
  Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190305T062626
 DTEND;TZID=Asia/Calcutta:20190306T062552
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190305_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-14\, Islamic: 1440-06-27 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10743,7 +10743,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190305
 DTEND;VALUE=DATE:20190306
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-05T06:26:26.880000+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -10783,7 +10783,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ṣṇāṅgāraka-caturdaśī-puṇyakālaḥ/yama-tarpaṇam
 DTSTART;VALUE=DATE:20190305
 DTEND;VALUE=DATE:20190306
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ṣṇāṅgāraka-caturdaśī-puṇyakālaḥ/yama-tarpaṇam_201
  9-03-05T06:26:26.880000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -10808,7 +10808,7 @@ BEGIN:VEVENT
 SUMMARY:Māchi Chevvāy
 DTSTART;VALUE=DATE:20190305
 DTEND;VALUE=DATE:20190306
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:MāchiChevvāy_2019-03-05T06:26:26.880000+05:30
 DESCRIPTION:Do upavāsam (at least do not take salt) and pray to Bhagavan 
  Shiva (Vaidyanatha Swami).<br/><br/>## Details<br/>- [Edit config file](ht
@@ -10829,7 +10829,7 @@ SUMMARY:Māghaḥ-11-30  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Kumbhaḥ-
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190306T062552
 DTEND;TZID=Asia/Calcutta:20190307T062517
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190306_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-15\, Islamic: 1440-06-28 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -10888,7 +10888,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -10923,7 +10923,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:Anadhyayana on account of yugādi. On the days of Ayana (solst
  ices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (Sh
@@ -10946,7 +10946,7 @@ BEGIN:VEVENT
 SUMMARY:kaliyugādiḥ
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kaliyugādiḥ_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/yugAdiH/lunar_month/tithi/11/30/kaliyu
@@ -10968,7 +10968,7 @@ BEGIN:VEVENT
 SUMMARY:Kochcheṅgaṭ Chōḻa Nāyanmār (60) Gurupūjai
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KochcheṅgaṭChōḻaNāyanmār(60)Gurupūjai_2019-03-06T06:25:52.32
  0018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -10992,7 +10992,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsaḥ
 DTSTART;VALUE=DATE:20190204
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsaḥ_2019-02-04T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/mAgha-mAsaH.toml
@@ -11013,7 +11013,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-māsa-samāpanam
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-māsa-samāpanam_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Māghaḥ (lunar) month (Sūr
  yōdayaḥ/paraviddha). <br/><br/>māgha-māsaḥ ends today<br/><br/>## D
@@ -11033,7 +11033,7 @@ BEGIN:VEVENT
 SUMMARY:māgha-snānapūrtiḥ
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:māgha-snānapūrtiḥ_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/11/30/mAgha-snA
@@ -11054,7 +11054,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -11075,7 +11075,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -11094,7 +11094,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -11115,7 +11115,7 @@ BEGIN:VEVENT
 SUMMARY:purandaradāsa-ārādhanā #455
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:purandaradāsa-ārādhanā#455_2019-03-06T06:25:52.320018+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Māghaḥ (lunar) month (Apar
  āhṇaḥ/vyaapti). The event occurred in 4665 (Kali era).  <br/><br/><br
@@ -11137,7 +11137,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-māgha-amāvāsyā (alabhyam–māgha-śatabhiṣak)
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190307
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sarva-māgha-amāvāsyā(alabhyam–māgha-śatabhiṣak)_2019-03-06T0
  6:25:52.320018+05:30
 DESCRIPTION:amāvāsyā of māgha month.<br/><br/>## Details<br/>- [Edit c
@@ -11166,7 +11166,7 @@ SUMMARY:Phālgunaḥ-12-01  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌  \
  🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190307T062517
 DTEND;TZID=Asia/Calcutta:20190308T062434
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190307_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-16\, Islamic: 1440-06-29 Jumādā
   ath-Thāniyah/ al-ʾĀkhirah\, 🌌🌞: सं- Kumbhaḥ\, तं- Mās
@@ -11226,7 +11226,7 @@ BEGIN:VEVENT
 SUMMARY:payōvrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:payōvrata-ārambhaḥ_2019-03-07T06:25:17.759997+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Phālgunaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>payōvratam observed by Aditi 
@@ -11248,7 +11248,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-07T06:25:17.759997+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -11294,7 +11294,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-03-07T06:25:17.759997+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -11313,7 +11313,7 @@ BEGIN:VEVENT
 SUMMARY:gōvinda-dāmōdara-svāminaḥ jayantī #89
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:gōvinda-dāmōdara-svāminaḥjayantī#89_2019-03-07T06:25:17.759997+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -11338,7 +11338,7 @@ SUMMARY:kāñcī 67 jagadguru-śrī-mahādēvēndra-sarasvatī-5-ārādhan
  ā #112
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī67jagadguru-śrī-mahādēvēndra-sarasvatī-5-ārādhanā#112
  _2019-03-07T06:25:17.759997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -11363,7 +11363,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-03-07T06:25:17.759997
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -11389,7 +11389,7 @@ BEGIN:VEVENT
 SUMMARY:phālguna-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:phālguna-māsa-ārambhaḥ_2019-03-07T06:25:17.759997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/12/01/phAlguna-
@@ -11411,7 +11411,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190307
 DTEND;VALUE=DATE:20190308
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-03-07T06:25:17.759997+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -11434,7 +11434,7 @@ SUMMARY:Phālgunaḥ-12-02  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \,
  🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190308T062434
 DTEND;TZID=Asia/Calcutta:20190309T062400
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190308_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-17\, Islamic: 1440-07-01 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -11493,7 +11493,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190308T181512
 DTEND;TZID=Asia/Calcutta:20190308T194053
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-03-08T18:15:12.960018+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -11513,7 +11513,7 @@ SUMMARY:kāñcī 68 jagadguru-śrī-candraśēkharēndra-sarasvatī-7-āś
  rama-svīkāra-dinam #112
 DTSTART;VALUE=DATE:20190308
 DTEND;VALUE=DATE:20190309
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī68jagadguru-śrī-candraśēkharēndra-sarasvatī-7-āśrama-s
  vīkāra-dinam#112_2019-03-08T06:24:34.559990+05:30
 DESCRIPTION:Observed on Uttaraprōṣṭhapadā nakshatra of Kumbhaḥ (si
@@ -11540,7 +11540,7 @@ BEGIN:VEVENT
 SUMMARY:phūlērā-dūj
 DTSTART;VALUE=DATE:20190308
 DTEND;VALUE=DATE:20190309
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:phūlērā-dūj_2019-03-08T06:24:34.559990+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Phālgunaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Very auspicious day\, celebrat
@@ -11560,7 +11560,7 @@ BEGIN:VEVENT
 SUMMARY:rāmakr̥ṣṇa-paramahaṁsa-jayantī #184
 DTSTART;VALUE=DATE:20190308
 DTEND;VALUE=DATE:20190309
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:rāmakr̥ṣṇa-paramahaṁsa-jayantī#184_2019-03-08T06:24:34.559990
  +05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Phālgunaḥ (lunar) mon
@@ -11584,7 +11584,7 @@ SUMMARY:Phālgunaḥ-12-03  \,Mīnaḥ-Rēvatī🌛🌌  \,  Kumbhaḥ-Pū
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190309T062400
 DTEND;TZID=Asia/Calcutta:20190310T062325
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190309_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-18\, Islamic: 1440-07-02 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -11645,7 +11645,7 @@ SUMMARY:Phālgunaḥ-12-04  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Kumbhaḥ-P
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190310T062325
 DTEND;TZID=Asia/Calcutta:20190311T062250
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190310_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-19\, Islamic: 1440-07-03 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -11704,7 +11704,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190310
 DTEND;VALUE=DATE:20190311
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-03-10T06:23:25.439986+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -11726,7 +11726,7 @@ SUMMARY:Phālgunaḥ-12-05  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Kumbha
  Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190311T062250
 DTEND;TZID=Asia/Calcutta:20190312T062207
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190311_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-20\, Islamic: 1440-07-04 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -11785,7 +11785,7 @@ BEGIN:VEVENT
 SUMMARY:kapālīśvara-dhvajārōhaṇam
 DTSTART;VALUE=DATE:20190311
 DTEND;VALUE=DATE:20190312
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kapālīśvara-dhvajārōhaṇam_2019-03-11T06:22:50.880005+05:30
 DESCRIPTION:Dhvajārohaṇam (ceremonial flag-hoisting) marking the commen
  cement of the Kapālīśvarar temple's Paṅguni Brahmotsavam\, nine days 
@@ -11809,7 +11809,7 @@ SUMMARY:Phālgunaḥ-12-06  \,Mēṣaḥ-Kr̥ttikā🌛🌌  \,  Kumbhaḥ
  ṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190312T062207
 DTEND;TZID=Asia/Calcutta:20190313T062133
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190312_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-21\, Islamic: 1440-07-05 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -11869,7 +11869,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190312
 DTEND;VALUE=DATE:20190313
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-03-12T06:22:07.679998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -11890,7 +11890,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190312
 DTEND;VALUE=DATE:20190313
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-03-12T06:22:07.679998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -11911,7 +11911,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Sūrya Chandra Vaṭṭam
 DTSTART;VALUE=DATE:20190312
 DTEND;VALUE=DATE:20190313
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KapālīSūryaChandraVaṭṭam_2019-03-12T06:22:07.679998+05:30
 DESCRIPTION:Sūrya-candra vaṭṭam (sun-and-moon disc vāhana) processio
  n during the Kapālīśvarar temple's Paṅguni Brahmotsavam\, eight days 
@@ -11932,7 +11932,7 @@ BEGIN:VEVENT
 SUMMARY:Māchi Chevvāy
 DTSTART;VALUE=DATE:20190312
 DTEND;VALUE=DATE:20190313
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:MāchiChevvāy_2019-03-12T06:22:07.679998+05:30
 DESCRIPTION:Do upavāsam (at least do not take salt) and pray to Bhagavan 
  Shiva (Vaidyanatha Swami).<br/><br/>## Details<br/>- [Edit config file](ht
@@ -11951,7 +11951,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190313T044958
 DTEND;TZID=Asia/Calcutta:20190313T045159
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-03-13T04:49:58.080017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -11970,7 +11970,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190312
 DTEND;VALUE=DATE:20190313
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-03-12T06:22:07.679998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -11994,7 +11994,7 @@ SUMMARY:Phālgunaḥ-12-07  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Kumbh
   Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190313T062133
 DTEND;TZID=Asia/Calcutta:20190314T062049
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190313_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-22\, Islamic: 1440-07-06 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -12053,7 +12053,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190313T181547
 DTEND;TZID=Asia/Calcutta:20190314T062049
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-13T18:15:47.520000+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -12074,7 +12074,7 @@ BEGIN:VEVENT
 SUMMARY:kapālyadhikāra-nandī
 DTSTART;VALUE=DATE:20190313
 DTEND;VALUE=DATE:20190314
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kapālyadhikāra-nandī_2019-03-13T06:21:33.120016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/relative_event/kar2pagAmbAL%E2%80%9
@@ -12096,7 +12096,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Bhūtaṇ Bhūtakī
 DTSTART;VALUE=DATE:20190313
 DTEND;VALUE=DATE:20190314
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KapālīBhūtaṇBhūtakī_2019-03-13T06:21:33.120016+05:30
 DESCRIPTION:Bhūtaṉ-Bhūtakī procession — a folk vāhana depicting Ś
  iva's gaṇas — during the Kapālīśvarar temple's Paṅguni Brahmotsav
@@ -12117,7 +12117,7 @@ BEGIN:VEVENT
 SUMMARY:nandā-saptamī
 DTSTART;VALUE=DATE:20190313
 DTEND;VALUE=DATE:20190314
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:nandā-saptamī_2019-03-13T06:21:33.120016+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Phālgunaḥ (lunar) mont
  h (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -12137,7 +12137,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-rāghavēndra-svāmi-jayantī #425
 DTSTART;VALUE=DATE:20190313
 DTEND;VALUE=DATE:20190314
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:śrī-rāghavēndra-svāmi-jayantī#425_2019-03-13T06:21:33.120016+05:
  30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Phālgunaḥ (lunar) mont
@@ -12161,7 +12161,7 @@ SUMMARY:Phālgunaḥ-12-08  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛🌌  \,
  🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190314T062049
 DTEND;TZID=Asia/Calcutta:20190315T062015
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190314_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-23\, Islamic: 1440-07-07 Rajab\, 
  🌌🌞: सं- Kumbhaḥ\, तं- Māsi\, म- Kumbhaṁ\, प- Phagga
@@ -12221,7 +12221,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190314
 DTEND;VALUE=DATE:20190315
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-14T06:20:49.920009+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -12256,7 +12256,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190314
 DTEND;VALUE=DATE:20190315
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-14T06:20:49.920009+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -12282,7 +12282,7 @@ SUMMARY:Phālgunaḥ-12-09  \,Mithunam-Ārdrā🌛🌌  \,  Mīnaḥ-Pūrv
  aprōṣṭhapadā-12-01🌞🌌  \,  Madhuḥ-01-25🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190315T062015
 DTEND;TZID=Asia/Calcutta:20190316T061932
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:20190315_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-24\, Islamic: 1440-07-08 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -12341,7 +12341,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190315T062015
 DTEND;TZID=Asia/Calcutta:20190315T181556
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-15T06:20:15.359987+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -12363,7 +12363,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190315T091613
 DTEND;TZID=Asia/Calcutta:20190315T235957
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-03-15T09:16:13.439996+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -12379,7 +12379,7 @@ BEGIN:VEVENT
 SUMMARY:sāvitrī-vratam
 DTSTART;VALUE=DATE:20190315
 DTEND;VALUE=DATE:20190316
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:sāvitrī-vratam_2019-03-15T06:20:15.359987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/tamil/description_only/kAraDaiyAn2_nOn2bu.toml)<b
@@ -12400,7 +12400,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Chavuḍal Vimānam
 DTSTART;VALUE=DATE:20190315
 DTEND;VALUE=DATE:20190316
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:KapālīChavuḍalVimānam_2019-03-15T06:20:15.359987+05:30
 DESCRIPTION:Cavuḍal vimāṉam vāhana procession during the Kapālīśv
  arar temple's Paṅguni Brahmotsavam\, five days before Tirukkalyāṇam.<
@@ -12421,7 +12421,7 @@ BEGIN:VEVENT
 SUMMARY:kapāli-vr̥ṣabha-vāhanam
 DTSTART;VALUE=DATE:20190315
 DTEND;VALUE=DATE:20190316
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:kapāli-vr̥ṣabha-vāhanam_2019-03-15T06:20:15.359987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/relative_event/kar2pagAmbAL%E2%80%9
@@ -12443,7 +12443,7 @@ BEGIN:VEVENT
 SUMMARY:mīna-ravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190315T062015
 DTEND;TZID=Asia/Calcutta:20190315T181556
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:mīna-ravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ_2019-03-15T06
  :20:15.359987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -12464,7 +12464,7 @@ BEGIN:VEVENT
 SUMMARY:ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190315T062015
 DTEND;TZID=Asia/Calcutta:20190315T114800
-DTSTAMP:20260822T115604Z
+DTSTAMP:20200101T000000Z
 UID:ravi-saṅkramaṇa-puṇyakālaḥ_2019-03-15T06:20:15.359987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/ravi-saGkra
@@ -12482,7 +12482,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190315T062015
 DTEND;TZID=Asia/Calcutta:20190315T121805
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-03-15T06:20:15.3
  59987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -12504,7 +12504,7 @@ SUMMARY:Phālgunaḥ-12-10  \,Mithunam-Punarvasuḥ🌛🌌  \,  Mīnaḥ-
  iḥ
 DTSTART;TZID=Asia/Calcutta:20190316T061932
 DTEND;TZID=Asia/Calcutta:20190317T061857
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190316_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-25\, Islamic: 1440-07-09 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -12564,7 +12564,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Pallakku Viḻā
 DTSTART;VALUE=DATE:20190316
 DTEND;VALUE=DATE:20190317
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:KapālīPallakkuViḻā_2019-03-16T06:19:32.159980+05:30
 DESCRIPTION:Pallakku vizhā (palanquin festival) during the Kapālīśvara
  r temple's Paṅguni Brahmotsavam\, four days before Tirukkalyāṇam.<br/
@@ -12585,7 +12585,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē plavōtsava-prārambhaḥ
 DTSTART;VALUE=DATE:20190316
 DTEND;VALUE=DATE:20190317
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēplavōtsava-prārambhaḥ_2019-03-16T06:19:32.159980
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -12610,7 +12610,7 @@ SUMMARY:Phālgunaḥ-12-11  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Mīna
  Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190317T061857
 DTEND;TZID=Asia/Calcutta:20190318T061814
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190317_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-26\, Islamic: 1440-07-10 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -12669,7 +12669,7 @@ BEGIN:VEVENT
 SUMMARY:kapālīśvarayātrā
 DTSTART;VALUE=DATE:20190317
 DTEND;VALUE=DATE:20190318
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kapālīśvarayātrā_2019-03-17T06:18:57.599999+05:30
 DESCRIPTION:Tēr (temple chariot) festival — the principal car processio
  n of Karpagāmbāḷ and Kapālīśvarar — three days before Tirukkalyā
@@ -12690,7 +12690,7 @@ BEGIN:VEVENT
 SUMMARY:Munaiyaḍuvār Nāyanmār (52) Gurupūjai
 DTSTART;VALUE=DATE:20190317
 DTEND;VALUE=DATE:20190318
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:MunaiyaḍuvārNāyanmār(52)Gurupūjai_2019-03-17T06:18:57.599999+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -12714,7 +12714,7 @@ BEGIN:VEVENT
 SUMMARY:raṁgabharī ēkādaśī
 DTSTART;VALUE=DATE:20190317
 DTEND;VALUE=DATE:20190318
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:raṁgabharīēkādaśī_2019-03-17T06:18:57.599999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/North/description_only/raMgabharI_EkAdazI
@@ -12738,7 +12738,7 @@ BEGIN:VEVENT
 SUMMARY:ravipuṣya-yōgaḥ
 DTSTART;VALUE=DATE:20190316
 DTEND;VALUE=DATE:20190317
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:ravipuṣya-yōgaḥ_2019-03-16T23:59:57.120005+05:30
 DESCRIPTION:When Pushya nakshatra falls on a Sunday\, it is a special yōg
  aḥ\, on which it is important to propitiate Surya Bhagavan.<br/><br/>ād
@@ -12761,7 +12761,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-āmalakī-ēkādaśī
 DTSTART;VALUE=DATE:20190317
 DTEND;VALUE=DATE:20190318
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sarva-āmalakī-ēkādaśī_2019-03-17T06:18:57.599999+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of phālguna month is known as āma
  lakī-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatl
@@ -12863,7 +12863,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190317
 DTEND;VALUE=DATE:20190318
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēplavōtsavaḥ_2019-03-17T06:18:57.599999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/venkaTAchala/relative_event/vEGkaTAcalE_p
@@ -12887,7 +12887,7 @@ SUMMARY:Phālgunaḥ-12-12  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Mīna
  Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190318T061814
 DTEND;TZID=Asia/Calcutta:20190319T061739
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190318_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-27\, Islamic: 1440-07-11 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -12947,7 +12947,7 @@ BEGIN:VEVENT
 SUMMARY:aditi-payōvratam
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190319
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:aditi-payōvratam_2019-03-06T23:59:57.120005+05:30
 DESCRIPTION:
 TRANSP:TRANSPARENT
@@ -12963,7 +12963,7 @@ BEGIN:VEVENT
 SUMMARY:payōvrata-samāpanam
 DTSTART;VALUE=DATE:20190318
 DTEND;VALUE=DATE:20190319
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:payōvrata-samāpanam_2019-03-18T06:18:14.399992+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Phālgunaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>payōvratam observed by Aditi
@@ -12985,7 +12985,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Aṟupattu Mūvar
 DTSTART;VALUE=DATE:20190318
 DTEND;VALUE=DATE:20190319
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:KapālīAṟupattuMūvar_2019-03-18T06:18:14.399992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/relative_event/kar2pagAmbAL%E2%80%9
@@ -13007,7 +13007,7 @@ BEGIN:VEVENT
 SUMMARY:narasiṁha-dvādaśī
 DTSTART;VALUE=DATE:20190318
 DTEND;VALUE=DATE:20190319
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:narasiṁha-dvādaśī_2019-03-18T06:18:14.399992+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Phālgunaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -13027,7 +13027,7 @@ BEGIN:VEVENT
 SUMMARY:sōma-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190318T181613
 DTEND;TZID=Asia/Calcutta:20190318T194622
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sōma-pradōṣa-vratam_2019-03-18T18:16:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/sOma
@@ -13045,7 +13045,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190318
 DTEND;VALUE=DATE:20190319
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēplavōtsavaḥ_2019-03-18T06:18:14.399992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/venkaTAchala/relative_event/vEGkaTAcalE_p
@@ -13069,7 +13069,7 @@ SUMMARY:Phālgunaḥ-12-13  \,Siṁhaḥ-Maghā🌛🌌  \,  Mīnaḥ-Utta
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190319T061739
 DTEND;TZID=Asia/Calcutta:20190320T061656
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190319_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-28\, Islamic: 1440-07-12 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -13128,7 +13128,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190319T181613
 DTEND;TZID=Asia/Calcutta:20190320T061656
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-19T18:16:13.439996+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -13149,7 +13149,7 @@ BEGIN:VEVENT
 SUMMARY:kāñcī 69 jagadguru-śrī-jayēndra-sarasvatī-ārādhanā #1
 DTSTART;VALUE=DATE:20190319
 DTEND;VALUE=DATE:20190320
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī69jagadguru-śrī-jayēndra-sarasvatī-ārādhanā#1_2019-03-1
  9T06:17:39.840010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -13173,7 +13173,7 @@ BEGIN:VEVENT
 SUMMARY:kāma-dahanam
 DTSTART;VALUE=DATE:20190319
 DTEND;VALUE=DATE:20190320
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāma-dahanam_2019-03-19T06:17:39.840010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/12/14/kAma-dahanam.toml
@@ -13195,7 +13195,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190319
 DTEND;VALUE=DATE:20190320
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēplavōtsavaḥ_2019-03-19T06:17:39.840010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/venkaTAchala/relative_event/vEGkaTAcalE_p
@@ -13219,7 +13219,7 @@ SUMMARY:Phālgunaḥ-12-14  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Mīn
   Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190320T061656
 DTEND;TZID=Asia/Calcutta:20190321T061613
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190320_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-29\, Islamic: 1440-07-13 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -13279,7 +13279,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -13319,7 +13319,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -13354,7 +13354,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -13377,7 +13377,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -13402,7 +13402,7 @@ BEGIN:VEVENT
 SUMMARY:hōlikā-pūrṇimā
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:hōlikā-pūrṇimā_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/12/15/hOlikA-pUrNimA.to
@@ -13424,7 +13424,7 @@ BEGIN:VEVENT
 SUMMARY:Kaṟpagāmbāḷ–Kapālīśvarar Tirukkalyāṇam
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:Kaṟpagāmbāḷ–KapālīśvararTirukkalyāṇam_2019-03-20T06:16:5
  6.640003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mīnaḥ (sidereal solar) 
@@ -13445,7 +13445,7 @@ BEGIN:VEVENT
 SUMMARY:mādhava-māsaḥ
 DTSTART;TZID=Asia/Calcutta:20190321T032827
 DTEND;TZID=Asia/Calcutta:20190320T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:mādhava-māsaḥ_2019-03-21T03:28:27.839996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -13464,7 +13464,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(rudra-sāvarṇiḥ-[12])
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(rudra-sāvarṇiḥ-[12])_2019-03-20T06:16:56.640003+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -13488,7 +13488,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -13509,7 +13509,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -13533,7 +13533,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-03-20T06:16:56.640003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -13552,7 +13552,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190315
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēplavōtsavaḥ_2019-03-15T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/venkaTAchala/description_only/vEGkaTAcalE
@@ -13573,7 +13573,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē plavōtsava-samāpanam
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190321
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēplavōtsava-samāpanam_2019-03-20T06:16:56.640003+05
  :30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -13597,7 +13597,7 @@ SUMMARY:Phālgunaḥ-12-15  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Mīnaḥ
  Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190321T061613
 DTEND;TZID=Asia/Calcutta:20190322T061538
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190321_day_summary
 DESCRIPTION:- Indian civil date: 1940-12-30\, Islamic: 1440-07-14 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -13657,7 +13657,7 @@ BEGIN:VEVENT
 SUMMARY:āmra-kusuma-prāśanam
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:āmra-kusuma-prāśanam_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of Phālgunaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -13677,7 +13677,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -13723,7 +13723,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:One should not perform adhyayana for three days\, commencing f
  rom the pūrṇimā of the three months\, āṣāḍha\, kārtika and phā
@@ -13746,7 +13746,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190321T061613
 DTEND;TZID=Asia/Calcutta:20190321T181622
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -13768,7 +13768,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Anadhyayana on account of viṣu. On the days of Ayana (solsti
  ces)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (Sha
@@ -13791,7 +13791,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–udayaḥ (prāk)
 DTSTART;VALUE=DATE:20190320
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–udayaḥ(prāk)_2019-03-20T23:59:57.120005+05:30
 DESCRIPTION:budhaḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Mar-22 05:55. At this moment budhaḥ is at pūrvaprōṣṭh
@@ -13813,7 +13813,7 @@ BEGIN:VEVENT
 SUMMARY:caitanya-mahāprabhu-jayantī #534
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:caitanya-mahāprabhu-jayantī#534_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Phālgunaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). The event occurred in 4586 (Kali era).  <b
@@ -13834,7 +13834,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -13855,7 +13855,7 @@ BEGIN:VEVENT
 SUMMARY:hōli
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:hōli_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Festival of colours is celebrated today.<br/><br/>## Details<b
  r/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master
@@ -13874,7 +13874,7 @@ BEGIN:VEVENT
 SUMMARY:umā-kapālīśvara-darśanam
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:umā-kapālīśvara-darśanam_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Umā-Maheśvara darśanam\, when Karpagāmbāḷ and Kapālī
  śvarar are presented together for devotees' darśana on the day after Tir
@@ -13895,7 +13895,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Viḍaiyāṟṟi Toḍakkam
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:KapālīViḍaiyāṟṟiToḍakkam_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Commencement (toḍakkam) of the viḍaiyāṟṟi (valedictor
  y send-off) rites at the Kapālīśvarar temple\, beginning on the day aft
@@ -13916,7 +13916,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-03-21T06:16:
  13.439996+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -13943,7 +13943,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -13962,7 +13962,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -13982,7 +13982,7 @@ BEGIN:VEVENT
 SUMMARY:mīnōttaraphālgunōtsavaḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:mīnōttaraphālgunōtsavaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Uttaraphalgunī nakshatra of Mīnaḥ (sidereal so
  lar) month (Madhyāhnaḥ##~##(Trēdhā)/paraviddha). <br/><br/>मीन
@@ -14007,7 +14007,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190321T061613
 DTEND;TZID=Asia/Calcutta:20190321T095230
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-03-21T06:16:13.439996
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -14026,7 +14026,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190321T061613
 DTEND;TZID=Asia/Calcutta:20190321T121622
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-03-21T06
  :16:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -14047,7 +14047,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -14068,7 +14068,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-03-21T06:16:13.4399
  96+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -14091,7 +14091,7 @@ BEGIN:VEVENT
 SUMMARY:viṣu-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190321T061613
 DTEND;TZID=Asia/Calcutta:20190321T072830
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:viṣu-puṇyakālaḥ_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/viSu-puNyak
@@ -14110,7 +14110,7 @@ BEGIN:VEVENT
 SUMMARY:viṣuvadinam
 DTSTART;VALUE=DATE:20190321
 DTEND;VALUE=DATE:20190322
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:viṣuvadinam_2019-03-21T06:16:13.439996+05:30
 DESCRIPTION:Observed on day 1 of Mādhavaḥ (tropical) month (Sūryōdaya
  ḥ/puurvaviddha). <br/><br/>Vernal equinox<br/><br/>## Details<br/>- [Edi
@@ -14129,7 +14129,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190322T033146
 DTEND;TZID=Asia/Calcutta:20190321T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-03-22T03:31:46.559980+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -14147,7 +14147,7 @@ SUMMARY:Phālgunaḥ-12-17  \,Kanyā-Hastaḥ🌛🌌  \,  Mīnaḥ-Uttara
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190322T061538
 DTEND;TZID=Asia/Calcutta:20190323T061455
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190322_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-01\, Islamic: 1440-07-15 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14207,7 +14207,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190322T144139
 DTEND;TZID=Asia/Calcutta:20190322T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-03-22T14:41:39.840018+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -14223,7 +14223,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190322
 DTEND;VALUE=DATE:20190323
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-22T06:15:38.880014+05:30
 DESCRIPTION:On the kr̥ṣṇa-pakṣa-dvitīyā days in the months of ā
  ṣāḍha\, kārtika and phālguna\, one must not perform adhyayana.<br/>
@@ -14252,7 +14252,7 @@ BEGIN:VEVENT
 SUMMARY:cāturmāsya-dvitīyā
 DTSTART;VALUE=DATE:20190322
 DTEND;VALUE=DATE:20190323
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:cāturmāsya-dvitīyā_2019-03-22T06:15:38.880014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/12/17/cAturmAsya-dv
@@ -14275,7 +14275,7 @@ SUMMARY:Phālgunaḥ-12-18  \,Tulā-Citrā🌛🌌  \,  Mīnaḥ-Uttarapr
  ōṣṭhapadā-12-09🌞🌌  \,  Mādhavaḥ-02-03🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190323T061455
 DTEND;TZID=Asia/Calcutta:20190324T061421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190323_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-02\, Islamic: 1440-07-16 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14333,7 +14333,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190323
 DTEND;VALUE=DATE:20190324
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-23T06:14:55.680007+05:30
 DESCRIPTION:On the kr̥ṣṇa-pakṣa-tr̥tīyā days in the months of ā
  ṣāḍha\, kārtika and phālguna\, one must not perform adhyayana\, as 
@@ -14358,7 +14358,7 @@ BEGIN:VEVENT
 SUMMARY:brahma-kalpādiḥ
 DTSTART;VALUE=DATE:20190323
 DTEND;VALUE=DATE:20190324
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:brahma-kalpādiḥ_2019-03-23T06:14:55.680007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/12/18/brahm
@@ -14379,7 +14379,7 @@ BEGIN:VEVENT
 SUMMARY:chatrapati-śivājī-jayantī #390
 DTSTART;VALUE=DATE:20190323
 DTEND;VALUE=DATE:20190324
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:chatrapati-śivājī-jayantī#390_2019-03-23T06:14:55.680007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Phālgunaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). The event occurred in 4730 (Kali e
@@ -14401,7 +14401,7 @@ SUMMARY:kāñcī 69 jagadguru-śrī-jayēndra-sarasvatī-āśrama-svīkār
  a-dinam #66
 DTSTART;VALUE=DATE:20190323
 DTEND;VALUE=DATE:20190324
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī69jagadguru-śrī-jayēndra-sarasvatī-āśrama-svīkāra-dina
  m#66_2019-03-23T06:14:55.680007+05:30
 DESCRIPTION:Observed on Svātī nakshatra of Mīnaḥ (sidereal solar) mon
@@ -14427,7 +14427,7 @@ BEGIN:VEVENT
 SUMMARY:Kāraikkāl Ammaiyār (24) Gurupūjai
 DTSTART;VALUE=DATE:20190323
 DTEND;VALUE=DATE:20190324
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:KāraikkālAmmaiyār(24)Gurupūjai_2019-03-23T06:14:55.680007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -14450,7 +14450,7 @@ BEGIN:VEVENT
 SUMMARY:rāhu-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190323T145428
 DTEND;TZID=Asia/Calcutta:20190323T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:rāhu-saṅkrāntiḥ_2019-03-23T14:54:28.799999+05:30
 DESCRIPTION:Transition of Rahu from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -14467,7 +14467,7 @@ SUMMARY:Phālgunaḥ-12-19  \,Tulā-Svātī🌛🌌  \,  Mīnaḥ-Uttarapr
  ōṣṭhapadā-12-10🌞🌌  \,  Mādhavaḥ-02-04🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190324T061421
 DTEND;TZID=Asia/Calcutta:20190325T061337
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190324_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-03\, Islamic: 1440-07-17 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14527,7 +14527,7 @@ SUMMARY:ravivāra-bhālacandra-mahāgaṇapati-saṅkaṭahara-caturthī-v
  ratam
 DTSTART;VALUE=DATE:20190324
 DTEND;VALUE=DATE:20190325
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:ravivāra-bhālacandra-mahāgaṇapati-saṅkaṭahara-caturthī-vrata
  m_2019-03-24T06:14:21.119986+05:30
 DESCRIPTION:
@@ -14547,7 +14547,7 @@ SUMMARY:Phālgunaḥ-12-20  \,Vr̥ścikaḥ-Viśākhā🌛🌌  \,  Mīna
  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190325T061337
 DTEND;TZID=Asia/Calcutta:20190326T061254
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190325_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-04\, Islamic: 1440-07-18 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14605,7 +14605,7 @@ BEGIN:VEVENT
 SUMMARY:raṅga-pañcamī
 DTSTART;VALUE=DATE:20190325
 DTEND;VALUE=DATE:20190326
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:raṅga-pañcamī_2019-03-25T06:13:37.920019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Phālgunaḥ (lunar
  ) month (Pradōṣaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -14627,7 +14627,7 @@ SUMMARY:Phālgunaḥ-12-21  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Mīna
  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190326T061254
 DTEND;TZID=Asia/Calcutta:20190327T061220
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190326_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-05\, Islamic: 1440-07-19 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14688,7 +14688,7 @@ SUMMARY:Phālgunaḥ-12-22  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Mī
    \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190327T061220
 DTEND;TZID=Asia/Calcutta:20190328T061136
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190327_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-06\, Islamic: 1440-07-20 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14747,7 +14747,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190327T181648
 DTEND;TZID=Asia/Calcutta:20190328T061136
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-27T18:16:48.000018+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -14768,7 +14768,7 @@ BEGIN:VEVENT
 SUMMARY:phālguna-aṣṭakā-pūrvēdyuḥ
 DTSTART;VALUE=DATE:20190327
 DTEND;VALUE=DATE:20190328
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:phālguna-aṣṭakā-pūrvēdyuḥ_2019-03-27T06:12:20.159990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/relative_event/phAlguna-aSTakA-zrAddh
@@ -14790,7 +14790,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190327
 DTEND;VALUE=DATE:20190328
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-03-27T06:12:20.159990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -14813,7 +14813,7 @@ SUMMARY:Phālgunaḥ-12-23  \,Dhanuḥ-Mūlā🌛🌌  \,  Mīnaḥ-Uttara
  prōṣṭhapadā-12-14🌞🌌  \,  Mādhavaḥ-02-08🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190328T061136
 DTEND;TZID=Asia/Calcutta:20190329T061053
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190328_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-07\, Islamic: 1440-07-21 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -14871,7 +14871,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190328
 DTEND;VALUE=DATE:20190329
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-03-28T06:11:36.959983+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -14906,7 +14906,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190328
 DTEND;VALUE=DATE:20190329
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-03-28T06:11:36.959983+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -14925,7 +14925,7 @@ BEGIN:VEVENT
 SUMMARY:phālguna-aṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20190328
 DTEND;VALUE=DATE:20190329
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:phālguna-aṣṭakā-śrāddham_2019-03-28T06:11:36.959983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/12/23/phAlguna-aSTa
@@ -14949,7 +14949,7 @@ SUMMARY:Phālgunaḥ-12-24  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Mī
    \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190329T061053
 DTEND;TZID=Asia/Calcutta:20190330T061019
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190329_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-08\, Islamic: 1440-07-22 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15008,7 +15008,7 @@ BEGIN:VEVENT
 SUMMARY:guru-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190329T133132
 DTEND;TZID=Asia/Calcutta:20190329T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:guru-saṅkrāntiḥ_2019-03-29T13:31:32.160004+05:30
 DESCRIPTION:Transition of Jupiter from one Rashi to another. When it is no
  t retrograde\, it also marks the beginning of a new Pushkara.<br/><br/>## 
@@ -15025,7 +15025,7 @@ BEGIN:VEVENT
 SUMMARY:phālguna-anvaṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20190329
 DTEND;VALUE=DATE:20190330
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:phālguna-anvaṣṭakā-śrāddham_2019-03-29T06:10:53.760016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/relative_event/phAlguna-aSTakA-zrAddh
@@ -15050,7 +15050,7 @@ SUMMARY:Phālgunaḥ-12-25  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  M
  🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190330T061019
 DTEND;TZID=Asia/Calcutta:20190331T060935
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190330_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-09\, Islamic: 1440-07-23 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15110,7 +15110,7 @@ SUMMARY:Phālgunaḥ-12-26  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Mīna
  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190331T060935
 DTEND;TZID=Asia/Calcutta:20190401T060901
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190331_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-10\, Islamic: 1440-07-24 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15169,7 +15169,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-12
 DTSTART;VALUE=DATE:20190331
 DTEND;VALUE=DATE:20190401
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-12_2019-03-31T06:09:35.999987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ēkādaśī tithi of Phālgunaḥ (lun
  ar) month (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -15189,7 +15189,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190401T060424
 DTEND;TZID=Asia/Calcutta:20190401T060901
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-04-01T06:04:24.959992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -15208,7 +15208,7 @@ BEGIN:VEVENT
 SUMMARY:Kapālī Viḍaiyāṟṟi Niṟaivu
 DTSTART;VALUE=DATE:20190331
 DTEND;VALUE=DATE:20190401
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:KapālīViḍaiyāṟṟiNiṟaivu_2019-03-31T06:09:35.999987+05:30
 DESCRIPTION:Conclusion (niṟaivu) of the viḍaiyāṟṟi (valedictory s
  end-off) rites\, marking the end of the Kapālīśvarar temple's Paṅguni
@@ -15230,7 +15230,7 @@ BEGIN:VEVENT
 SUMMARY:smārta-pāpamōcanī-ēkādaśī
 DTSTART;VALUE=DATE:20190331
 DTEND;VALUE=DATE:20190401
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:smārta-pāpamōcanī-ēkādaśī_2019-03-31T06:09:35.999987+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of phālguna month is known as pā
  pamōchanī-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are 
@@ -15325,7 +15325,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190331
 DTEND;VALUE=DATE:20190401
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-03-31T06:09:35.999987+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -15345,7 +15345,7 @@ SUMMARY:Phālgunaḥ-12-27  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Mīna
  ḥ-Rēvatī-12-18🌞🌌  \,  Mādhavaḥ-02-12🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190401T060901
 DTEND;TZID=Asia/Calcutta:20190402T060818
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190401_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-11\, Islamic: 1440-07-25 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15403,7 +15403,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190331T235957
 DTEND;TZID=Asia/Calcutta:20190401T124400
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-03-31T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -15421,7 +15421,7 @@ BEGIN:VEVENT
 SUMMARY:vaiṣṇava-pāpamōcanī-ēkādaśī
 DTSTART;VALUE=DATE:20190401
 DTEND;VALUE=DATE:20190402
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vaiṣṇava-pāpamōcanī-ēkādaśī_2019-04-01T06:09:01.440006+05:3
  0
 DESCRIPTION:The Krishna-paksha Ekadashi of phālguna month is known as pā
@@ -15517,7 +15517,7 @@ BEGIN:VEVENT
 SUMMARY:vyañjulī-mahādvādaśī
 DTSTART;VALUE=DATE:20190401
 DTEND;VALUE=DATE:20190402
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vyañjulī-mahādvādaśī_2019-04-01T06:09:01.440006+05:30
 DESCRIPTION:Dvadashi tithi\, which is present at sunrise on two consecutiv
  e days.<br/><br/>## Details<br/>- [Edit config file](https://github.com/jy
@@ -15538,7 +15538,7 @@ SUMMARY:Phālgunaḥ-12-27  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Mīna
  ḥ-Rēvatī-12-19🌞🌌  \,  Mādhavaḥ-02-13🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190402T060818
 DTEND;TZID=Asia/Calcutta:20190403T060743
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190402_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-12\, Islamic: 1440-07-26 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15596,7 +15596,7 @@ BEGIN:VEVENT
 SUMMARY:Daṇḍiyaḍigaḷ Nāyanmār (31) Gurupūjai
 DTSTART;VALUE=DATE:20190402
 DTEND;VALUE=DATE:20190403
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:DaṇḍiyaḍigaḷNāyanmār(31)Gurupūjai_2019-04-02T06:08:18.23999
  9+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -15620,7 +15620,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190402T181713
 DTEND;TZID=Asia/Calcutta:20190402T194556
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-04-02T18:17:13.920014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -15638,7 +15638,7 @@ BEGIN:VEVENT
 SUMMARY:vāruṇī-trayōdaśī
 DTSTART;TZID=Asia/Calcutta:20190402T083847
 DTEND;TZID=Asia/Calcutta:20190403T004754
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vāruṇī-trayōdaśī_2019-04-02T08:38:47.039990+05:30
 DESCRIPTION:Phalguna Krishna Trayodashi\, combined with Shatabhishak Naksh
  atram.<br/><br/>vāruṇēna samāyuktā madhau kr̥ṣṇā trayōdaśī
@@ -15659,7 +15659,7 @@ SUMMARY:Phālgunaḥ-12-28  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌  \
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190403T060743
 DTEND;TZID=Asia/Calcutta:20190404T060700
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190403_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-13\, Islamic: 1440-07-27 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15718,7 +15718,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190403T181713
 DTEND;TZID=Asia/Calcutta:20190404T060700
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-03T18:17:13.920014+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -15739,7 +15739,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190403
 DTEND;VALUE=DATE:20190404
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-04-03T06:07:43.680017+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -15759,7 +15759,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190403
 DTEND;VALUE=DATE:20190404
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-04-03T06:07:43.680017+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -15780,7 +15780,7 @@ SUMMARY:Phālgunaḥ-12-29  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \,
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190404T060700
 DTEND;TZID=Asia/Calcutta:20190405T060625
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190404_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-14\, Islamic: 1440-07-28 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -15838,7 +15838,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -15878,7 +15878,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-04T06:07:00.480010+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -15902,7 +15902,7 @@ SUMMARY:kāñcī 65 jagadguru-śrī-sudarśana-mahādēvēndra-sarasvatī-
  ārādhanā #129
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī65jagadguru-śrī-sudarśana-mahādēvēndra-sarasvatī-ārād
  hanā#129_2019-04-04T06:07:00.480010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -15927,7 +15927,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(raivataḥ-[5])
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(raivataḥ-[5])_2019-04-04T06:07:00.480010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/12/30/manvA
@@ -15949,7 +15949,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-04-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -15968,7 +15968,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-phālguna-amāvāsyā (alabhyam–puṣkalā)
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sarva-phālguna-amāvāsyā(alabhyam–puṣkalā)_2019-04-04T06:07:00
  .480010+05:30
 DESCRIPTION:amāvāsyā of phālguna month.<br/><br/>## Details<br/>- [Edi
@@ -15997,7 +15997,7 @@ SUMMARY:Phālgunaḥ-12-30  \,Mīnaḥ-Rēvatī🌛🌌  \,  Mīnaḥ-Rēv
  atī-12-22🌞🌌  \,  Mādhavaḥ-02-16🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190405T060625
 DTEND;TZID=Asia/Calcutta:20190406T060542
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190405_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-15\, Islamic: 1440-07-29 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -16055,7 +16055,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190406
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-05T06:06:25.919988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -16090,7 +16090,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-iṣṭiḥ
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190406
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-iṣṭiḥ_2019-04-05T06:06:25.919988+05:30
 DESCRIPTION:iṣṭiḥ is performed on this day by those following the b
  ōdhāyana/kātyāyana sūtras. This difference happens because chandradar
@@ -16112,7 +16112,7 @@ BEGIN:VEVENT
 SUMMARY:bhr̥gurēvatī-yōgaḥ
 DTSTART;VALUE=DATE:20190404
 DTEND;VALUE=DATE:20190405
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bhr̥gurēvatī-yōgaḥ_2019-04-04T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/bhRgurE
@@ -16134,7 +16134,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190406
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-04-05T06:06:25.919988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -16155,7 +16155,7 @@ BEGIN:VEVENT
 SUMMARY:phālguna-māsaḥ
 DTSTART;VALUE=DATE:20190306
 DTEND;VALUE=DATE:20190406
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:phālguna-māsaḥ_2019-03-06T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/phAlguna-mAsaH.t
@@ -16177,7 +16177,7 @@ BEGIN:VEVENT
 SUMMARY:phālguna-māsa-samāpanam
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190406
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:phālguna-māsa-samāpanam_2019-04-05T06:06:25.919988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Phālgunaḥ (lunar) month (S
  ūryōdayaḥ/paraviddha). <br/><br/>phālguna-māsaḥ ends today<br/><br
@@ -16197,7 +16197,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190406
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-04-05T06:06:25.919988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -16219,7 +16219,7 @@ SUMMARY:Caitraḥ-01-01  \,Mīnaḥ-Rēvatī🌛🌌  \,  Mīnaḥ-Rēvat
  ī-12-23🌞🌌  \,  Mādhavaḥ-02-17🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190406T060542
 DTEND;TZID=Asia/Calcutta:20190407T060508
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190406_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-16\, Islamic: 1440-07-30 Rajab\, 
  🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- Chē
@@ -16277,7 +16277,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -16323,7 +16323,7 @@ BEGIN:VEVENT
 SUMMARY:caitra-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:caitra-māsa-ārambhaḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/01/01/caitra-mA
@@ -16345,7 +16345,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190406T181722
 DTEND;TZID=Asia/Calcutta:20190406T191314
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-04-06T18:17:22.559999+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -16364,7 +16364,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -16384,7 +16384,7 @@ SUMMARY:kāñcī 15 jagadguru-śrī-gaṅgādharēndra-sarasvatī-ārādha
  nā #1691
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī15jagadguru-śrī-gaṅgādharēndra-sarasvatī-ārādhanā#16
  91_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -16410,7 +16410,7 @@ SUMMARY:kāñcī 27 jagadguru-śrī-cidvilāsēndra-sarasvatī-ārādhanā
   #1443
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī27jagadguru-śrī-cidvilāsēndra-sarasvatī-ārādhanā#1443_
  2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -16436,7 +16436,7 @@ SUMMARY:kāñcī 52 jagadguru-śrī-śaṅkarānandēndra-sarasvatī-ārā
  dhanā #603
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī52jagadguru-śrī-śaṅkarānandēndra-sarasvatī-ārādhanā
  #603_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -16461,7 +16461,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-04-06T06:05:42.719981
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -16487,7 +16487,7 @@ BEGIN:VEVENT
 SUMMARY:prapādāna-ārambhaḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:prapādāna-ārambhaḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/01/01/prapAdAnArambhaH.
@@ -16508,7 +16508,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -16529,7 +16529,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -16551,7 +16551,7 @@ BEGIN:VEVENT
 SUMMARY:vasantanavarātra-ārambhaḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vasantanavarātra-ārambhaḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Caitraḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/>śaratkālē mahāpūjā kriyatē
@@ -16574,7 +16574,7 @@ BEGIN:VEVENT
 SUMMARY:yugādiḥ/cāndramāna-saṁvatsarārambhaḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:yugādiḥ/cāndramāna-saṁvatsarārambhaḥ_2019-04-06T06:05:42.719
  981+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Caitraḥ (lunar) month 
@@ -16595,7 +16595,7 @@ BEGIN:VEVENT
 SUMMARY:śvētavarāha-kalpādiḥ
 DTSTART;VALUE=DATE:20190406
 DTEND;VALUE=DATE:20190407
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śvētavarāha-kalpādiḥ_2019-04-06T06:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/01/01/zvEta
@@ -16618,7 +16618,7 @@ SUMMARY:Caitraḥ-01-02  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Mīnaḥ-Rēva
  tī-12-24🌞🌌  \,  Mādhavaḥ-02-18🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190407T060508
 DTEND;TZID=Asia/Calcutta:20190408T060424
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190407_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-17\, Islamic: 1440-08-01 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -16676,7 +16676,7 @@ BEGIN:VEVENT
 SUMMARY:āndōlana-tr̥tīyā
 DTSTART;VALUE=DATE:20190407
 DTEND;VALUE=DATE:20190408
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:āndōlana-tr̥tīyā_2019-04-07T06:05:08.160000+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Caitraḥ (lunar) month
   (Rātrimānam/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -16695,7 +16695,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190407T181731
 DTEND;TZID=Asia/Calcutta:20190408T060424
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-07T18:17:31.199985+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -16716,7 +16716,7 @@ BEGIN:VEVENT
 SUMMARY:bālēnduvratam
 DTSTART;VALUE=DATE:20190407
 DTEND;VALUE=DATE:20190408
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bālēnduvratam_2019-04-07T06:05:08.160000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/graha/lunar_month/tithi/01/02/bAlenduvrata
@@ -16738,7 +16738,7 @@ SUMMARY:kāñcī 60 jagadguru-śrī-advaitātmaprakāśēndra-sarasvatī-
  ārādhanā #316
 DTSTART;VALUE=DATE:20190407
 DTEND;VALUE=DATE:20190408
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī60jagadguru-śrī-advaitātmaprakāśēndra-sarasvatī-ārādh
  anā#316_2019-04-07T06:05:08.160000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -16764,7 +16764,7 @@ SUMMARY:Caitraḥ-01-03  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Mīnaḥ-
  Rēvatī-12-25🌞🌌  \,  Mādhavaḥ-02-19🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190408T060424
 DTEND;TZID=Asia/Calcutta:20190409T060350
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190408_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-18\, Islamic: 1440-08-02 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -16822,7 +16822,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-08T06:04:24.959992+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -16845,7 +16845,7 @@ BEGIN:VEVENT
 SUMMARY:arundhatī-vratam
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:arundhatī-vratam_2019-04-08T06:04:24.959992+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Caitraḥ (lunar) month
   (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -16865,7 +16865,7 @@ BEGIN:VEVENT
 SUMMARY:gaurī-tr̥tīyā/saubhāgya-gaurī-vratam
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:gaurī-tr̥tīyā/saubhāgya-gaurī-vratam_2019-04-08T06:04:24.959992+
  05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Caitraḥ (lunar) month
@@ -16891,7 +16891,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-04-08T06:04:24.959992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -16912,7 +16912,7 @@ BEGIN:VEVENT
 SUMMARY:mahātārā-jayantī
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:mahātārā-jayantī_2019-04-08T06:04:24.959992+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Caitraḥ (lunar) month 
  (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Mahatara is 2nd of the Dash
@@ -16932,7 +16932,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(uttamaḥ-[3])
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(uttamaḥ-[3])_2019-04-08T06:04:24.959992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/01/03/manvA
@@ -16954,7 +16954,7 @@ BEGIN:VEVENT
 SUMMARY:pārvatīśvarayōrāndōlanavratam
 DTSTART;VALUE=DATE:20190408
 DTEND;VALUE=DATE:20190409
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvatīśvarayōrāndōlanavratam_2019-04-08T06:04:24.959992+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Caitraḥ (lunar) month
   (Sūryōdayaḥ/paraviddha). <br/><br/>tr̥tīyāyāṁ madhōrdēvīṁ 
@@ -16982,7 +16982,7 @@ SUMMARY:Caitraḥ-01-04  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Mīnaḥ
  -Rēvatī-12-26🌞🌌  \,  Mādhavaḥ-02-20🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190409T060350
 DTEND;TZID=Asia/Calcutta:20190410T060315
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190409_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-19\, Islamic: 1440-08-03 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -17040,7 +17040,7 @@ BEGIN:VEVENT
 SUMMARY:muttusvāmi-dīkṣita-janmadinam #245
 DTSTART;VALUE=DATE:20190409
 DTEND;VALUE=DATE:20190410
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:muttusvāmi-dīkṣita-janmadinam#245_2019-04-09T06:03:50.400011+05:30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Mīnaḥ (sidereal solar) 
  month (Prātaḥ/paraviddha). The event occurred in 4875 (Kali era).  <br/
@@ -17061,7 +17061,7 @@ BEGIN:VEVENT
 SUMMARY:sukhā aṅgārakī caturthī
 DTSTART;VALUE=DATE:20190409
 DTEND;VALUE=DATE:20190410
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sukhāaṅgārakīcaturthī_2019-04-09T06:03:50.400011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/tithi-vara-combinations/description_on
@@ -17083,7 +17083,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190409
 DTEND;VALUE=DATE:20190410
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-04-09T06:03:50.400011+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -17104,7 +17104,7 @@ SUMMARY:Caitraḥ-01-05  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Mīnaḥ
  -Rēvatī-12-27🌞🌌  \,  Mādhavaḥ-02-21🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190410T060315
 DTEND;TZID=Asia/Calcutta:20190411T060232
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190410_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-20\, Islamic: 1440-08-04 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -17163,7 +17163,7 @@ BEGIN:VEVENT
 SUMMARY:haya-pūjā
 DTSTART;VALUE=DATE:20190410
 DTEND;VALUE=DATE:20190411
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:haya-pūjā_2019-04-10T06:03:15.839989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-fauna/lunar_month/tithi/01/05/haya-pU
@@ -17184,7 +17184,7 @@ BEGIN:VEVENT
 SUMMARY:kūrma-kalpādiḥ
 DTSTART;VALUE=DATE:20190410
 DTEND;VALUE=DATE:20190411
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kūrma-kalpādiḥ_2019-04-10T06:03:15.839989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/01/05/kUrma
@@ -17205,7 +17205,7 @@ BEGIN:VEVENT
 SUMMARY:lakṣmī-pañcamī
 DTSTART;VALUE=DATE:20190410
 DTEND;VALUE=DATE:20190411
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:lakṣmī-pañcamī_2019-04-10T06:03:15.839989+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Caitraḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/>śuklāyāmatha pañcamyāṁ cai
@@ -17229,7 +17229,7 @@ BEGIN:VEVENT
 SUMMARY:Nēcha Nāyanmār (59) Gurupūjai
 DTSTART;VALUE=DATE:20190410
 DTEND;VALUE=DATE:20190411
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:NēchaNāyanmār(59)Gurupūjai_2019-04-10T06:03:15.839989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -17252,7 +17252,7 @@ BEGIN:VEVENT
 SUMMARY:śālihōtra-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190410
 DTEND;VALUE=DATE:20190411
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śālihōtra-vrata-ārambhaḥ_2019-04-10T06:03:15.839989+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Caitraḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -17273,7 +17273,7 @@ SUMMARY:Caitraḥ-01-06  \,Mithunam-Mr̥gaśīrṣam🌛🌌  \,  Mīnaḥ
  -Rēvatī-12-28🌞🌌  \,  Mādhavaḥ-02-22🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190411T060232
 DTEND;TZID=Asia/Calcutta:20190412T060158
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190411_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-21\, Islamic: 1440-08-05 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -17331,7 +17331,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190411
 DTEND;VALUE=DATE:20190412
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-04-11T06:02:32.639982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -17352,7 +17352,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190412T040904
 DTEND;TZID=Asia/Calcutta:20190411T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-04-12T04:09:04.320001+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -17368,7 +17368,7 @@ BEGIN:VEVENT
 SUMMARY:yamunā-jayantī
 DTSTART;VALUE=DATE:20190411
 DTEND;VALUE=DATE:20190412
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:yamunā-jayantī_2019-04-11T06:02:32.639982+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Caitraḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>kr̥ṣṇē sākṣātkr̥
@@ -17392,7 +17392,7 @@ SUMMARY:Caitraḥ-01-07  \,Mithunam-Ārdrā🌛🌌  \,  Mīnaḥ-Rēvatī
  -12-29🌞🌌  \,  Mādhavaḥ-02-23🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190412T060158
 DTEND;TZID=Asia/Calcutta:20190413T060123
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190412_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-22\, Islamic: 1440-08-06 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -17450,7 +17450,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190412T181757
 DTEND;TZID=Asia/Calcutta:20190413T060123
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-12T18:17:57.119981+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -17471,7 +17471,7 @@ BEGIN:VEVENT
 SUMMARY:Gaṇanātha Nāyanmār (38) Gurupūjai
 DTSTART;VALUE=DATE:20190412
 DTEND;VALUE=DATE:20190413
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:GaṇanāthaNāyanmār(38)Gurupūjai_2019-04-12T06:01:58.080001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -17494,7 +17494,7 @@ BEGIN:VEVENT
 SUMMARY:sūryasya damanakapūjā
 DTSTART;VALUE=DATE:20190412
 DTEND;VALUE=DATE:20190413
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sūryasyadamanakapūjā_2019-04-12T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Caitraḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform pūjā to sūryā using da
@@ -17519,7 +17519,7 @@ SUMMARY:Caitraḥ-01-08  \,Karkaṭaḥ-Punarvasuḥ🌛🌌  \,  Mīnaḥ
  -Rēvatī-12-30🌞🌌  \,  Mādhavaḥ-02-24🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190413T060123
 DTEND;TZID=Asia/Calcutta:20190414T060048
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190413_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-23\, Islamic: 1440-08-07 Shaʿbā
  n\, 🌌🌞: सं- Mīnaḥ\, तं- Paṅguni\, म- Mīnaṁ\, प- 
@@ -17577,7 +17577,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190413
 DTEND;VALUE=DATE:20190414
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-13T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -17612,7 +17612,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190413T181757
 DTEND;TZID=Asia/Calcutta:20190414T060048
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-13T18:17:57.119981+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -17634,7 +17634,7 @@ BEGIN:VEVENT
 SUMMARY:aśōkāṣṭamī
 DTSTART;VALUE=DATE:20190413
 DTEND;VALUE=DATE:20190414
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:aśōkāṣṭamī_2019-04-13T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Caitraḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>brahmōvāca---  <br/>aśōkaka
@@ -17659,7 +17659,7 @@ BEGIN:VEVENT
 SUMMARY:bhavānyutpattiḥ
 DTSTART;VALUE=DATE:20190413
 DTEND;VALUE=DATE:20190414
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bhavānyutpattiḥ_2019-04-13T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Caitraḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refe
@@ -17679,7 +17679,7 @@ BEGIN:VEVENT
 SUMMARY:brahmaputrasnānam
 DTSTART;VALUE=DATE:20190413
 DTEND;VALUE=DATE:20190414
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:brahmaputrasnānam_2019-04-13T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/01/08/brahmaputrasnAnam
@@ -17701,7 +17701,7 @@ SUMMARY:kāñcī 43 jagadguru-śrī-ānandaghanēndra-sarasvatī-ārādhan
  ā #1006
 DTSTART;VALUE=DATE:20190413
 DTEND;VALUE=DATE:20190414
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī43jagadguru-śrī-ānandaghanēndra-sarasvatī-ārādhanā#100
  6_2019-04-13T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -17726,7 +17726,7 @@ BEGIN:VEVENT
 SUMMARY:śrīrāmanavamī
 DTSTART;VALUE=DATE:20190413
 DTEND;VALUE=DATE:20190414
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śrīrāmanavamī_2019-04-13T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/01/09/zrIrAman
@@ -17749,7 +17749,7 @@ SUMMARY:Caitraḥ-01-09  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Mēṣaḥ
  -Rēvatī-01-01🌞🌌  \,  Mādhavaḥ-02-25🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190414T060048
 DTEND;TZID=Asia/Calcutta:20190415T060005
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190414_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-24\, Islamic: 1440-08-08 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -17805,7 +17805,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -17830,7 +17830,7 @@ BEGIN:VEVENT
 SUMMARY:dharmarāja-daśamī
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:dharmarāja-daśamī_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Caitraḥ (lunar) month (
  Madhyāhnaḥ/paraviddha). <br/><br/>dharmarājasya damanakēna pūjanamuk
@@ -17853,7 +17853,7 @@ BEGIN:VEVENT
 SUMMARY:khālsārambhaḥ #321
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:khālsārambhaḥ#321_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/xatra/sidereal_solar_month/day/01/01/
@@ -17874,7 +17874,7 @@ BEGIN:VEVENT
 SUMMARY:mēṣa-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190414T095357
 DTEND;TZID=Asia/Calcutta:20190414T175354
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:mēṣa-saṅkramaṇa-puṇyakālaḥ_2019-04-14T09:53:57.120013+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -17894,7 +17894,7 @@ BEGIN:VEVENT
 SUMMARY:nimba-kusuma-bhakṣaṇam
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:nimba-kusuma-bhakṣaṇam_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:Observed on day 1 of Mēṣaḥ (sidereal solar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>Partake Neem flowers in the early part 
@@ -17919,7 +17919,7 @@ BEGIN:VEVENT
 SUMMARY:pañcāṅga-paṭhanam
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañcāṅga-paṭhanam_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:Being the first day of the new year\, read the pañchāṅga t
  oday\, followed by naivedyam of pānakam to gaṇēśādi trayastriṁśat
@@ -17939,7 +17939,7 @@ BEGIN:VEVENT
 SUMMARY:ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190414T072957
 DTEND;TZID=Asia/Calcutta:20190414T181805
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:ravi-saṅkramaṇa-puṇyakālaḥ_2019-04-14T07:29:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/ravi-saGkra
@@ -17957,7 +17957,7 @@ BEGIN:VEVENT
 SUMMARY:ravipuṣya-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190413T235957
 DTEND;TZID=Asia/Calcutta:20190414T073844
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:ravipuṣya-yōgaḥ_2019-04-13T23:59:57.120005+05:30
 DESCRIPTION:When Pushya nakshatra falls on a Sunday\, it is a special yōg
  aḥ\, on which it is important to propitiate Surya Bhagavan.<br/><br/>ād
@@ -17977,7 +17977,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190414T120927
 DTEND;TZID=Asia/Calcutta:20190414T181805
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-04-14T12:09:27.36
  0002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -17997,7 +17997,7 @@ BEGIN:VEVENT
 SUMMARY:sauramāna-saṁvatsarārambhaḥ (vikāri-saṁvatsaraḥ)
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sauramāna-saṁvatsarārambhaḥ(vikāri-saṁvatsaraḥ)_2019-04-14T
  06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -18021,7 +18021,7 @@ BEGIN:VEVENT
 SUMMARY:vasantanavarātraḥ
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vasantanavarātraḥ_2019-04-05T23:59:57.120005+05:30
 DESCRIPTION:śaratkālē mahāpūjā kriyatē yā ca vārṣikī।  <br/>
  vasantakālē sā prōktā kāryā sarvaiḥ śubhārthibhiḥ॥  <br/>--
@@ -18042,7 +18042,7 @@ BEGIN:VEVENT
 SUMMARY:vasantanavarātra-samāpanam
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vasantanavarātra-samāpanam_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Caitraḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/>śaratkālē mahāpūjā kriyatē y
@@ -18065,7 +18065,7 @@ BEGIN:VEVENT
 SUMMARY:Viṣukkani
 DTSTART;VALUE=DATE:20190414
 DTEND;VALUE=DATE:20190415
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:Viṣukkani_2019-04-14T06:00:48.959997+05:30
 DESCRIPTION:To celebrate the new year\, first thing in the morning\, one s
  ees the various symbols of prosperity (dhana\, dhaanya\, etc.---ornaments\
@@ -18087,7 +18087,7 @@ SUMMARY:Caitraḥ-01-10  \,Siṁhaḥ-Maghā🌛🌌  \,  Mēṣaḥ-Aśvi
  nī-01-02🌞🌌  \,  Mādhavaḥ-02-26🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190415T060005
 DTEND;TZID=Asia/Calcutta:20190416T055931
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190415_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-25\, Islamic: 1440-08-09 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -18143,7 +18143,7 @@ BEGIN:VEVENT
 SUMMARY:r̥ṣīṇāṁ damanakapūjā
 DTSTART;VALUE=DATE:20190415
 DTEND;VALUE=DATE:20190416
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:r̥ṣīṇāṁdamanakapūjā_2019-04-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Caitraḥ (lunar) mont
  h (Madhyāhnaḥ/puurvaviddha). <br/><br/>Perform pūjā to r̥ṣis using
@@ -18167,7 +18167,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190415
 DTEND;VALUE=DATE:20190416
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-04-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -18188,7 +18188,7 @@ BEGIN:VEVENT
 SUMMARY:samudra-manthanam
 DTSTART;VALUE=DATE:20190415
 DTEND;VALUE=DATE:20190416
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:samudra-manthanam_2019-04-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Caitraḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>Jyeshtha Devi (Kali wife)\, Var
@@ -18210,7 +18210,7 @@ BEGIN:VEVENT
 SUMMARY:smārta-kāmadā-ēkādaśī
 DTSTART;VALUE=DATE:20190415
 DTEND;VALUE=DATE:20190416
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:smārta-kāmadā-ēkādaśī_2019-04-15T06:00:05.759990+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of chaitra month is known as kāmad
  ā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatly e
@@ -18305,7 +18305,7 @@ BEGIN:VEVENT
 SUMMARY:śrīkr̥ṣṇadōlōtsavaḥ
 DTSTART;VALUE=DATE:20190415
 DTEND;VALUE=DATE:20190416
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śrīkr̥ṣṇadōlōtsavaḥ_2019-04-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/01/11/zrIkRSNa
@@ -18327,7 +18327,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190416T005204
 DTEND;TZID=Asia/Calcutta:20190415T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-04-16T00:52:04.800003+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -18344,7 +18344,7 @@ SUMMARY:Caitraḥ-01-12  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Mēṣa
  ḥ-Aśvinī-01-03🌞🌌  \,  Mādhavaḥ-02-27🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190416T055931
 DTEND;TZID=Asia/Calcutta:20190417T055856
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190416_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-26\, Islamic: 1440-08-10 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -18399,7 +18399,7 @@ BEGIN:VEVENT
 SUMMARY:bhrātr̥prāpti-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190416
 DTEND;VALUE=DATE:20190417
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bhrātr̥prāpti-vrata-ārambhaḥ_2019-04-16T05:59:31.200009+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Caitraḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -18419,7 +18419,7 @@ BEGIN:VEVENT
 SUMMARY:damanakārōpaṇa-dvādaśī
 DTSTART;VALUE=DATE:20190416
 DTEND;VALUE=DATE:20190417
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:damanakārōpaṇa-dvādaśī_2019-04-16T05:59:31.200009+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Caitraḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/>Celebrating the stealing of Dama
@@ -18440,7 +18440,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190415T235957
 DTEND;TZID=Asia/Calcutta:20190416T093950
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-04-15T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -18458,7 +18458,7 @@ BEGIN:VEVENT
 SUMMARY:tulasī-jananaṁ-kṣīrasāgarataḥ
 DTSTART;VALUE=DATE:20190416
 DTEND;VALUE=DATE:20190417
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:tulasī-jananaṁ-kṣīrasāgarataḥ_2019-04-16T05:59:31.200009+05:3
  0
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Caitraḥ (lunar) month
@@ -18479,7 +18479,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē vasantōtsava-prārambhaḥ
 DTSTART;VALUE=DATE:20190416
 DTEND;VALUE=DATE:20190417
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēvasantōtsava-prārambhaḥ_2019-04-16T05:59:31.2000
  09+05:30
 DESCRIPTION:Vasantotsava is an annual festival conducted for three days (T
@@ -18505,7 +18505,7 @@ BEGIN:VEVENT
 SUMMARY:vaiṣṇava-kāmadā-ēkādaśī
 DTSTART;VALUE=DATE:20190416
 DTEND;VALUE=DATE:20190417
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vaiṣṇava-kāmadā-ēkādaśī_2019-04-16T05:59:31.200009+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of chaitra month is known as kāmad
  ā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatly e
@@ -18600,7 +18600,7 @@ BEGIN:VEVENT
 SUMMARY:viṣṇu-damanakōtsavaḥ
 DTSTART;VALUE=DATE:20190416
 DTEND;VALUE=DATE:20190417
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:viṣṇu-damanakōtsavaḥ_2019-04-16T05:59:31.200009+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Caitraḥ (lunar) month
   (Madhyāhnaḥ/puurvaviddha). <br/><br/>Perform pūjā to viṣṇus usin
@@ -18626,7 +18626,7 @@ SUMMARY:Caitraḥ-01-13  \,Siṁhaḥ-Uttaraphalgunī🌛🌌  \,  Mēṣa
  ḥ-Aśvinī-01-04🌞🌌  \,  Mādhavaḥ-02-28🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190417T055856
 DTEND;TZID=Asia/Calcutta:20190418T055822
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190417_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-27\, Islamic: 1440-08-11 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -18682,7 +18682,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190417T181823
 DTEND;TZID=Asia/Calcutta:20190418T055822
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-17T18:18:23.040017+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -18703,7 +18703,7 @@ BEGIN:VEVENT
 SUMMARY:damanaka-cōrī-utsavaḥ
 DTSTART;VALUE=DATE:20190417
 DTEND;VALUE=DATE:20190418
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:damanaka-cōrī-utsavaḥ_2019-04-17T05:58:56.639987+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Caitraḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Celebrating the stealing of Da
@@ -18724,7 +18724,7 @@ BEGIN:VEVENT
 SUMMARY:madana-trayōdaśī
 DTSTART;VALUE=DATE:20190417
 DTEND;VALUE=DATE:20190418
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:madana-trayōdaśī_2019-04-17T05:58:56.639987+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Caitraḥ (lunar) mon
  th (Madhyāhnaḥ/puurvaviddha). <br/><br/>caitraśuklatrayōdaśyāṁ ma
@@ -18747,7 +18747,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190417T181823
 DTEND;TZID=Asia/Calcutta:20190417T194556
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-04-17T18:18:23.040017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -18765,7 +18765,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē vasantōtsavaḥ
 DTSTART;VALUE=DATE:20190417
 DTEND;VALUE=DATE:20190418
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēvasantōtsavaḥ_2019-04-17T05:58:56.639987+05:30
 DESCRIPTION:Vasantotsava is an annual festival conducted for three days (T
  rayodashi\, Chaturdashi and Paurnami in the month of Chaitra). During this
@@ -18791,7 +18791,7 @@ SUMMARY:Caitraḥ-01-14  \,Kanyā-Hastaḥ🌛🌌  \,  Mēṣaḥ-Aśvin
  ī-01-05🌞🌌  \,  Mādhavaḥ-02-29🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190418T055822
 DTEND;TZID=Asia/Calcutta:20190419T055756
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190418_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-28\, Islamic: 1440-08-12 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -18846,7 +18846,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -18886,7 +18886,7 @@ BEGIN:VEVENT
 SUMMARY:citrā-pūrṇimā/citragupta-pūjā
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:citrā-pūrṇimā/citragupta-pūjā_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mēṣaḥ (sidereal solar
  ) month (Chandrōdayaḥ/puurvaviddha). <br/><br/>citraguptaṁ mahāprāj
@@ -18908,7 +18908,7 @@ BEGIN:VEVENT
 SUMMARY:damanaka-caturdaśī
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:damanaka-caturdaśī_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Caitraḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>Celebrating the stealing of Dam
@@ -18929,7 +18929,7 @@ BEGIN:VEVENT
 SUMMARY:madana-caturdaśī
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:madana-caturdaśī_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Caitraḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -18949,7 +18949,7 @@ BEGIN:VEVENT
 SUMMARY:nr̥siṁha-dōlōtsavaḥ
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:nr̥siṁha-dōlōtsavaḥ_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Caitraḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform dōlōtsavaḥ for nr̥
@@ -18974,7 +18974,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -18998,7 +18998,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-04-18T05:58:22.080005+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -19017,7 +19017,7 @@ BEGIN:VEVENT
 SUMMARY:prōklas-mr̥tyuḥ #1534
 DTSTART;VALUE=DATE:20190417
 DTEND;VALUE=DATE:20190418
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:prōklas-mr̥tyuḥ#1534_2019-04-17T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/general-indic-tropical/julian/day/04/
@@ -19038,7 +19038,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē vasantōtsavaḥ
 DTSTART;VALUE=DATE:20190415
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēvasantōtsavaḥ_2019-04-15T23:59:57.120005+05:30
 DESCRIPTION:Vasantotsava is an annual festival conducted for three days (T
  rayodashi\, Chaturdashi and Paurnami in the month of Chaitra). During this
@@ -19063,7 +19063,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē vasantōtsava-samāpanam
 DTSTART;VALUE=DATE:20190418
 DTEND;VALUE=DATE:20190419
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēvasantōtsava-samāpanam_2019-04-18T05:58:22.080005+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -19086,7 +19086,7 @@ SUMMARY:Caitraḥ-01-15  \,Kanyā-Citrā🌛🌌  \,  Mēṣaḥ-Aśvinī-
  01-06🌞🌌  \,  Mādhavaḥ-02-30🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190419T055756
 DTEND;TZID=Asia/Calcutta:20190420T055721
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190419_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-29\, Islamic: 1440-08-13 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -19141,7 +19141,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -19176,7 +19176,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190419T181840
 DTEND;TZID=Asia/Calcutta:20190420T055721
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-19T18:18:40.319988+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -19198,7 +19198,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -19221,7 +19221,7 @@ BEGIN:VEVENT
 SUMMARY:caitra-pūrṇimā
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:caitra-pūrṇimā_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Caitraḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/>Daanam of Varaha Puran<br/><br/>## 
@@ -19241,7 +19241,7 @@ BEGIN:VEVENT
 SUMMARY:citragupta-vratam
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:citragupta-vratam_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Caitraḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -19261,7 +19261,7 @@ BEGIN:VEVENT
 SUMMARY:gajēndra-mōkṣaḥ
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:gajēndra-mōkṣaḥ_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Caitraḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -19281,7 +19281,7 @@ BEGIN:VEVENT
 SUMMARY:Ichaiñāniyār Nāyanmār (63) Gurupūjai
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:IchaiñāniyārNāyanmār(63)Gurupūjai_2019-04-19T05:57:56.160009+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -19305,7 +19305,7 @@ BEGIN:VEVENT
 SUMMARY:Madhurakavi Āḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:MadhurakaviĀḻvārTirunakṣattiram_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Observed on Citrā nakshatra of Mēṣaḥ (sidereal solar) mo
  nth (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit con
@@ -19325,7 +19325,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(raucyaḥ-[13])
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(raucyaḥ-[13])_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/01/15/manvA
@@ -19347,7 +19347,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -19368,7 +19368,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -19388,7 +19388,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-04-19T05:57:56.1600
  09+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -19411,7 +19411,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-hanūmat-jayantī
 DTSTART;VALUE=DATE:20190419
 DTEND;VALUE=DATE:20190420
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śrī-hanūmat-jayantī_2019-04-19T05:57:56.160009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/01/15/zrI~hanU
@@ -19433,7 +19433,7 @@ SUMMARY:Caitraḥ-01-16  \,Tulā-Svātī🌛🌌  \,  Mēṣaḥ-Aśvinī-
  01-07🌞🌌  \,  Śukraḥ-03-01🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190420T055721
 DTEND;TZID=Asia/Calcutta:20190421T055647
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190420_day_summary
 DESCRIPTION:- Indian civil date: 1941-01-30\, Islamic: 1440-08-14 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -19488,7 +19488,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-20T05:57:21.599987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -19534,7 +19534,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-20T05:57:21.599987+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -19559,7 +19559,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-04-20T05:57:
  21.599987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -19586,7 +19586,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-04-20T05:57:21.599987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -19605,7 +19605,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190420T120800
 DTEND;TZID=Asia/Calcutta:20190420T181848
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-04-20T12:
  08:00.959988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -19626,7 +19626,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190420T080120
 DTEND;TZID=Asia/Calcutta:20190420T181848
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-viṣṇupadī-puṇyakālaḥ_2019-04-20T08:01:20.639984+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -19646,7 +19646,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-04-20T05:57:21.599987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -19667,7 +19667,7 @@ BEGIN:VEVENT
 SUMMARY:Tirukkuṟipput Toṇḍa Nāyanmār (19) Gurupūjai
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:TirukkuṟipputToṇḍaNāyanmār(19)Gurupūjai_2019-04-20T05:57:21.5
  99987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -19692,7 +19692,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190420T175704
 DTEND;TZID=Asia/Calcutta:20190421T055647
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-04-20T17:57:04.320017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -19711,7 +19711,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-māsaḥ/grīṣmar̥tuḥ
 DTSTART;TZID=Asia/Calcutta:20190420T142514
 DTEND;TZID=Asia/Calcutta:20190420T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śukra-māsaḥ/grīṣmar̥tuḥ_2019-04-20T14:25:14.880002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -19731,7 +19731,7 @@ SUMMARY:Caitraḥ-01-17  \,Tulā-Viśākhā🌛🌌  \,  Mēṣaḥ-Aśvin
  ī-01-08🌞🌌  \,  Śukraḥ-03-02🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190421T055647
 DTEND;TZID=Asia/Calcutta:20190422T055612
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190421_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-01\, Islamic: 1440-08-15 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -19787,7 +19787,7 @@ BEGIN:VEVENT
 SUMMARY:pātārka-yōgaḥ
 DTSTART;VALUE=DATE:20190420
 DTEND;VALUE=DATE:20190421
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pātārka-yōgaḥ_2019-04-20T23:59:57.120005+05:30
 DESCRIPTION:When Vyatipata yoga falls on a Sunday\, it is a special yōga
  ḥ\, which is equal to a thousand Surya grahanas.<br/><br/>bhānōrvārē
@@ -19809,7 +19809,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190421T055647
 DTEND;TZID=Asia/Calcutta:20190421T123247
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-04-21T05:56:47.040006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -19828,7 +19828,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190421
 DTEND;VALUE=DATE:20190422
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-04-21T05:56:47.040006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -19851,7 +19851,7 @@ SUMMARY:Caitraḥ-01-18  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Mēṣa
  ḥ-Aśvinī-01-09🌞🌌  \,  Śukraḥ-03-03🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190422T055612
 DTEND;TZID=Asia/Calcutta:20190423T055546
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190422_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-02\, Islamic: 1440-08-16 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -19906,7 +19906,7 @@ BEGIN:VEVENT
 SUMMARY:vikaṭa-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20190422
 DTEND;VALUE=DATE:20190423
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vikaṭa-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-04-22T0
  5:56:12.479984+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -19935,7 +19935,7 @@ SUMMARY:Caitraḥ-01-19  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Mēṣ
  aḥ-Aśvinī-01-10🌞🌌  \,  Śukraḥ-03-04🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190423T055546
 DTEND;TZID=Asia/Calcutta:20190424T055512
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190423_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-03\, Islamic: 1440-08-17 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -19991,7 +19991,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgārakī caturthī
 DTSTART;VALUE=DATE:20190423
 DTEND;VALUE=DATE:20190424
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:aṅgārakīcaturthī_2019-04-23T05:55:46.559988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/tithi-vara-combinations/description_on
@@ -20013,7 +20013,7 @@ BEGIN:VEVENT
 SUMMARY:guru-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190423T074237
 DTEND;TZID=Asia/Calcutta:20190423T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:guru-saṅkrāntiḥ_2019-04-23T07:42:37.440001+05:30
 DESCRIPTION:Transition of Jupiter from one Rashi to another. When it is no
  t retrograde\, it also marks the beginning of a new Pushkara.<br/><br/>## 
@@ -20030,7 +20030,7 @@ BEGIN:VEVENT
 SUMMARY:varāha-jayantī
 DTSTART;VALUE=DATE:20190423
 DTEND;VALUE=DATE:20190424
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:varāha-jayantī_2019-04-23T05:55:46.559988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/01/20/varAha~j
@@ -20052,7 +20052,7 @@ SUMMARY:Caitraḥ-01-20  \,Dhanuḥ-Mūlā🌛🌌  \,  Mēṣaḥ-Aśvin
  ī-01-11🌞🌌  \,  Śukraḥ-03-05🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190424T055512
 DTEND;TZID=Asia/Calcutta:20190425T055446
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190424_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-04\, Islamic: 1440-08-18 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20108,7 +20108,7 @@ SUMMARY:Caitraḥ-01-21  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Mēṣ
  aḥ-Aśvinī-01-12🌞🌌  \,  Śukraḥ-03-06🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190425T055446
 DTEND;TZID=Asia/Calcutta:20190426T055411
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190425_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-05\, Islamic: 1440-08-19 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20165,7 +20165,7 @@ SUMMARY:Caitraḥ-01-22  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  Mē
  ṣaḥ-Aśvinī-01-13🌞🌌  \,  Śukraḥ-03-07🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190426T055411
 DTEND;TZID=Asia/Calcutta:20190427T055345
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190426_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-06\, Islamic: 1440-08-20 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20220,7 +20220,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190426T181932
 DTEND;TZID=Asia/Calcutta:20190427T055345
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-26T18:19:32.159980+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -20241,7 +20241,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190426
 DTEND;VALUE=DATE:20190427
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-04-26T05:54:11.519988+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -20261,7 +20261,7 @@ SUMMARY:Caitraḥ-01-23  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Mēṣaḥ
  -Aśvinī-01-14🌞🌌  \,  Śukraḥ-03-08🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190427T055345
 DTEND;TZID=Asia/Calcutta:20190428T055319
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190427_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-07\, Islamic: 1440-08-21 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20316,7 +20316,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190427
 DTEND;VALUE=DATE:20190428
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-04-27T05:53:45.599992+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -20352,7 +20352,7 @@ SUMMARY:kāñcī 56 jagadguru-śrī-sarvajña-sadāśiva-bōdhēndra-saras
  vatī-ārādhanā #481
 DTSTART;VALUE=DATE:20190427
 DTEND;VALUE=DATE:20190428
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī56jagadguru-śrī-sarvajña-sadāśiva-bōdhēndra-sarasvatī-
  ārādhanā#481_2019-04-27T05:53:45.599992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -20377,7 +20377,7 @@ BEGIN:VEVENT
 SUMMARY:Naṭarājar Chittirai Ōṇam Mahābhiṣēkam
 DTSTART;VALUE=DATE:20190427
 DTEND;VALUE=DATE:20190428
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:NaṭarājarChittiraiŌṇamMahābhiṣēkam_2019-04-27T05:53:45.59999
  2+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -20400,7 +20400,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190427
 DTEND;VALUE=DATE:20190428
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-04-27T05:53:45.599992+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -20420,7 +20420,7 @@ SUMMARY:Caitraḥ-01-24  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Mēṣa
  ḥ-Apabharaṇī-01-15🌞🌌  \,  Śukraḥ-03-09🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190428T055319
 DTEND;TZID=Asia/Calcutta:20190429T055245
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190428_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-08\, Islamic: 1440-08-22 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20477,7 +20477,7 @@ SUMMARY:Caitraḥ-01-25  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Mēṣaḥ
  -Apabharaṇī-01-16🌞🌌  \,  Śukraḥ-03-10🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190429T055245
 DTEND;TZID=Asia/Calcutta:20190430T055219
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190429_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-09\, Islamic: 1440-08-23 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20533,7 +20533,7 @@ SUMMARY:kāñcī 71 jagadguru-śrī-satya-candraśēkharēndra-sarasvatī-
  jayantī #20
 DTSTART;VALUE=DATE:20190429
 DTEND;VALUE=DATE:20190430
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī71jagadguru-śrī-satya-candraśēkharēndra-sarasvatī-jayant
  ī#20_2019-04-29T05:52:45.120015+05:30
 DESCRIPTION:Observed on Śatabhiṣak nakshatra of Mēṣaḥ (sidereal so
@@ -20558,7 +20558,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunāvukkarachha Nāyanmār (21) Gurupūjai
 DTSTART;VALUE=DATE:20190429
 DTEND;VALUE=DATE:20190430
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:TirunāvukkarachhaNāyanmār(21)Gurupūjai_2019-04-29T05:52:45.120015+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -20583,7 +20583,7 @@ SUMMARY:Caitraḥ-01-26  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Mēṣaḥ
  -Apabharaṇī-01-17🌞🌌  \,  Śukraḥ-03-11🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190430T055219
 DTEND;TZID=Asia/Calcutta:20190501T055153
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190430_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-10\, Islamic: 1440-08-24 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20639,7 +20639,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-varūthinī-ēkādaśī
 DTSTART;VALUE=DATE:20190430
 DTEND;VALUE=DATE:20190501
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:sarva-varūthinī-ēkādaśī_2019-04-30T05:52:19.200018+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of chaitra month is known as varū
  thinī-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are great
@@ -20734,7 +20734,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190501T001757
 DTEND;TZID=Asia/Calcutta:20190501T055153
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-05-01T00:17:57.119981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -20753,7 +20753,7 @@ BEGIN:VEVENT
 SUMMARY:vallabhācārya-jayantī #541
 DTSTART;VALUE=DATE:20190430
 DTEND;VALUE=DATE:20190501
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vallabhācārya-jayantī#541_2019-04-30T05:52:19.200018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ēkādaśī tithi of Caitraḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). The event occurred in 4580 (Kali era
@@ -20776,7 +20776,7 @@ SUMMARY:Caitraḥ-01-27  \,Mīnaḥ-Pūrvaprōṣṭhapadā🌛🌌  \,  M
  haḥ
 DTSTART;TZID=Asia/Calcutta:20190501T055153
 DTEND;TZID=Asia/Calcutta:20190502T055127
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190501_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-11\, Islamic: 1440-08-25 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20832,7 +20832,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190430T235957
 DTEND;TZID=Asia/Calcutta:20190501T064728
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-04-30T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -20850,7 +20850,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190501
 DTEND;VALUE=DATE:20190502
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-05-01T05:51:53.279982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -20874,7 +20874,7 @@ SUMMARY:Caitraḥ-01-28  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \,  M
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190502T055127
 DTEND;TZID=Asia/Calcutta:20190503T055101
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190502_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-12\, Islamic: 1440-08-26 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -20930,7 +20930,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190502T182032
 DTEND;TZID=Asia/Calcutta:20190503T055101
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-02T18:20:32.639998+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -20951,7 +20951,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-1
 DTSTART;VALUE=DATE:20190502
 DTEND;VALUE=DATE:20190503
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-1_2019-05-02T05:51:27.359986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Trayōdaśī tithi of Caitraḥ (lunar
  ) month (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -20971,7 +20971,7 @@ BEGIN:VEVENT
 SUMMARY:matsya-jayantī
 DTSTART;VALUE=DATE:20190502
 DTEND;VALUE=DATE:20190503
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:matsya-jayantī_2019-05-02T05:51:27.359986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/01/28/matsya~j
@@ -20992,7 +20992,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190502T182032
 DTEND;TZID=Asia/Calcutta:20190502T194656
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-05-02T18:20:32.639998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -21010,7 +21010,7 @@ BEGIN:VEVENT
 SUMMARY:ramaṇa-maharṣi-ārādhanā #69
 DTSTART;VALUE=DATE:20190502
 DTEND;VALUE=DATE:20190503
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:ramaṇa-maharṣi-ārādhanā#69_2019-05-02T05:51:27.359986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Trayōdaśī tithi of Mēṣaḥ (side
  real solar) month (Aparāhṇaḥ/vyaapti). The event occurred in 5052 (Ka
@@ -21032,7 +21032,7 @@ SUMMARY:Caitraḥ-01-29  \,Mīnaḥ-Rēvatī🌛🌌  \,  Mēṣaḥ-Apabh
  araṇī-01-20🌞🌌  \,  Śukraḥ-03-14🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190503T055101
 DTEND;TZID=Asia/Calcutta:20190504T055044
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190503_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-13\, Islamic: 1440-08-27 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -21088,7 +21088,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190503
 DTEND;VALUE=DATE:20190504
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-03T05:51:01.439990+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -21128,7 +21128,7 @@ BEGIN:VEVENT
 SUMMARY:bhr̥gurēvatī-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190502T235957
 DTEND;TZID=Asia/Calcutta:20190503T143847
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bhr̥gurēvatī-yōgaḥ_2019-05-02T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/bhRgurE
@@ -21147,7 +21147,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190503T165400
 DTEND;TZID=Asia/Calcutta:20190503T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-05-03T16:54:00.000008+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -21163,7 +21163,7 @@ BEGIN:VEVENT
 SUMMARY:gaṅgā-snānam
 DTSTART;VALUE=DATE:20190503
 DTEND;VALUE=DATE:20190504
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:gaṅgā-snānam_2019-05-03T05:51:01.439990+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of Caitraḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>On the Krishna Chaturdashi
@@ -21187,7 +21187,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190503
 DTEND;VALUE=DATE:20190504
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-05-03T05:51:01.439990+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -21207,7 +21207,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190503
 DTEND;VALUE=DATE:20190504
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-05-03T05:51:01.439990+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -21227,7 +21227,7 @@ SUMMARY:Caitraḥ-01-30  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Mēṣaḥ-Apa
  bharaṇī-01-21🌞🌌  \,  Śukraḥ-03-15🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190504T055044
 DTEND;TZID=Asia/Calcutta:20190505T055018
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:20190504_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-14\, Islamic: 1440-08-28 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -21282,7 +21282,7 @@ BEGIN:VEVENT
 SUMMARY:agninakṣatra-ārambhaḥ
 DTSTART;TZID=Asia/Calcutta:20190505T023310
 DTEND;TZID=Asia/Calcutta:20190504T235957
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:agninakṣatra-ārambhaḥ_2019-05-05T02:33:10.079999+05:30
 DESCRIPTION:The start of the period agninakṣatram\, the transit of the S
  un through kr̥ttikā asterism.<br/><br/>## Details<br/>- [Edit config fil
@@ -21299,7 +21299,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -21334,7 +21334,7 @@ BEGIN:VEVENT
 SUMMARY:bhārgava-rāma-pūjā
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:bhārgava-rāma-pūjā_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Caitraḥ (lunar) month (Sūr
  yōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit confi
@@ -21354,7 +21354,7 @@ BEGIN:VEVENT
 SUMMARY:caitra-māsaḥ
 DTSTART;VALUE=DATE:20190405
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:caitra-māsaḥ_2019-04-05T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/caitra-mAsaH.tom
@@ -21376,7 +21376,7 @@ BEGIN:VEVENT
 SUMMARY:caitra-māsa-samāpanam
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:caitra-māsa-samāpanam_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Caitraḥ (lunar) month (Sūr
  yōdayaḥ/paraviddha). <br/><br/>chaitra-māsaḥ ends today<br/><br/>## 
@@ -21397,7 +21397,7 @@ SUMMARY:kāñcī 47 jagadguru-śrī-candraśēkharēndra-sarasvatī-3-ār
  ādhanā #854
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī47jagadguru-śrī-candraśēkharēndra-sarasvatī-3-ārādhan
  ā#854_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -21422,7 +21422,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -21443,7 +21443,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -21462,7 +21462,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115605Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -21483,7 +21483,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-caitra-amāvāsyā
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sarva-caitra-amāvāsyā_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/amAvAsyA/description_only/cait
@@ -21504,7 +21504,7 @@ BEGIN:VEVENT
 SUMMARY:vahni-vratam
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190505
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vahni-vratam_2019-05-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Caitraḥ (lunar) month (Sūr
  yōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit confi
@@ -21525,7 +21525,7 @@ SUMMARY:Vaiśākhaḥ-02-01  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Mē
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190505T055018
 DTEND;TZID=Asia/Calcutta:20190506T054952
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190505_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-15\, Islamic: 1440-08-29 Shaʿbā
  n\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\, 
@@ -21581,7 +21581,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-05T05:50:18.239982+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -21627,7 +21627,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190505T141754
 DTEND;TZID=Asia/Calcutta:20190505T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-05-05T14:17:54.239986+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-May-05 14:17. At this moment budhaḥ is at aśvinī-2 mēṣ
@@ -21646,7 +21646,7 @@ BEGIN:VEVENT
 SUMMARY:Chiṟuttoṇḍa Nāyanmār (36) Gurupūjai
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ChiṟuttoṇḍaNāyanmār(36)Gurupūjai_2019-05-05T05:50:18.239982+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -21670,7 +21670,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-05-05T05:50:18.239982+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -21689,7 +21689,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-05-05T05:50:18.239982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -21710,7 +21710,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-05-05T05:50:18.239982
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -21736,7 +21736,7 @@ BEGIN:VEVENT
 SUMMARY:parāśara-maharṣi-jayantī
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:parāśara-maharṣi-jayantī_2019-05-05T05:50:18.239982+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Vaiśākhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Re
@@ -21757,7 +21757,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-05-05T05:50:18.239982+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -21778,7 +21778,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190506T035850
 DTEND;TZID=Asia/Calcutta:20190506T054952
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-05-06T03:58:50.879997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -21797,7 +21797,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190505
 DTEND;VALUE=DATE:20190506
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsa-ārambhaḥ_2019-05-05T05:50:18.239982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/02/01/vaizAkha-
@@ -21821,7 +21821,7 @@ SUMMARY:Vaiśākhaḥ-02-02  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Mē
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190506T054952
 DTEND;TZID=Asia/Calcutta:20190507T054935
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190506_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-16\, Islamic: 1440-09-01 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -21876,7 +21876,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190506T182124
 DTEND;TZID=Asia/Calcutta:20190507T054935
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-06T18:21:24.479991+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -21897,7 +21897,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190506T182124
 DTEND;TZID=Asia/Calcutta:20190506T194346
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-05-06T18:21:24.479991+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -21916,7 +21916,7 @@ BEGIN:VEVENT
 SUMMARY:śyāma-śāstrī-janmadinam #258
 DTSTART;VALUE=DATE:20190506
 DTEND;VALUE=DATE:20190507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śyāma-śāstrī-janmadinam#258_2019-05-06T05:49:52.319986+05:30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Mēṣaḥ (sidereal solar
  ) month (Prātaḥ/paraviddha). The event occurred in 4863 (Kali era).  <b
@@ -21939,7 +21939,7 @@ SUMMARY:Vaiśākhaḥ-02-03  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Mē
  galaḥ
 DTSTART;TZID=Asia/Calcutta:20190507T054935
 DTEND;TZID=Asia/Calcutta:20190508T054917
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190507_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-17\, Islamic: 1440-09-02 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -21995,7 +21995,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190507T062928
 DTEND;TZID=Asia/Calcutta:20190507T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-05-07T06:29:28.320014+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -22011,7 +22011,7 @@ BEGIN:VEVENT
 SUMMARY:akṣaya-tr̥tīyā
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:akṣaya-tr̥tīyā_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/02/03/akSaya-tRtIyA.tom
@@ -22032,7 +22032,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:Anadhyayana on account of yugādi. On the days of Ayana (solst
  ices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (Sh
@@ -22059,7 +22059,7 @@ BEGIN:VEVENT
 SUMMARY:balarāma-jayantī (draviḍa-sampradāyaḥ)
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:balarāma-jayantī(draviḍa-sampradāyaḥ)_2019-05-07T05:49:35.04001
  6+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -22082,7 +22082,7 @@ BEGIN:VEVENT
 SUMMARY:candana-pūjā
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:candana-pūjā_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Vaiśākhaḥ (lunar) m
  onth (Madhyāhnaḥ/paraviddha). <br/><br/>yaḥ karōti tr̥tīyāyāṁ 
@@ -22106,7 +22106,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-2
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-2_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Vaiśākhaḥ (lunar) m
  onth (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -22125,7 +22125,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥tayugādiḥ
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kr̥tayugādiḥ_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/yugAdiH/lunar_month/tithi/02/03/kRtayu
@@ -22147,7 +22147,7 @@ BEGIN:VEVENT
 SUMMARY:Maṅgaiyarkkarachiyār Nāyanmār (50) Gurupūjai
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:MaṅgaiyarkkarachiyārNāyanmār(50)Gurupūjai_2019-05-07T05:49:35.04
  0016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -22171,7 +22171,7 @@ BEGIN:VEVENT
 SUMMARY:paraśurāma-jayantī
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:paraśurāma-jayantī_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/02/03/parazurA
@@ -22193,7 +22193,7 @@ BEGIN:VEVENT
 SUMMARY:rāja-mātaṅgī-jayantī
 DTSTART;VALUE=DATE:20190507
 DTEND;VALUE=DATE:20190508
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:rāja-mātaṅgī-jayantī_2019-05-07T05:49:35.040016+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Vaiśākhaḥ (lunar) m
  onth (Aparāhṇaḥ/puurvaviddha). <br/><br/>Devi Raja Matangi is 9th of 
@@ -22216,7 +22216,7 @@ SUMMARY:Vaiśākhaḥ-02-04  \,Mithunam-Mr̥gaśīrṣam🌛🌌  \,  Mē
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190508T054917
 DTEND;TZID=Asia/Calcutta:20190509T054851
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190508_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-18\, Islamic: 1440-09-03 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -22271,7 +22271,7 @@ BEGIN:VEVENT
 SUMMARY:bagalāmukhī-jayantī
 DTSTART;VALUE=DATE:20190508
 DTEND;VALUE=DATE:20190509
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:bagalāmukhī-jayantī_2019-05-08T05:49:17.760005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Vaiśākhaḥ (lunar) mo
  nth (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Bagalamukhi is 8th of t
@@ -22292,7 +22292,7 @@ BEGIN:VEVENT
 SUMMARY:vārtā-gaurī-vratam
 DTSTART;VALUE=DATE:20190508
 DTEND;VALUE=DATE:20190509
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vārtā-gaurī-vratam_2019-05-08T05:49:17.760005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Vaiśākhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -22312,7 +22312,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190508
 DTEND;VALUE=DATE:20190509
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-05-08T05:49:17.760005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -22333,7 +22333,7 @@ SUMMARY:Vaiśākhaḥ-02-05  \,Mithunam-Ārdrā🌛🌌  \,  Mēṣaḥ-Ap
  abharaṇī-01-26🌞🌌  \,  Śukraḥ-03-20🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190509T054851
 DTEND;TZID=Asia/Calcutta:20190510T054834
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190509_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-19\, Islamic: 1440-09-04 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -22389,7 +22389,7 @@ BEGIN:VEVENT
 SUMMARY:lāvaṇya-gaurī-vratam
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:lāvaṇya-gaurī-vratam_2019-05-09T05:48:51.840008+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Vaiśākhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -22409,7 +22409,7 @@ BEGIN:VEVENT
 SUMMARY:Mīnākṣī Taṅga Kudirai Vāhanam
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:MīnākṣīTaṅgaKudiraiVāhanam_2019-05-09T05:48:51.840008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/relative_event/mIn2AkSI_tirukkalyAN
@@ -22431,7 +22431,7 @@ BEGIN:VEVENT
 SUMMARY:rāmānuja-janma-nakṣatram #1003
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:rāmānuja-janma-nakṣatram#1003_2019-05-09T05:48:51.840008+05:30
 DESCRIPTION:Observed on Ārdrā nakshatra of Mēṣaḥ (sidereal solar) m
  onth (Sūryōdayaḥ/puurvaviddha). The event occurred in 4118 (Kali era).
@@ -22452,7 +22452,7 @@ BEGIN:VEVENT
 SUMMARY:sūradāsa-jayantī #542
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sūradāsa-jayantī#542_2019-05-09T05:48:51.840008+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Vaiśākhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). The event occurred in 4579 (Kali era). 
@@ -22472,7 +22472,7 @@ BEGIN:VEVENT
 SUMMARY:sarpa-pūjā
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sarpa-pūjā_2019-05-09T05:48:51.840008+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Vaiśākhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vishnu's boon to AdiSesha tha
@@ -22493,7 +22493,7 @@ BEGIN:VEVENT
 SUMMARY:Viṟanmiṇḍa Nāyanmār (6) Gurupūjai
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ViṟanmiṇḍaNāyanmār(6)Gurupūjai_2019-05-09T05:48:51.840008+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -22517,7 +22517,7 @@ BEGIN:VEVENT
 SUMMARY:śaṅkara-jayantī #2528
 DTSTART;VALUE=DATE:20190509
 DTEND;VALUE=DATE:20190510
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śaṅkara-jayantī#2528_2019-05-09T05:48:51.840008+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Vaiśākhaḥ (lunar) mo
  nth (Prātaḥ/paraviddha). The event occurred in 2593 (Kali era).  <br/><
@@ -22539,7 +22539,7 @@ SUMMARY:Vaiśākhaḥ-02-06  \,Mithunam-Punarvasuḥ🌛🌌  \,  Mēṣa
  ḥ-Apabharaṇī-01-27🌞🌌  \,  Śukraḥ-03-21🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190510T054834
 DTEND;TZID=Asia/Calcutta:20190511T054817
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190510_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-20\, Islamic: 1440-09-05 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -22596,7 +22596,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190510
 DTEND;VALUE=DATE:20190511
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-05-10T05:48:34.559998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -22618,7 +22618,7 @@ SUMMARY:kāñcī 40 jagadguru-śrī-mahādēvēndra-sarasvatī-2-ārādhan
  ā #1105
 DTSTART;VALUE=DATE:20190510
 DTEND;VALUE=DATE:20190511
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī40jagadguru-śrī-mahādēvēndra-sarasvatī-2-ārādhanā#110
  5_2019-05-10T05:48:34.559998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -22643,7 +22643,7 @@ BEGIN:VEVENT
 SUMMARY:rāmānuja-jayantī #1003
 DTSTART;VALUE=DATE:20190510
 DTEND;VALUE=DATE:20190511
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:rāmānuja-jayantī#1003_2019-05-10T05:48:34.559998+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Vaiśākhaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). The event occurred in 4118 (Kali er
@@ -22664,7 +22664,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190510T185256
 DTEND;TZID=Asia/Calcutta:20190510T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-05-10T18:52:56.639995+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -22681,7 +22681,7 @@ SUMMARY:Vaiśākhaḥ-02-07  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Mēṣ
  aḥ-Apabharaṇī-01-28🌞🌌  \,  Śukraḥ-03-22🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190511T054817
 DTEND;TZID=Asia/Calcutta:20190512T054800
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190511_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-21\, Islamic: 1440-09-06 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -22737,7 +22737,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190511T182233
 DTEND;TZID=Asia/Calcutta:20190512T054800
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-11T18:22:33.599994+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -22758,7 +22758,7 @@ BEGIN:VEVENT
 SUMMARY:gaṅgā-saptamī
 DTSTART;VALUE=DATE:20190511
 DTEND;VALUE=DATE:20190512
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:gaṅgā-saptamī_2019-05-11T05:48:17.279987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/nadI/lunar_month/tithi/02/07/gaGgA-saptamI
@@ -22780,7 +22780,7 @@ BEGIN:VEVENT
 SUMMARY:tyāgarāja-janmadinam #253
 DTSTART;VALUE=DATE:20190511
 DTEND;VALUE=DATE:20190512
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:tyāgarāja-janmadinam#253_2019-05-11T05:48:17.279987+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Vaiśākhaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). The event occurred in 4868 (Kali era).  
@@ -22803,7 +22803,7 @@ BEGIN:VEVENT
 SUMMARY:śarkarā-saptamī
 DTSTART;VALUE=DATE:20190511
 DTEND;VALUE=DATE:20190512
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śarkarā-saptamī_2019-05-11T05:48:17.279987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/02/07/zarkarA-saptamI.t
@@ -22827,7 +22827,7 @@ SUMMARY:Vaiśākhaḥ-02-08  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Mē
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190512T054800
 DTEND;TZID=Asia/Calcutta:20190513T054742
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190512_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-22\, Islamic: 1440-09-07 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -22884,7 +22884,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190512
 DTEND;VALUE=DATE:20190513
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-12T05:48:00.000016+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -22920,7 +22920,7 @@ SUMMARY:kāñcī 26 jagadguru-śrī-prajñāghanēndra-sarasvatī-ārādha
  nā #1456
 DTSTART;VALUE=DATE:20190512
 DTEND;VALUE=DATE:20190513
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī26jagadguru-śrī-prajñāghanēndra-sarasvatī-ārādhanā#14
  56_2019-05-12T05:48:00.000016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -22946,7 +22946,7 @@ SUMMARY:Vaiśākhaḥ-02-09  \,Siṁhaḥ-Maghā🌛🌌  \,  Mēṣaḥ-K
  r̥ttikā-01-30🌞🌌  \,  Śukraḥ-03-24🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190513T054742
 DTEND;TZID=Asia/Calcutta:20190514T054725
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190513_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-23\, Islamic: 1440-09-08 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -23002,7 +23002,7 @@ BEGIN:VEVENT
 SUMMARY:nerūr-śrī-sadāśiva-brahmēndra-ārādhanā #105
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:nerūr-śrī-sadāśiva-brahmēndra-ārādhanā#105_2019-05-13T05:47:4
  2.720005+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Vaiśākhaḥ (lunar) mon
@@ -23024,7 +23024,7 @@ BEGIN:VEVENT
 SUMMARY:purī gōvardhana-maṭha-pratiṣṭhāpana-jayantī #2504
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:purīgōvardhana-maṭha-pratiṣṭhāpana-jayantī#2504_2019-05-13T0
  5:47:42.720005+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Vaiśākhaḥ (lunar) mont
@@ -23048,7 +23048,7 @@ BEGIN:VEVENT
 SUMMARY:sītānavamī
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sītānavamī_2019-05-13T05:47:42.720005+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Vaiśākhaḥ (lunar) mont
  h (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refer
@@ -23068,7 +23068,7 @@ BEGIN:VEVENT
 SUMMARY:siṁhācalaṁ-candana-mahōtsavaḥ
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:siṁhācalaṁ-candana-mahōtsavaḥ_2019-05-13T05:47:42.720005+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Vaiśākhaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -23088,7 +23088,7 @@ BEGIN:VEVENT
 SUMMARY:tr̥śūr pūram
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:tr̥śūrpūram_2019-05-13T05:47:42.720005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shaiva/sidereal_solar_month/nakshatra/01/1
@@ -23111,7 +23111,7 @@ SUMMARY:vēṅkaṭācalē padmāvatī-pariṇayōtsava-prārambhaḥ (gaj
  a-vāhanam)
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpadmāvatī-pariṇayōtsava-prārambhaḥ(gaja-vāh
  anam)_2019-05-13T05:47:42.720005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -23137,7 +23137,7 @@ BEGIN:VEVENT
 SUMMARY:vasiṣṭha-maharṣi-jayantī
 DTSTART;VALUE=DATE:20190513
 DTEND;VALUE=DATE:20190514
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vasiṣṭha-maharṣi-jayantī_2019-05-13T05:47:42.720005+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Vaiśākhaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refe
@@ -23160,7 +23160,7 @@ SUMMARY:Vaiśākhaḥ-02-10  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Mē
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190514T054725
 DTEND;TZID=Asia/Calcutta:20190515T054708
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190514_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-24\, Islamic: 1440-09-09 Ramaḍ
  ān\, 🌌🌞: सं- Mēṣaḥ\, तं- Chittirai\, म- Mēṭaṁ\,
@@ -23217,7 +23217,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190514T182316
 DTEND;TZID=Asia/Calcutta:20190515T054708
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-14T18:23:16.800001+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -23240,7 +23240,7 @@ SUMMARY:kāñcī 1 jagadguru-śrī-ādi-śaṅkara-bhagavatpāda-ārādhan
  ā #2495
 DTSTART;VALUE=DATE:20190514
 DTEND;VALUE=DATE:20190515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī1jagadguru-śrī-ādi-śaṅkara-bhagavatpāda-ārādhanā#249
  5_2019-05-14T05:47:25.439994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -23265,7 +23265,7 @@ BEGIN:VEVENT
 SUMMARY:Mīnākṣī Tirukkalyāṇam
 DTSTART;VALUE=DATE:20190514
 DTEND;VALUE=DATE:20190515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:MīnākṣīTirukkalyāṇam_2019-05-14T05:47:25.439994+05:30
 DESCRIPTION:Observed on Uttaraphalgunī nakshatra of Mēṣaḥ (sidereal 
  solar) month (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<
@@ -23285,7 +23285,7 @@ BEGIN:VEVENT
 SUMMARY:nimiṣāmbā-jayantī
 DTSTART;VALUE=DATE:20190514
 DTEND;VALUE=DATE:20190515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:nimiṣāmbā-jayantī_2019-05-14T05:47:25.439994+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Vaiśākhaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -23305,7 +23305,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē padmāvatī-pariṇayam (aśva-vāhanam)
 DTSTART;VALUE=DATE:20190514
 DTEND;VALUE=DATE:20190515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpadmāvatī-pariṇayam(aśva-vāhanam)_2019-05-14T0
  5:47:25.439994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -23329,7 +23329,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-vāsavī-jayantī
 DTSTART;VALUE=DATE:20190514
 DTEND;VALUE=DATE:20190515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śrī-vāsavī-jayantī_2019-05-14T05:47:25.439994+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Vaiśākhaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -23350,7 +23350,7 @@ SUMMARY:Vaiśākhaḥ-02-11  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Vr̥ṣ
  abhaḥ-Kr̥ttikā-02-01🌞🌌  \,  Śukraḥ-03-26🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190515T054708
 DTEND;TZID=Asia/Calcutta:20190516T054659
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190515_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-25\, Islamic: 1440-09-10 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -23407,7 +23407,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190515
 DTEND;VALUE=DATE:20190516
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-15T05:47:08.159983+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -23432,7 +23432,7 @@ BEGIN:VEVENT
 SUMMARY:budha-jayantī
 DTSTART;VALUE=DATE:20190515
 DTEND;VALUE=DATE:20190516
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:budha-jayantī_2019-05-15T05:47:08.159983+05:30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Vaiśākhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -23452,7 +23452,7 @@ BEGIN:VEVENT
 SUMMARY:dvāparayugāntaḥ
 DTSTART;VALUE=DATE:20190515
 DTEND;VALUE=DATE:20190516
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dvāparayugāntaḥ_2019-05-15T05:47:08.159983+05:30
 DESCRIPTION:The day on which Vrishabha sankranti happens is also the Dvapa
  rayuganta day. Shraadhams offered on this day beget endless fruit.<br/><br
@@ -23478,7 +23478,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190515T054708
 DTEND;TZID=Asia/Calcutta:20190515T120525
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-05-15T05:47:08.1
  59983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -23498,7 +23498,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-mōhinī-ēkādaśī
 DTSTART;VALUE=DATE:20190515
 DTEND;VALUE=DATE:20190516
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sarva-mōhinī-ēkādaśī_2019-05-15T05:47:08.159983+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of vaiśākha month is known as mō
  hinī-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatl
@@ -23594,7 +23594,7 @@ SUMMARY:vēṅkaṭācalē padmāvatī-pariṇayōtsavaḥ (garuḍa-vāha
  nam)
 DTSTART;VALUE=DATE:20190512
 DTEND;VALUE=DATE:20190516
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpadmāvatī-pariṇayōtsavaḥ(garuḍa-vāhanam)_2
  019-05-12T23:59:57.120005+05:30
 DESCRIPTION:
@@ -23613,7 +23613,7 @@ SUMMARY:vēṅkaṭācalē padmāvatī-pariṇayōtsava-samāpanam (garu
  ḍa-vāhanam)
 DTSTART;VALUE=DATE:20190515
 DTEND;VALUE=DATE:20190516
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpadmāvatī-pariṇayōtsava-samāpanam(garuḍa-vā
  hanam)_2019-05-15T05:47:08.159983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -23639,7 +23639,7 @@ BEGIN:VEVENT
 SUMMARY:vr̥ṣabha-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190515T054708
 DTEND;TZID=Asia/Calcutta:20190515T170841
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vr̥ṣabha-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ_2019-05
  -15T05:47:08.159983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -23662,7 +23662,7 @@ SUMMARY:Vaiśākhaḥ-02-12  \,Kanyā-Citrā🌛🌌  \,  Vr̥ṣabhaḥ-K
  r̥ttikā-02-02🌞🌌  \,  Śukraḥ-03-27🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190516T054659
 DTEND;TZID=Asia/Calcutta:20190517T054642
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190516_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-26\, Islamic: 1440-09-11 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -23719,7 +23719,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190516T182342
 DTEND;TZID=Asia/Calcutta:20190517T054642
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-16T18:23:42.719997+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -23740,7 +23740,7 @@ BEGIN:VEVENT
 SUMMARY:girijā-vivāhaḥ
 DTSTART;VALUE=DATE:20190516
 DTEND;VALUE=DATE:20190517
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:girijā-vivāhaḥ_2019-05-16T05:46:59.519998+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Vaiśākhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -23760,7 +23760,7 @@ BEGIN:VEVENT
 SUMMARY:madhusūdana-pūjā
 DTSTART;VALUE=DATE:20190516
 DTEND;VALUE=DATE:20190517
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:madhusūdana-pūjā_2019-05-16T05:46:59.519998+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Vaiśākhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>vaiśākhamāsi dvādaśyā
@@ -23782,7 +23782,7 @@ BEGIN:VEVENT
 SUMMARY:paraśurāma-dvādaśī
 DTSTART;VALUE=DATE:20190516
 DTEND;VALUE=DATE:20190517
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:paraśurāma-dvādaśī_2019-05-16T05:46:59.519998+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Vaiśākhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>vaiśākhaśuklaikādaśyām
@@ -23808,7 +23808,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190516T182342
 DTEND;TZID=Asia/Calcutta:20190516T194906
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-05-16T18:23:42.719997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -23826,7 +23826,7 @@ BEGIN:VEVENT
 SUMMARY:rukmiṇī-dvādaśī
 DTSTART;VALUE=DATE:20190516
 DTEND;VALUE=DATE:20190517
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:rukmiṇī-dvādaśī_2019-05-16T05:46:59.519998+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Vaiśākhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -23847,7 +23847,7 @@ SUMMARY:Vaiśākhaḥ-02-13  \,Tulā-Svātī🌛🌌  \,  Vr̥ṣabhaḥ-K
  r̥ttikā-02-03🌞🌌  \,  Śukraḥ-03-28🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190517T054642
 DTEND;TZID=Asia/Calcutta:20190518T054633
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190517_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-27\, Islamic: 1440-09-12 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -23904,7 +23904,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-17T05:46:42.239987+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -23944,7 +23944,7 @@ BEGIN:VEVENT
 SUMMARY:chinnamastā-jayantī
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:chinnamastā-jayantī_2019-05-17T05:46:42.239987+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Vaiśākhaḥ (lunar) 
  month (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Chinnamasta is 6th of
@@ -23964,7 +23964,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-05-17T05:46:42.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -23986,7 +23986,7 @@ SUMMARY:kāñcī 39 jagadguru-śrī-saccidvilāsēndra-sarasvatī-ārādha
  nā #1147
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī39jagadguru-śrī-saccidvilāsēndra-sarasvatī-ārādhanā#11
  47_2019-05-17T05:46:42.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -24011,7 +24011,7 @@ BEGIN:VEVENT
 SUMMARY:nr̥siṁha-jayantī
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:nr̥siṁha-jayantī_2019-05-17T05:46:42.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/02/14/nRsiMha~
@@ -24033,7 +24033,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsa-antimatrayatithi-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsa-antimatrayatithi-vrata-ārambhaḥ_2019-05-17T05:46:4
  2.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -24056,7 +24056,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsa-antimatrayatithi-vratam
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsa-antimatrayatithi-vratam_2019-05-17T05:46:42.239987+05
  :30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -24079,7 +24079,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190517
 DTEND;VALUE=DATE:20190518
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-05-17T05:46:42.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -24102,7 +24102,7 @@ SUMMARY:Vaiśākhaḥ-02-15  \,Tulā-Viśākhā🌛🌌  \,  Vr̥ṣabha
  ḥ-Kr̥ttikā-02-04🌞🌌  \,  Śukraḥ-03-29🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190518T054633
 DTEND;TZID=Asia/Calcutta:20190519T054616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190518_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-28\, Islamic: 1440-09-13 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -24159,7 +24159,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -24194,7 +24194,7 @@ BEGIN:VEVENT
 SUMMARY:annamācārya-jayantī
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:annamācārya-jayantī_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vaiśākhaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refe
@@ -24215,7 +24215,7 @@ BEGIN:VEVENT
 SUMMARY:ardhanārīśvara-vratam
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ardhanārīśvara-vratam_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vaiśākhaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -24235,7 +24235,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190518T232715
 DTEND;TZID=Asia/Calcutta:20190518T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-05-18T23:27:15.839997+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -24251,7 +24251,7 @@ BEGIN:VEVENT
 SUMMARY:kāñcī-kāmakōṭi-maṭha-pratiṣṭhāpana-jayantī #2501
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī-kāmakōṭi-maṭha-pratiṣṭhāpana-jayantī#2501_2019-05
  -18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vaiśākhaḥ (lunar) mont
@@ -24275,7 +24275,7 @@ BEGIN:VEVENT
 SUMMARY:Nammāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:NammāḻvārTirunakṣattiram_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Viśākhā nakshatra of Vr̥ṣabhaḥ (sidereal s
  olar) month (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -24295,7 +24295,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -24316,7 +24316,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -24340,7 +24340,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -24360,7 +24360,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -24379,7 +24379,7 @@ BEGIN:VEVENT
 SUMMARY:sampat-gaurī-vratam
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sampat-gaurī-vratam_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vaiśākhaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -24399,7 +24399,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-05-18T05:46:33.6000
  02+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -24422,7 +24422,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsaḥantimatrayatithi-vratam
 DTSTART;VALUE=DATE:20190516
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsaḥantimatrayatithi-vratam_2019-05-16T23:59:57.120005+
  05:30
 DESCRIPTION:
@@ -24439,7 +24439,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsa-antimatrayatithi-vrata-samāpanam
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsa-antimatrayatithi-vrata-samāpanam_2019-05-18T05:46:33
  .600002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -24462,7 +24462,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-pūrṇimā-snānam
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-pūrṇimā-snānam_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/02/15/vaizAkha-pUrNimA-
@@ -24483,7 +24483,7 @@ BEGIN:VEVENT
 SUMMARY:śarabha-jayantī
 DTSTART;VALUE=DATE:20190518
 DTEND;VALUE=DATE:20190519
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śarabha-jayantī_2019-05-18T05:46:33.600002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vaiśākhaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -24505,7 +24505,7 @@ SUMMARY:Vaiśākhaḥ-02-16  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Vr̥
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190519T054616
 DTEND;TZID=Asia/Calcutta:20190520T054607
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190519_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-29\, Islamic: 1440-09-14 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -24562,7 +24562,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190519
 DTEND;VALUE=DATE:20190520
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-19T05:46:16.319991+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -24609,7 +24609,7 @@ SUMMARY:kāñcī 68 jagadguru-śrī-candraśēkharēndra-sarasvatī-7-jaya
  ntī #126
 DTSTART;VALUE=DATE:20190519
 DTEND;VALUE=DATE:20190520
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī68jagadguru-śrī-candraśēkharēndra-sarasvatī-7-jayantī#1
  26_2019-05-19T05:46:16.319991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -24634,7 +24634,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190519
 DTEND;VALUE=DATE:20190520
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-05-19T05:46:
  16.319991+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -24661,7 +24661,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190519
 DTEND;VALUE=DATE:20190520
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-05-19T05:46:16.319991+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -24680,7 +24680,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190519
 DTEND;VALUE=DATE:20190520
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-05-19T05:46:16.319991+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -24701,7 +24701,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruvaḷḷuva Nāyanmār Jayantī
 DTSTART;VALUE=DATE:20190519
 DTEND;VALUE=DATE:20190520
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:TiruvaḷḷuvaNāyanmārJayantī_2019-05-19T05:46:16.319991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/smArta-misc/sidereal_solar_month/naks
@@ -24725,7 +24725,7 @@ SUMMARY:Vaiśākhaḥ-02-17  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Vr
  maḥ
 DTSTART;TZID=Asia/Calcutta:20190520T054607
 DTEND;TZID=Asia/Calcutta:20190521T054559
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190520_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-30\, Islamic: 1440-09-15 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -24782,7 +24782,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190520T182451
 DTEND;TZID=Asia/Calcutta:20190521T054559
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-20T18:24:51.840000+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -24804,7 +24804,7 @@ BEGIN:VEVENT
 SUMMARY:nārada-jayantī
 DTSTART;VALUE=DATE:20190520
 DTEND;VALUE=DATE:20190521
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:nārada-jayantī_2019-05-20T05:46:07.680006+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvitīyā tithi of Vaiśākhaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Avataram of nārada muni
@@ -24826,7 +24826,7 @@ SUMMARY:Vaiśākhaḥ-02-18  \,Dhanuḥ-Mūlā🌛🌌  \,  Vr̥ṣabhaḥ
  -Kr̥ttikā-02-07🌞🌌  \,  Śuciḥ-04-01🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190521T054559
 DTEND;TZID=Asia/Calcutta:20190522T054550
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190521_day_summary
 DESCRIPTION:- Indian civil date: 1941-02-31\, Islamic: 1440-09-16 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -24882,7 +24882,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-21T05:45:59.039980+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -24908,7 +24908,7 @@ SUMMARY:kāñcī 70 jagadguru-śrī-śaṅkara-vijayēndra-sarasvatī-āś
  rama-svīkāra-dinam #37
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī70jagadguru-śrī-śaṅkara-vijayēndra-sarasvatī-āśrama-s
  vīkāra-dinam#37_2019-05-21T05:45:59.039980+05:30
 DESCRIPTION:Observed on Mūlā nakshatra of Vr̥ṣabhaḥ (sidereal solar
@@ -24935,7 +24935,7 @@ BEGIN:VEVENT
 SUMMARY:Muruga Nāyanmār (16) Gurupūjai
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:MurugaNāyanmār(16)Gurupūjai_2019-05-21T05:45:59.039980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -24958,7 +24958,7 @@ BEGIN:VEVENT
 SUMMARY:pārthiva-kalpādiḥ
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārthiva-kalpādiḥ_2019-05-21T05:45:59.039980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/02/18/pArth
@@ -24979,7 +24979,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190521T132905
 DTEND;TZID=Asia/Calcutta:20190521T182509
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ṣaḍaśīti-puṇyakālaḥ_2019-05-21T13:29:05.280012+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -24999,7 +24999,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190521T070511
 DTEND;TZID=Asia/Calcutta:20190521T182509
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-05-21T07:05:11.039995
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25018,7 +25018,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190521T120534
 DTEND;TZID=Asia/Calcutta:20190521T182509
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-05-21T12:
  05:34.079996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25039,7 +25039,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruñānasambandhamūrtti Nāyanmār (28) Gurupūjai
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:TiruñānasambandhamūrttiNāyanmār(28)Gurupūjai_2019-05-21T05:45:59
  .039980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25065,7 +25065,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunīlakaṇṭha Yāḻppāṇa Nāyanmār (61) Gurupūjai
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:TirunīlakaṇṭhaYāḻppāṇaNāyanmār(61)Gurupūjai_2019-05-21T0
  5:45:59.039980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25091,7 +25091,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunīlanakka Nāyanmār (26) Gurupūjai
 DTSTART;VALUE=DATE:20190521
 DTEND;VALUE=DATE:20190522
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:TirunīlanakkaNāyanmār(26)Gurupūjai_2019-05-21T05:45:59.039980+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25115,7 +25115,7 @@ BEGIN:VEVENT
 SUMMARY:śuci-māsaḥ
 DTSTART;TZID=Asia/Calcutta:20190521T132905
 DTEND;TZID=Asia/Calcutta:20190521T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śuci-māsaḥ_2019-05-21T13:29:05.280012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -25136,7 +25136,7 @@ SUMMARY:Vaiśākhaḥ-02-19  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Vr
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190522T054550
 DTEND;TZID=Asia/Calcutta:20190523T054541
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190522_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-01\, Islamic: 1440-09-17 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25193,7 +25193,7 @@ BEGIN:VEVENT
 SUMMARY:ēkadanta-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20190522
 DTEND;VALUE=DATE:20190523
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ēkadanta-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-05-22T
  05:45:50.399995+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -25222,7 +25222,7 @@ SUMMARY:kāñcī 30 jagadguru-śrī-bōdhēndra-sarasvatī-2-ārādhanā #
  1365
 DTSTART;VALUE=DATE:20190522
 DTEND;VALUE=DATE:20190523
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī30jagadguru-śrī-bōdhēndra-sarasvatī-2-ārādhanā#1365_20
  19-05-22T05:45:50.399995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25247,7 +25247,7 @@ BEGIN:VEVENT
 SUMMARY:Mayilai Veḷḷīśvarar Brahmōtsavam
 DTSTART;VALUE=DATE:20190522
 DTEND;VALUE=DATE:20190523
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:MayilaiVeḷḷīśvararBrahmōtsavam_2019-05-22T05:45:50.399995+05:30
 DESCRIPTION:Observed on day 8 of Vr̥ṣabhaḥ (sidereal solar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/>Enactment of restoration of eyesigh
@@ -25268,7 +25268,7 @@ BEGIN:VEVENT
 SUMMARY:sāvitrī-vratam
 DTSTART;VALUE=DATE:20190522
 DTEND;VALUE=DATE:20190523
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sāvitrī-vratam_2019-05-22T05:45:50.399995+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturthī tithi of Vaiśākhaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -25290,7 +25290,7 @@ SUMMARY:Vaiśākhaḥ-02-20  \,Dhanuḥ-Uttarāṣāḍhā🌛🌌  \,  Vr
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190523T054541
 DTEND;TZID=Asia/Calcutta:20190524T054533
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190523_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-02\, Islamic: 1440-09-18 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25347,7 +25347,7 @@ BEGIN:VEVENT
 SUMMARY:kaśyapa-maharṣi-jayantī
 DTSTART;VALUE=DATE:20190523
 DTEND;VALUE=DATE:20190524
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kaśyapa-maharṣi-jayantī_2019-05-23T05:45:41.760010+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Vaiśākhaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -25370,7 +25370,7 @@ SUMMARY:Vaiśākhaḥ-02-21  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  V
  kraḥ
 DTSTART;TZID=Asia/Calcutta:20190524T054533
 DTEND;TZID=Asia/Calcutta:20190525T054524
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190524_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-03\, Islamic: 1440-09-19 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25428,7 +25428,7 @@ SUMMARY:Vaiśākhaḥ-02-21  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190525T054524
 DTEND;TZID=Asia/Calcutta:20190526T054524
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190525_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-04\, Islamic: 1440-09-20 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25485,7 +25485,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;VALUE=DATE:20190525
 DTEND;VALUE=DATE:20190526
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-05-25T10:13:14.880018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -25507,7 +25507,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190525
 DTEND;VALUE=DATE:20190526
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-05-25T05:45:24.479999+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -25528,7 +25528,7 @@ SUMMARY:Vaiśākhaḥ-02-22  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190526T054524
 DTEND;TZID=Asia/Calcutta:20190527T054515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190526_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-05\, Islamic: 1440-09-21 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25585,7 +25585,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190526T182635
 DTEND;TZID=Asia/Calcutta:20190527T054515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-26T18:26:35.519985+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -25606,7 +25606,7 @@ BEGIN:VEVENT
 SUMMARY:bhānusaptamī
 DTSTART;VALUE=DATE:20190526
 DTEND;VALUE=DATE:20190527
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:bhānusaptamī_2019-05-26T05:45:24.479999+05:30
 DESCRIPTION:saptamī tithi on a Sunday is as sacred as a solar eclipse. Pa
  rticularly good for worshipping Surya.<br/><br/>amāvāsyā tu sōmēna sa
@@ -25628,7 +25628,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190526T054524
 DTEND;TZID=Asia/Calcutta:20190526T084935
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-05-26T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -25647,7 +25647,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190526
 DTEND;VALUE=DATE:20190527
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-05-26T05:45:24.479999+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -25666,7 +25666,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190526
 DTEND;VALUE=DATE:20190527
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-05-26T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -25690,7 +25690,7 @@ SUMMARY:Vaiśākhaḥ-02-23  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190527T054515
 DTEND;TZID=Asia/Calcutta:20190528T054515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190527_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-06\, Islamic: 1440-09-22 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25747,7 +25747,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190527
 DTEND;VALUE=DATE:20190528
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-05-27T05:45:15.840013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -25783,7 +25783,7 @@ SUMMARY:kāñcī 7 jagadguru-śrī-ānandajñānēndra-sarasvatī-ārādha
  nā #2074
 DTSTART;VALUE=DATE:20190527
 DTEND;VALUE=DATE:20190528
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī7jagadguru-śrī-ānandajñānēndra-sarasvatī-ārādhanā#20
  74_2019-05-27T05:45:15.840013+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -25810,7 +25810,7 @@ SUMMARY:Vaiśākhaḥ-02-24  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌
  , Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190528T054515
 DTEND;TZID=Asia/Calcutta:20190529T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190528_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-07\, Islamic: 1440-09-23 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25869,7 +25869,7 @@ SUMMARY:Vaiśākhaḥ-02-25  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \
   Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190529T054507
 DTEND;TZID=Asia/Calcutta:20190530T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190529_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-08\, Islamic: 1440-09-24 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -25926,7 +25926,7 @@ BEGIN:VEVENT
 SUMMARY:āyuṣmad-bava-saumya-saṁyōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190529T152133
 DTEND;TZID=Asia/Calcutta:20190529T182727
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:āyuṣmad-bava-saumya-saṁyōgaḥ_2019-05-29T15:21:33.120016+05:30
 DESCRIPTION:A rare combination of āyuṣmān yōga\, bava karaṇa and sa
  umyavāsara.<br/><br/>## Details<br/>- References<br/>  - Maha Periva / De
@@ -25943,7 +25943,7 @@ BEGIN:VEVENT
 SUMMARY:agninakṣatram
 DTSTART;VALUE=DATE:20190503
 DTEND;VALUE=DATE:20190529
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:agninakṣatram_2019-05-03T23:59:57.120005+05:30
 DESCRIPTION:The period agninakṣatram\, the transit of the Sun through kr
  ̥ttikā asterism.<br/><br/>## Details<br/>- [Edit config file](https://gi
@@ -25962,7 +25962,7 @@ BEGIN:VEVENT
 SUMMARY:agninakṣatra-samāpanam
 DTSTART;TZID=Asia/Calcutta:20190528T235957
 DTEND;TZID=Asia/Calcutta:20190529T072804
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:agninakṣatra-samāpanam_2019-05-28T23:59:57.120005+05:30
 DESCRIPTION:The end of the period agninakṣatram\, the transit of the Sun
   through kr̥ttikā asterism.<br/><br/>## Details<br/>- [Edit config file]
@@ -25978,7 +25978,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-hanūmat-jayantī (āndhra-sampradāyaḥ)
 DTSTART;VALUE=DATE:20190529
 DTEND;VALUE=DATE:20190530
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śrī-hanūmat-jayantī(āndhra-sampradāyaḥ)_2019-05-29T05:45:07.19
  9988+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Daśamī tithi of Vaiśākhaḥ (lunar
@@ -26001,7 +26001,7 @@ SUMMARY:Vaiśākhaḥ-02-26  \,Mīnaḥ-Rēvatī🌛🌌  \,  Vr̥ṣabha
  ḥ-Rōhiṇī-02-16🌞🌌  \,  Śuciḥ-04-10🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190530T054507
 DTEND;TZID=Asia/Calcutta:20190531T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190530_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-09\, Islamic: 1440-09-25 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -26058,7 +26058,7 @@ BEGIN:VEVENT
 SUMMARY:bhadrakālī-jayantī
 DTSTART;VALUE=DATE:20190530
 DTEND;VALUE=DATE:20190531
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:bhadrakālī-jayantī_2019-05-30T05:45:07.199988+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ēkādaśī tithi of Vaiśākhaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -26079,7 +26079,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-aparā-ēkādaśī
 DTSTART;VALUE=DATE:20190530
 DTEND;VALUE=DATE:20190531
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sarva-aparā-ēkādaśī_2019-05-30T05:45:07.199988+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of vaiśākha month is known as ap
  arā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatly
@@ -26178,7 +26178,7 @@ SUMMARY:Vaiśākhaḥ-02-27  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Vr̥ṣabh
  aḥ-Rōhiṇī-02-17🌞🌌  \,  Śuciḥ-04-11🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190531T054507
 DTEND;TZID=Asia/Calcutta:20190601T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190531_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-10\, Islamic: 1440-09-26 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -26235,7 +26235,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190531T182801
 DTEND;TZID=Asia/Calcutta:20190531T195242
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-05-31T18:28:01.919999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -26255,7 +26255,7 @@ SUMMARY:Vaiśākhaḥ-02-28  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190601T054507
 DTEND;TZID=Asia/Calcutta:20190602T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190601_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-11\, Islamic: 1440-09-27 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -26312,7 +26312,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190601T182819
 DTEND;TZID=Asia/Calcutta:20190602T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-01T18:28:19.200010+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -26333,7 +26333,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190602T000800
 DTEND;TZID=Asia/Calcutta:20190601T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-06-02T00:08:00.959988+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -26349,7 +26349,7 @@ BEGIN:VEVENT
 SUMMARY:Kaḻaṟchiṅga Nāyanmār (53) Gurupūjai
 DTSTART;VALUE=DATE:20190601
 DTEND;VALUE=DATE:20190602
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:KaḻaṟchiṅgaNāyanmār(53)Gurupūjai_2019-06-01T05:45:07.199988+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -26373,7 +26373,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190601
 DTEND;VALUE=DATE:20190602
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-06-01T05:45:07.199988+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -26393,7 +26393,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190601
 DTEND;VALUE=DATE:20190602
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-06-01T05:45:07.199988+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -26413,7 +26413,7 @@ SUMMARY:Vaiśākhaḥ-02-29  \,Mēṣaḥ-Kr̥ttikā🌛🌌  \,  Vr̥ṣa
  bhaḥ-Rōhiṇī-02-19🌞🌌  \,  Śuciḥ-04-13🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190602T054507
 DTEND;TZID=Asia/Calcutta:20190603T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190602_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-12\, Islamic: 1440-09-28 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -26469,7 +26469,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190602
 DTEND;VALUE=DATE:20190603
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-02T05:45:07.199988+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -26509,7 +26509,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-vaiśākha-amāvāsyā
 DTSTART;VALUE=DATE:20190602
 DTEND;VALUE=DATE:20190603
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-vaiśākha-amāvāsyā_2019-06-02T05:45:07.199
  988+05:30
 DESCRIPTION:
@@ -26526,7 +26526,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–udayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190601T235957
 DTEND;TZID=Asia/Calcutta:20190602T163149
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–udayaḥ(prāk)_2019-06-01T23:59:57.120005+05:30
 DESCRIPTION:budhaḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Jun-02 16:31. At this moment budhaḥ is at mr̥gaśīrṣam-
@@ -26546,7 +26546,7 @@ SUMMARY:kāñcī 3 jagadguru-śrī-sarvajñātmēndra-sarasvatī-ārādhan
  ā #2383
 DTSTART;VALUE=DATE:20190602
 DTEND;VALUE=DATE:20190603
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī3jagadguru-śrī-sarvajñātmēndra-sarasvatī-ārādhanā#238
  3_2019-06-02T05:45:07.199988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -26571,7 +26571,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190602
 DTEND;VALUE=DATE:20190603
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-06-02T05:45:07.199988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -26592,7 +26592,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190602
 DTEND;VALUE=DATE:20190603
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-06-02T05:45:07.199988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -26613,7 +26613,7 @@ SUMMARY:Vaiśākhaḥ-02-30  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190603T054507
 DTEND;TZID=Asia/Calcutta:20190604T054507
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190603_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-13\, Islamic: 1440-09-29 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -26668,7 +26668,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -26703,7 +26703,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-iṣṭiḥ
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-iṣṭiḥ_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:iṣṭiḥ is performed on this day by those following the b
  ōdhāyana/kātyāyana sūtras. This difference happens because chandradar
@@ -26725,7 +26725,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -26746,7 +26746,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -26767,7 +26767,7 @@ BEGIN:VEVENT
 SUMMARY:sōmavatī amāvāsyā
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sōmavatīamāvāsyā_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/amAvAsyA/description_only/sOma
@@ -26788,7 +26788,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-amāvāsyā (alabhyam–puṣkalā)
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-amāvāsyā(alabhyam–puṣkalā)_2019-06-03T05:45:07.1999
  88+05:30
 DESCRIPTION:amāvāsyā of the vaiśākha month.<br/><br/>## Details<br/>-
@@ -26816,7 +26816,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsaḥ
 DTSTART;VALUE=DATE:20190504
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsaḥ_2019-05-04T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/vaizAkha-mAsaH.t
@@ -26837,7 +26837,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-māsa-samāpanam
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-māsa-samāpanam_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Vaiśākhaḥ (lunar) month (
  Sūryōdayaḥ/paraviddha). <br/><br/>vaiśākha-māsaḥ ends today<br/><
@@ -26857,7 +26857,7 @@ BEGIN:VEVENT
 SUMMARY:vaiśākha-snānapūrtiḥ
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaiśākha-snānapūrtiḥ_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Vaiśākhaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/>mādhavē mēṣagē bhānau murā
@@ -26879,7 +26879,7 @@ BEGIN:VEVENT
 SUMMARY:śani-jayantī
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śani-jayantī_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Vaiśākhaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Referen
@@ -26899,7 +26899,7 @@ BEGIN:VEVENT
 SUMMARY:śuka-maharṣi-jayantī
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190604
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śuka-maharṣi-jayantī_2019-06-03T05:45:07.199988+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Vaiśākhaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -26921,7 +26921,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-01  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛🌌
  , Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190604T054507
 DTEND;TZID=Asia/Calcutta:20190605T054515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190604_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-14\, Islamic: 1440-09-30 Ramaḍ
  ān\, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭava
@@ -26978,7 +26978,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -27024,7 +27024,7 @@ BEGIN:VEVENT
 SUMMARY:bhadra-catuṣṭaya-vratam
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:bhadra-catuṣṭaya-vratam_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Jyaiṣṭhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -27044,7 +27044,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190604T182911
 DTEND;TZID=Asia/Calcutta:20190604T192913
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-06-04T18:29:11.040003+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -27063,7 +27063,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -27082,7 +27082,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190604T135736
 DTEND;TZID=Asia/Calcutta:20190604T230706
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-06-04T13:57:36.000003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -27101,7 +27101,7 @@ BEGIN:VEVENT
 SUMMARY:jyaiṣṭha-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:jyaiṣṭha-māsa-ārambhaḥ_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/03/01/jyaiShTha
@@ -27123,7 +27123,7 @@ BEGIN:VEVENT
 SUMMARY:karavīra-vratam
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:karavīra-vratam_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Jyaiṣṭhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of karavīra p
@@ -27146,7 +27146,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-06-04T05:45:07.199988
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -27172,7 +27172,7 @@ BEGIN:VEVENT
 SUMMARY:punnāga-gaurī-vratam
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:punnāga-gaurī-vratam_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Jyaiṣṭhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -27192,7 +27192,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -27214,7 +27214,7 @@ SUMMARY:śr̥ṅgērī 32 jagadguru-śrī-nr̥siṁha bhāratī-ārādhan
  ā
 DTSTART;VALUE=DATE:20190604
 DTEND;VALUE=DATE:20190605
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śr̥ṅgērī32jagadguru-śrī-nr̥siṁhabhāratī-ārādhanā_2019-
  06-04T05:45:07.199988+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Jyaiṣṭhaḥ (lunar) 
@@ -27238,7 +27238,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190604T110548
 DTEND;TZID=Asia/Calcutta:20190604T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-06-04T11:05:48.480012+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -27255,7 +27255,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-02  \,Mithunam-Ārdrā🌛🌌  \,  Vr̥ṣabha
  ḥ-Rōhiṇī-02-22🌞🌌  \,  Śuciḥ-04-16🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190605T054515
 DTEND;TZID=Asia/Calcutta:20190606T054515
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190605_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-15\, Islamic: 1440-10-01 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -27313,7 +27313,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-03  \,Mithunam-Punarvasuḥ🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190606T054515
 DTEND;TZID=Asia/Calcutta:20190607T054524
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190606_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-16\, Islamic: 1440-10-02 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -27369,7 +27369,7 @@ BEGIN:VEVENT
 SUMMARY:gurupuṣya-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190606T202707
 DTEND;TZID=Asia/Calcutta:20190606T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:gurupuṣya-yōgaḥ_2019-06-06T20:27:07.200012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/gurupuS
@@ -27387,7 +27387,7 @@ BEGIN:VEVENT
 SUMMARY:rambhā-tr̥tīyā
 DTSTART;VALUE=DATE:20190606
 DTEND;VALUE=DATE:20190607
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:rambhā-tr̥tīyā_2019-06-06T05:45:15.840013+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/03/03/rambhA~tRtIyA.tom
@@ -27408,7 +27408,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190606
 DTEND;VALUE=DATE:20190607
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-06-06T05:45:15.840013+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -27430,7 +27430,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-04  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Vr̥
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190607T054524
 DTEND;TZID=Asia/Calcutta:20190608T054524
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190607_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-17\, Islamic: 1440-10-03 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -27486,7 +27486,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190607
 DTEND;VALUE=DATE:20190608
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-06-07T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -27507,7 +27507,7 @@ BEGIN:VEVENT
 SUMMARY:kadalī-gaurī-vratam/pūjā
 DTSTART;VALUE=DATE:20190607
 DTEND;VALUE=DATE:20190608
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kadalī-gaurī-vratam/pūjā_2019-06-07T05:45:24.479999+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Jyaiṣṭhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of Shiva-Parva
@@ -27531,7 +27531,7 @@ BEGIN:VEVENT
 SUMMARY:Naminandiyaḍigaḷ Nāyanmār (27) Gurupūjai
 DTSTART;VALUE=DATE:20190607
 DTEND;VALUE=DATE:20190608
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:NaminandiyaḍigaḷNāyanmār(27)Gurupūjai_2019-06-07T05:45:24.47999
  9+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -27555,7 +27555,7 @@ BEGIN:VEVENT
 SUMMARY:umā-avatāraḥ
 DTSTART;VALUE=DATE:20190607
 DTEND;VALUE=DATE:20190608
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:umā-avatāraḥ_2019-06-07T05:45:24.479999+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Jyaiṣṭhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of Uma-Maheshv
@@ -27579,7 +27579,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-06  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Vr
  iḥ
 DTSTART;TZID=Asia/Calcutta:20190608T054524
 DTEND;TZID=Asia/Calcutta:20190609T054533
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190608_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-18\, Islamic: 1440-10-04 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -27635,7 +27635,7 @@ BEGIN:VEVENT
 SUMMARY:āraṇya-gaurī-vratam
 DTSTART;VALUE=DATE:20190608
 DTEND;VALUE=DATE:20190609
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:āraṇya-gaurī-vratam_2019-06-08T05:45:24.479999+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Jyaiṣṭhaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -27655,7 +27655,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190608
 DTEND;VALUE=DATE:20190609
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-06-08T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -27677,7 +27677,7 @@ SUMMARY:kāñcī 50 jagadguru-śrī-candracūḍēndra-sarasvatī-2-ārād
  hanā #723
 DTSTART;VALUE=DATE:20190608
 DTEND;VALUE=DATE:20190609
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī50jagadguru-śrī-candracūḍēndra-sarasvatī-2-ārādhanā#
  723_2019-06-08T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -27703,7 +27703,7 @@ SUMMARY:kāñcī 6 jagadguru-śrī-śuddhānandēndra-sarasvatī-ārādhan
  ā #2143
 DTSTART;VALUE=DATE:20190608
 DTEND;VALUE=DATE:20190609
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī6jagadguru-śrī-śuddhānandēndra-sarasvatī-ārādhanā#214
  3_2019-06-08T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -27728,7 +27728,7 @@ BEGIN:VEVENT
 SUMMARY:Sōmāsimāra Nāyanmār (33) Gurupūjai
 DTSTART;VALUE=DATE:20190608
 DTEND;VALUE=DATE:20190609
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:SōmāsimāraNāyanmār(33)Gurupūjai_2019-06-08T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -27751,7 +27751,7 @@ BEGIN:VEVENT
 SUMMARY:vindhyāvāsinī-dēvī-pūjā
 DTSTART;VALUE=DATE:20190608
 DTEND;VALUE=DATE:20190609
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vindhyāvāsinī-dēvī-pūjā_2019-06-08T05:45:24.479999+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Jyaiṣṭhaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -27773,7 +27773,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-07  \,Siṁhaḥ-Maghā🌛🌌  \,  Vr̥ṣabh
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190609T054533
 DTEND;TZID=Asia/Calcutta:20190610T054541
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190609_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-19\, Islamic: 1440-10-05 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -27829,7 +27829,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190609T183046
 DTEND;TZID=Asia/Calcutta:20190610T054541
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-09T18:30:46.080002+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -27850,7 +27850,7 @@ BEGIN:VEVENT
 SUMMARY:dhūmāvatī-jayantī
 DTSTART;VALUE=DATE:20190609
 DTEND;VALUE=DATE:20190610
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dhūmāvatī-jayantī_2019-06-09T05:45:33.119984+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Jyaiṣṭhaḥ (lunar
  ) month (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Dhumavati is 7th of
@@ -27873,7 +27873,7 @@ SUMMARY:kāñcī 23 jagadguru-śrī-saccitsukhēndra-sarasvatī-ārādhan
  ā #1508
 DTSTART;VALUE=DATE:20190609
 DTEND;VALUE=DATE:20190610
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī23jagadguru-śrī-saccitsukhēndra-sarasvatī-ārādhanā#1508
  _2019-06-09T05:45:33.119984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -27898,7 +27898,7 @@ BEGIN:VEVENT
 SUMMARY:varuṇa-pūjā
 DTSTART;VALUE=DATE:20190609
 DTEND;VALUE=DATE:20190610
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:varuṇa-pūjā_2019-06-09T05:45:33.119984+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Jyaiṣṭhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -27917,7 +27917,7 @@ BEGIN:VEVENT
 SUMMARY:vijayā-bhānusaptamī
 DTSTART;VALUE=DATE:20190609
 DTEND;VALUE=DATE:20190610
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vijayā-bhānusaptamī_2019-06-09T05:45:33.119984+05:30
 DESCRIPTION:saptamī tithi on a Sunday is as sacred as a solar eclipse. Pa
  rticularly good for worshipping Surya. When śukla saptamī is present at 
@@ -27942,7 +27942,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-08  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  V
  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190610T054541
 DTEND;TZID=Asia/Calcutta:20190611T054541
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190610_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-20\, Islamic: 1440-10-06 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -27998,7 +27998,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190610
 DTEND;VALUE=DATE:20190611
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-10T05:45:41.760010+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -28033,7 +28033,7 @@ BEGIN:VEVENT
 SUMMARY:jyēṣṭhāṣṭamī
 DTSTART;VALUE=DATE:20190610
 DTEND;VALUE=DATE:20190611
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:jyēṣṭhāṣṭamī_2019-06-10T05:45:41.760010+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Jyaiṣṭhaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -28054,7 +28054,7 @@ SUMMARY:kāñcī 16 jagadguru-śrī-ujjvala-śaṅkarēndra-sarasvatī-ār
  ādhanā #1653
 DTSTART;VALUE=DATE:20190610
 DTEND;VALUE=DATE:20190611
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī16jagadguru-śrī-ujjvala-śaṅkarēndra-sarasvatī-ārādhan
  ā#1653_2019-06-10T05:45:41.760010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -28081,7 +28081,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-09  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Vr̥
  Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190611T054541
 DTEND;TZID=Asia/Calcutta:20190612T054550
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190611_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-21\, Islamic: 1440-10-07 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -28137,7 +28137,7 @@ BEGIN:VEVENT
 SUMMARY:brahmāṇī-pūjā
 DTSTART;VALUE=DATE:20190611
 DTEND;VALUE=DATE:20190612
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:brahmāṇī-pūjā_2019-06-11T05:45:41.760010+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Jyaiṣṭhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>brahmāṇī is one of the se
@@ -28157,7 +28157,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-3
 DTSTART;VALUE=DATE:20190611
 DTEND;VALUE=DATE:20190612
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-3_2019-06-11T05:45:41.760010+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Jyaiṣṭhaḥ (lunar) m
  onth (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -28177,7 +28177,7 @@ SUMMARY:kāñcī 61 jagadguru-śrī-mahādēvēndra-sarasvatī-4-ārādhan
  ā #274
 DTSTART;VALUE=DATE:20190611
 DTEND;VALUE=DATE:20190612
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī61jagadguru-śrī-mahādēvēndra-sarasvatī-4-ārādhanā#274
  _2019-06-11T05:45:41.760010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -28202,7 +28202,7 @@ BEGIN:VEVENT
 SUMMARY:mahēśa-navamī
 DTSTART;VALUE=DATE:20190611
 DTEND;VALUE=DATE:20190612
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:mahēśa-navamī_2019-06-11T05:45:41.760010+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Jyaiṣṭhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Re
@@ -28223,7 +28223,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190611
 DTEND;VALUE=DATE:20190612
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-06-11T05:45:41.760010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -28245,7 +28245,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-dēvī-pūjā
 DTSTART;VALUE=DATE:20190611
 DTEND;VALUE=DATE:20190612
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śukla-dēvī-pūjā_2019-06-11T05:45:41.760010+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Jyaiṣṭhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -28267,7 +28267,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-10  \,Kanyā-Hastaḥ🌛🌌  \,  Vr̥ṣabha
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190612T054550
 DTEND;TZID=Asia/Calcutta:20190613T054559
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190612_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-22\, Islamic: 1440-10-08 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -28324,7 +28324,7 @@ SUMMARY:kāñcī 17 jagadguru-śrī-sadāśivēndra-sarasvatī-ārādhanā
   #1645
 DTSTART;VALUE=DATE:20190612
 DTEND;VALUE=DATE:20190613
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī17jagadguru-śrī-sadāśivēndra-sarasvatī-ārādhanā#1645_
  2019-06-12T05:45:50.399995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -28350,7 +28350,7 @@ SUMMARY:kāñcī 53 jagadguru-śrī-pūrṇānanda-sadāśivēndra-sarasva
  tī-ārādhanā #522
 DTSTART;VALUE=DATE:20190612
 DTEND;VALUE=DATE:20190613
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī53jagadguru-śrī-pūrṇānanda-sadāśivēndra-sarasvatī-ā
  rādhanā#522_2019-06-12T05:45:50.399995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -28376,7 +28376,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-11  \,Tulā-Citrā🌛🌌  \,  Vr̥ṣabhaḥ-
  Mr̥gaśīrṣam-02-30🌞🌌  \,  Śuciḥ-04-24🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190613T054559
 DTEND;TZID=Asia/Calcutta:20190614T054607
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190613_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-23\, Islamic: 1440-10-09 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -28431,7 +28431,7 @@ BEGIN:VEVENT
 SUMMARY:alarmēlmaṅgāpurē plavōtsava-prārambhaḥ
 DTSTART;VALUE=DATE:20190613
 DTEND;VALUE=DATE:20190614
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:alarmēlmaṅgāpurēplavōtsava-prārambhaḥ_2019-06-13T05:45:59.039
  980+05:30
 DESCRIPTION:Rukmini Satyabhama sahita Krishna are taken out on the plava.<
@@ -28452,7 +28452,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-pāṇḍava-nirjalā-ēkādaśī
 DTSTART;VALUE=DATE:20190613
 DTEND;VALUE=DATE:20190614
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sarva-pāṇḍava-nirjalā-ēkādaśī_2019-06-13T05:45:59.039980+05:
  30
 DESCRIPTION:The Shukla-paksha Ekadashi of jyaiṣṭha month is known as p
@@ -28572,7 +28572,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-12  \,Tulā-Svātī🌛🌌  \,  Vr̥ṣabhaḥ
  -Mr̥gaśīrṣam-02-31🌞🌌  \,  Śuciḥ-04-25🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190614T054607
 DTEND;TZID=Asia/Calcutta:20190615T054616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190614_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-24\, Islamic: 1440-10-10 Shawwāl
  \, 🌌🌞: सं- Vr̥ṣabhaḥ\, तं- Vaigāsi\, म- Iṭavaṁ\,
@@ -28628,7 +28628,7 @@ BEGIN:VEVENT
 SUMMARY:alarmēlmaṅgāpurē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:alarmēlmaṅgāpurēplavōtsavaḥ_2019-06-14T05:46:07.680006+05:30
 DESCRIPTION:Sridevi Bhudevi sahita Sundararaja Swami are taken out on the 
  plava.<br/><br/>## Details<br/>- [Edit config file](https://github.com/jyo
@@ -28648,7 +28648,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190614T183203
 DTEND;TZID=Asia/Calcutta:20190615T054616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-14T18:32:03.839991+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -28670,7 +28670,7 @@ BEGIN:VEVENT
 SUMMARY:campaka-dvādaśī
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:campaka-dvādaśī_2019-06-14T05:46:07.680006+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Jyaiṣṭhaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -28690,7 +28690,7 @@ BEGIN:VEVENT
 SUMMARY:gavāmayana-dvādaśī
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:gavāmayana-dvādaśī_2019-06-14T05:46:07.680006+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Jyaiṣṭhaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of Bhagavan T
@@ -28714,7 +28714,7 @@ BEGIN:VEVENT
 SUMMARY:kāñcī 2 jagadguru-śrī-surēśvarācārya-ārādhanā #2425
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī2jagadguru-śrī-surēśvarācārya-ārādhanā#2425_2019-06-1
  4T05:46:07.680006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -28738,7 +28738,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikāvaiṣākhōtsavaḥ
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikāvaiṣākhōtsavaḥ_2019-06-14T05:46:07.680006+05:30
 DESCRIPTION:Observed on Viśākhā nakshatra of Vr̥ṣabhaḥ (sidereal s
  olar) month (Madhyāhnaḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>Special
@@ -28768,7 +28768,7 @@ BEGIN:VEVENT
 SUMMARY:rāmalakṣmaṇa-dvādaśī
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:rāmalakṣmaṇa-dvādaśī_2019-06-14T05:46:07.680006+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Jyaiṣṭhaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -28788,7 +28788,7 @@ BEGIN:VEVENT
 SUMMARY:Vaikāchi Viśākham
 DTSTART;VALUE=DATE:20190614
 DTEND;VALUE=DATE:20190615
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:VaikāchiViśākham_2019-06-14T05:46:07.680006+05:30
 DESCRIPTION:Observed on Viśākhā nakshatra of Vr̥ṣabhaḥ (sidereal s
  olar) month (Madhyāhnaḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>Special
@@ -28818,7 +28818,7 @@ BEGIN:VEVENT
 SUMMARY:śukravāra-śukla-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190614T183203
 DTEND;TZID=Asia/Calcutta:20190614T195626
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śukravāra-śukla-pradōṣa-vratam_2019-06-14T18:32:03.839991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/zukr
@@ -28839,7 +28839,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-13  \,Vr̥ścikaḥ-Viśākhā🌛🌌  \,  Mit
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190615T054616
 DTEND;TZID=Asia/Calcutta:20190616T054624
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190615_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-25\, Islamic: 1440-10-11 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -28895,7 +28895,7 @@ BEGIN:VEVENT
 SUMMARY:alarmēlmaṅgāpurē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190615
 DTEND;VALUE=DATE:20190616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:alarmēlmaṅgāpurēplavōtsavaḥ_2019-06-15T05:46:16.319991+05:30
 DESCRIPTION:Padmavati Devi is taken out on the plava (last three days).<br
  /><br/>## Details<br/>- [Edit config file](https://github.com/jyotisham/ad
@@ -28915,7 +28915,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190615
 DTEND;VALUE=DATE:20190616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-15T05:46:16.319991+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -28940,7 +28940,7 @@ BEGIN:VEVENT
 SUMMARY:chatrapati-śivājī-rājyābhiṣēkaḥ #346
 DTSTART;VALUE=DATE:20190615
 DTEND;VALUE=DATE:20190616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:chatrapati-śivājī-rājyābhiṣēkaḥ#346_2019-06-15T05:46:16.3199
  91+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Jyaiṣṭhaḥ (luna
@@ -28962,7 +28962,7 @@ BEGIN:VEVENT
 SUMMARY:durgandha-daurbhāgya-nāśaka-trayōdaśī
 DTSTART;VALUE=DATE:20190615
 DTEND;VALUE=DATE:20190616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:durgandha-daurbhāgya-nāśaka-trayōdaśī_2019-06-15T05:46:16.319991
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -28984,7 +28984,7 @@ BEGIN:VEVENT
 SUMMARY:mithuna-ravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190615T171837
 DTEND;TZID=Asia/Calcutta:20190615T183221
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:mithuna-ravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ_2019-06-15T
  17:18:37.439993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -29005,7 +29005,7 @@ BEGIN:VEVENT
 SUMMARY:ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190615T105434
 DTEND;TZID=Asia/Calcutta:20190615T183221
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:ravi-saṅkramaṇa-puṇyakālaḥ_2019-06-15T10:54:34.559990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/ravi-saGkra
@@ -29023,7 +29023,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190615T120918
 DTEND;TZID=Asia/Calcutta:20190615T183221
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-06-15T12:09:18.72
  0016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -29044,7 +29044,7 @@ SUMMARY:vēṅkaṭācalē jyēṣṭha-abhidyēyakābhiṣēkaḥ (vajra-
  kavacam)
 DTSTART;VALUE=DATE:20190615
 DTEND;VALUE=DATE:20190616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalējyēṣṭha-abhidyēyakābhiṣēkaḥ(vajra-kavaca
  m)_2019-06-15T05:46:16.319991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -29069,7 +29069,7 @@ BEGIN:VEVENT
 SUMMARY:vidyāraṇya-svāmi-ārādhanā #628
 DTSTART;VALUE=DATE:20190615
 DTEND;VALUE=DATE:20190616
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vidyāraṇya-svāmi-ārādhanā#628_2019-06-15T05:46:16.319991+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Jyaiṣṭhaḥ (luna
  r) month (Aparāhṇaḥ/vyaapti). The event occurred in 4493 (Kali era). 
@@ -29092,7 +29092,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-14  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Mi
  nuḥ
 DTSTART;TZID=Asia/Calcutta:20190616T054624
 DTEND;TZID=Asia/Calcutta:20190617T054642
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190616_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-26\, Islamic: 1440-10-12 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -29147,7 +29147,7 @@ BEGIN:VEVENT
 SUMMARY:alarmēlmaṅgāpurē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:alarmēlmaṅgāpurēplavōtsavaḥ_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:Padmavati Devi is taken out on the plava (last three days).<br
  /><br/>## Details<br/>- [Edit config file](https://github.com/jyotisham/ad
@@ -29167,7 +29167,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -29207,7 +29207,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -29230,7 +29230,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(bhautyaḥ-[14])
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(bhautyaḥ-[14])_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/03/15/manvA
@@ -29252,7 +29252,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -29276,7 +29276,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -29296,7 +29296,7 @@ SUMMARY:vēṅkaṭācalē jyēṣṭha-abhidyēyakābhiṣēkaḥ (mutyal
  a-kavacam)
 DTSTART;VALUE=DATE:20190616
 DTEND;VALUE=DATE:20190617
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalējyēṣṭha-abhidyēyakābhiṣēkaḥ(mutyala-kava
  cam)_2019-06-16T05:46:24.960017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -29323,7 +29323,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-15  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,
  ōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190617T054642
 DTEND;TZID=Asia/Calcutta:20190618T054650
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190617_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-27\, Islamic: 1440-10-13 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -29378,7 +29378,7 @@ BEGIN:VEVENT
 SUMMARY:alarmēlmaṅgāpurē plavōtsavaḥ
 DTSTART;VALUE=DATE:20190612
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:alarmēlmaṅgāpurēplavōtsavaḥ_2019-06-12T23:59:57.120005+05:30
 DESCRIPTION:Rukmini Satyabhama sahita Krishna are taken out on the plava.<
  br/><br/>## Details<br/>- [Edit config file](https://github.com/jyotisham/
@@ -29397,7 +29397,7 @@ BEGIN:VEVENT
 SUMMARY:alarmēlmaṅgāpurē plavōtsava-samāpanam
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:alarmēlmaṅgāpurēplavōtsava-samāpanam_2019-06-17T05:46:42.239987
  +05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Jyaiṣṭhaḥ (lunar) mo
@@ -29419,7 +29419,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-17T05:46:42.239987+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -29454,7 +29454,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ṣi-pūrṇimā
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ṣi-pūrṇimā_2019-06-17T05:46:42.239987+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Jyaiṣṭhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Danam of Padma Purāṇam. Al
@@ -29474,7 +29474,7 @@ BEGIN:VEVENT
 SUMMARY:kabīradāsa-jayantī
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kabīradāsa-jayantī_2019-06-17T05:46:42.239987+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Jyaiṣṭhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -29494,7 +29494,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-06-17T05:46:42.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -29515,7 +29515,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-06-17T05:46:42.239987+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -29536,7 +29536,7 @@ SUMMARY:vēṅkaṭācalē jyēṣṭha-abhidyēyakābhiṣēkaḥ (svar
  ṇa-kavacam)
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalējyēṣṭha-abhidyēyakābhiṣēkaḥ(svarṇa-kav
  acam)_2019-06-17T05:46:42.239987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -29560,7 +29560,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-06-17T05:46:42.2399
  87+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -29583,7 +29583,7 @@ BEGIN:VEVENT
 SUMMARY:vaṭa-pūrṇimā/vaṭa-sāvitrī-vratam
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190618
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaṭa-pūrṇimā/vaṭa-sāvitrī-vratam_2019-06-17T05:46:42.239987+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -29607,7 +29607,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-16  \,Dhanuḥ-Mūlā🌛🌌  \,  Mithunam-Mr
  ̥gaśīrṣam-03-04🌞🌌  \,  Śuciḥ-04-29🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190618T054650
 DTEND;TZID=Asia/Calcutta:20190619T054659
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190618_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-28\, Islamic: 1440-10-14 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -29662,7 +29662,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190618
 DTEND;VALUE=DATE:20190619
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-18T05:46:50.880013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -29709,7 +29709,7 @@ SUMMARY:graha-yuddhaḥ (★budhaḥ-aṅgārakaḥ\, punarvasuḥ mithuna
  m)
 DTSTART;VALUE=DATE:20190617
 DTEND;VALUE=DATE:20190620
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:graha-yuddhaḥ(★budhaḥ-aṅgārakaḥ\,punarvasuḥmithunam)_2019
  -06-17T10:43:29.279993+05:30
 DESCRIPTION:Graha-yuddha (amshu-vimarda) between aṅgārakaḥ and budha
@@ -29770,7 +29770,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190618
 DTEND;VALUE=DATE:20190619
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-06-18T05:46:
  50.880013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -29797,7 +29797,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190618
 DTEND;VALUE=DATE:20190619
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-06-18T05:46:50.880013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -29816,7 +29816,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190618
 DTEND;VALUE=DATE:20190619
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-06-18T05:46:50.880013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -29839,7 +29839,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-17  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,
  dhaḥ
 DTSTART;TZID=Asia/Calcutta:20190619T054659
 DTEND;TZID=Asia/Calcutta:20190620T054716
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190619_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-29\, Islamic: 1440-10-15 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -29897,7 +29897,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-18  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,
  uruḥ
 DTSTART;TZID=Asia/Calcutta:20190620T054716
 DTEND;TZID=Asia/Calcutta:20190621T054725
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190620_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-30\, Islamic: 1440-10-16 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -29953,7 +29953,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190620T183338
 DTEND;TZID=Asia/Calcutta:20190621T054725
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-20T18:33:38.879990+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -29974,7 +29974,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190621T020915
 DTEND;TZID=Asia/Calcutta:20190620T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-06-21T02:09:15.839981+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -29991,7 +29991,7 @@ SUMMARY:kr̥ṣṇapiṅgala-mahāgaṇapati-saṅkaṭahara-caturthī-vra
  tam
 DTSTART;VALUE=DATE:20190620
 DTEND;VALUE=DATE:20190621
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ṣṇapiṅgala-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_
  2019-06-20T05:47:16.800009+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -30021,7 +30021,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-19  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Mith
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190621T054725
 DTEND;TZID=Asia/Calcutta:20190622T054742
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:20190621_day_summary
 DESCRIPTION:- Indian civil date: 1941-03-31\, Islamic: 1440-10-17 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30077,7 +30077,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190621
 DTEND;VALUE=DATE:20190622
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-21T05:47:25.439994+05:30
 DESCRIPTION:Anadhyayana on account of dakṣiṇāyana. On the days of Aya
  na (solstices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to 
@@ -30101,7 +30101,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190621
 DTEND;VALUE=DATE:20190622
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-21T05:47:25.439994+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -30126,7 +30126,7 @@ BEGIN:VEVENT
 SUMMARY:dakṣiṇāyana-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190621T092417
 DTEND;TZID=Asia/Calcutta:20190621T183347
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:dakṣiṇāyana-puṇyakālaḥ_2019-06-21T09:24:17.280019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/dakSiNAyana
@@ -30145,7 +30145,7 @@ BEGIN:VEVENT
 SUMMARY:nabhō-māsaḥ/varṣar̥tuḥ/dakṣiṇāyanam
 DTSTART;TZID=Asia/Calcutta:20190621T212417
 DTEND;TZID=Asia/Calcutta:20190621T235957
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:nabhō-māsaḥ/varṣar̥tuḥ/dakṣiṇāyanam_2019-06-21T21:24:17.
  280019+05:30
 DESCRIPTION:
@@ -30159,7 +30159,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190621T150014
 DTEND;TZID=Asia/Calcutta:20190621T183347
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-06-21T15:00:14.400016
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -30178,7 +30178,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190621T121036
 DTEND;TZID=Asia/Calcutta:20190621T183347
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-06-21T12:
  10:36.480005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -30199,7 +30199,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190621
 DTEND;VALUE=DATE:20190622
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-06-21T05:47:25.439994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -30221,7 +30221,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190621
 DTEND;VALUE=DATE:20190622
-DTSTAMP:20260822T115606Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-06-21T05:47:25.439994+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -30242,7 +30242,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-20  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Mi
  iḥ
 DTSTART;TZID=Asia/Calcutta:20190622T054742
 DTEND;TZID=Asia/Calcutta:20190623T054751
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190622_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-01\, Islamic: 1440-10-18 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30298,7 +30298,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190622T225133
 DTEND;TZID=Asia/Calcutta:20190622T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-06-22T22:51:33.120016+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -30314,7 +30314,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190622T054742
 DTEND;TZID=Asia/Calcutta:20190622T183404
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-22T05:47:42.720005+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -30336,7 +30336,7 @@ BEGIN:VEVENT
 SUMMARY:dakṣiṇāyanārambhaḥ
 DTSTART;VALUE=DATE:20190622
 DTEND;VALUE=DATE:20190623
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dakṣiṇāyanārambhaḥ_2019-06-22T05:47:42.720005+05:30
 DESCRIPTION:Observed on day 1 of Nabhaḥ (tropical) month (Sūryōdayaḥ
  /puurvaviddha). <br/><br/>Summer solstice.<br/><br/>## Details<br/>- [Edit
@@ -30357,7 +30357,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-21  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Mith
  unam-Ārdrā-03-09🌞🌌  \,  Nabhaḥ-05-02🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190623T054751
 DTEND;TZID=Asia/Calcutta:20190624T054808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190623_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-02\, Islamic: 1440-10-19 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30413,7 +30413,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190624T000542
 DTEND;TZID=Asia/Calcutta:20190624T054808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-06-24T00:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -30434,7 +30434,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-22  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190624T054808
 DTEND;TZID=Asia/Calcutta:20190625T054817
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190624_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-03\, Islamic: 1440-10-20 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30490,7 +30490,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190624T183422
 DTEND;TZID=Asia/Calcutta:20190625T054817
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-24T18:34:22.079997+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -30511,7 +30511,7 @@ BEGIN:VEVENT
 SUMMARY:dēhū-vārī-prārambhaḥ
 DTSTART;VALUE=DATE:20190624
 DTEND;VALUE=DATE:20190625
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dēhū-vārī-prārambhaḥ_2019-06-24T05:48:08.640001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Maharashtra/lunar_month/tithi/03/22/dEhU-
@@ -30534,7 +30534,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-23  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌
  alaḥ
 DTSTART;TZID=Asia/Calcutta:20190625T054817
 DTEND;TZID=Asia/Calcutta:20190626T054834
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190625_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-04\, Islamic: 1440-10-21 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30590,7 +30590,7 @@ BEGIN:VEVENT
 SUMMARY:āḷandī-vārī-prārambhaḥ
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āḷandī-vārī-prārambhaḥ_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Maharashtra/lunar_month/tithi/03/23/ALand
@@ -30611,7 +30611,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -30646,7 +30646,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -30665,7 +30665,7 @@ BEGIN:VEVENT
 SUMMARY:tindukāṣṭamī
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:tindukāṣṭamī_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Jyaiṣṭhaḥ (
  lunar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Start of one year vr
@@ -30686,7 +30686,7 @@ BEGIN:VEVENT
 SUMMARY:trilōcanāṣṭamī
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:trilōcanāṣṭamī_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Jyaiṣṭhaḥ (
  lunar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details
@@ -30706,7 +30706,7 @@ BEGIN:VEVENT
 SUMMARY:vināyakāṣṭamī
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vināyakāṣṭamī_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Jyaiṣṭhaḥ (
  lunar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details
@@ -30726,7 +30726,7 @@ BEGIN:VEVENT
 SUMMARY:śītalāṣṭamī
 DTSTART;VALUE=DATE:20190625
 DTEND;VALUE=DATE:20190626
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śītalāṣṭamī_2019-06-25T05:48:17.279987+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Jyaiṣṭhaḥ (
  lunar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>vandē'haṁ śītal
@@ -30749,7 +30749,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-24  \,Mīnaḥ-Rēvatī🌛🌌  \,  Mithunam-
  Ārdrā-03-12🌞🌌  \,  Nabhaḥ-05-05🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190626T054834
 DTEND;TZID=Asia/Calcutta:20190627T054851
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190626_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-05\, Islamic: 1440-10-22 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30804,7 +30804,7 @@ BEGIN:VEVENT
 SUMMARY:Ēyarkōn Kalikkāma Nāyanmār (29) Gurupūjai
 DTSTART;VALUE=DATE:20190626
 DTEND;VALUE=DATE:20190627
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ĒyarkōnKalikkāmaNāyanmār(29)Gurupūjai_2019-06-26T05:48:34.559998
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -30828,7 +30828,7 @@ BEGIN:VEVENT
 SUMMARY:durgā-svāpanam
 DTSTART;VALUE=DATE:20190626
 DTEND;VALUE=DATE:20190627
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:durgā-svāpanam_2019-06-26T05:48:34.559998+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Jyaiṣṭhaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -30849,7 +30849,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-25  \,Mīnaḥ-Rēvatī🌛🌌  \,  Mithunam-
  Ārdrā-03-13🌞🌌  \,  Nabhaḥ-05-06🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190627T054851
 DTEND;TZID=Asia/Calcutta:20190628T054900
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190627_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-06\, Islamic: 1440-10-23 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30904,7 +30904,7 @@ BEGIN:VEVENT
 SUMMARY:śukrasya vārdhakya-prārambhaḥ
 DTSTART;TZID=Asia/Calcutta:20190627T194027
 DTEND;TZID=Asia/Calcutta:20190627T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukrasyavārdhakya-prārambhaḥ_2019-06-27T19:40:27.840020+05:30
 DESCRIPTION:śukraḥ enters vArdhakya (old age) on 2019-Jun-27 19:40\, 15
   days before it sets into combustion (mAudhyam). At this moment śukraḥ 
@@ -30923,7 +30923,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-25  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Mithunam
  -Ārdrā-03-14🌞🌌  \,  Nabhaḥ-05-07🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190628T054900
 DTEND;TZID=Asia/Calcutta:20190629T054917
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190628_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-07\, Islamic: 1440-10-24 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -30979,7 +30979,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190629T011650
 DTEND;TZID=Asia/Calcutta:20190628T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-06-29T01:16:50.880013+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -30996,7 +30996,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-26  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Mit
  hunam-Ārdrā-03-15🌞🌌  \,  Nabhaḥ-05-08🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190629T054917
 DTEND;TZID=Asia/Calcutta:20190630T054935
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190629_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-08\, Islamic: 1440-10-25 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -31052,7 +31052,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē dhvajārōhaṇam/pañcamūrti-rathōtsavaḥ
 DTSTART;VALUE=DATE:20190629
 DTEND;VALUE=DATE:20190630
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarēdhvajārōhaṇam/pañcamūrti-rathōtsavaḥ_2019-06-29T05:
  49:17.760005+05:30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
@@ -31076,7 +31076,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190629
 DTEND;VALUE=DATE:20190630
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-06-29T05:49:17.760005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -31097,7 +31097,7 @@ BEGIN:VEVENT
 SUMMARY:kūrma-jayantī
 DTSTART;VALUE=DATE:20190629
 DTEND;VALUE=DATE:20190630
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kūrma-jayantī_2019-06-29T05:49:17.760005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/03/27/kUrma~ja
@@ -31119,7 +31119,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-yōginī-ēkādaśī
 DTSTART;VALUE=DATE:20190629
 DTEND;VALUE=DATE:20190630
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarva-yōginī-ēkādaśī_2019-06-29T05:49:17.760005+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of jyaiṣṭha month is known as 
  yōginī-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are gre
@@ -31214,7 +31214,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;VALUE=DATE:20190629
 DTEND;VALUE=DATE:20190630
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-06-29T09:55:58.080009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -31237,7 +31237,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-27  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Mi
  thunam-Ārdrā-03-16🌞🌌  \,  Nabhaḥ-05-09🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190630T054935
 DTEND;TZID=Asia/Calcutta:20190701T054952
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190630_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-09\, Islamic: 1440-10-26 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -31293,7 +31293,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190630T183522
 DTEND;TZID=Asia/Calcutta:20190701T054952
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-06-30T18:35:22.560015+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -31314,7 +31314,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē rajata-candraprabha-vāhanam
 DTSTART;VALUE=DATE:20190630
 DTEND;VALUE=DATE:20190701
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarērajata-candraprabha-vāhanam_2019-06-30T05:49:35.040016+05:3
  0
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
@@ -31337,7 +31337,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190630
 DTEND;VALUE=DATE:20190701
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-06-30T05:49:35.040016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -31358,7 +31358,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190630T183522
 DTEND;TZID=Asia/Calcutta:20190630T195945
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-06-30T18:35:22.560015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -31376,7 +31376,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190630T054935
 DTEND;TZID=Asia/Calcutta:20190630T061136
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-06-30T05:49:35.040016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -31396,7 +31396,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-29  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Mi
  thunam-Ārdrā-03-17🌞🌌  \,  Nabhaḥ-05-10🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190701T054952
 DTEND;TZID=Asia/Calcutta:20190702T055009
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190701_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-10\, Islamic: 1440-10-27 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -31452,7 +31452,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190701
 DTEND;VALUE=DATE:20190702
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-01T05:49:52.319986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -31492,7 +31492,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē svarṇa-sūryaprabha-vāhanam
 DTSTART;VALUE=DATE:20190701
 DTEND;VALUE=DATE:20190702
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarēsvarṇa-sūryaprabha-vāhanam_2019-07-01T05:49:52.319986+05
  :30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
@@ -31515,7 +31515,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190701
 DTEND;VALUE=DATE:20190702
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-07-01T05:49:52.319986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -31535,7 +31535,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190701
 DTEND;VALUE=DATE:20190702
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-07-01T05:49:52.319986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -31554,7 +31554,7 @@ BEGIN:VEVENT
 SUMMARY:sōmamr̥gaśīrṣa-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190701T092316
 DTEND;TZID=Asia/Calcutta:20190701T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sōmamr̥gaśīrṣa-yōgaḥ_2019-07-01T09:23:16.800001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmamRg
@@ -31574,7 +31574,7 @@ SUMMARY:Jyaiṣṭhaḥ-03-30  \,Mithunam-Mr̥gaśīrṣam🌛🌌  \,  Mi
  thunam-Ārdrā-03-18🌞🌌  \,  Nabhaḥ-05-11🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190702T055009
 DTEND;TZID=Asia/Calcutta:20190703T055026
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190702_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-11\, Islamic: 1440-10-28 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -31629,7 +31629,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -31664,7 +31664,7 @@ BEGIN:VEVENT
 SUMMARY:bhōgaśāyi-pūjā
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:bhōgaśāyi-pūjā_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Jyaiṣṭhaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -31683,7 +31683,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē rajata-bhūta-vāhanam
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarērajata-bhūta-vāhanam_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
  around the Aani Thirumanjana festival each year\, for ten days. On this da
@@ -31704,7 +31704,7 @@ BEGIN:VEVENT
 SUMMARY:jyaiṣṭha-māsaḥ
 DTSTART;VALUE=DATE:20190603
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:jyaiṣṭha-māsaḥ_2019-06-03T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/jyaiShTha-mAsaH.
@@ -31726,7 +31726,7 @@ BEGIN:VEVENT
 SUMMARY:jyaiṣṭha-māsa-samāpanam
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:jyaiṣṭha-māsa-samāpanam_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Jyaiṣṭhaḥ (lunar) month
   (Sūryōdayaḥ/paraviddha). <br/><br/>jyaiṣhṭha-māsaḥ ends today<
@@ -31746,7 +31746,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -31767,7 +31767,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -31786,7 +31786,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-07-02T05:50:09.599997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -31807,7 +31807,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-jyaiṣṭha-amāvāsyā (alabhyam–ārdrā\, puṣkalā)
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190703
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarva-jyaiṣṭha-amāvāsyā(alabhyam–ārdrā\,puṣkalā)_2019-07
  -02T05:50:09.599997+05:30
 DESCRIPTION:amāvāsyā of jyaiṣṭha lunar month.<br/><br/>## Details<b
@@ -31843,7 +31843,7 @@ SUMMARY:Āṣāḍhaḥ-04-01  \,Mithunam-Ārdrā🌛🌌  \,  Mithunam-Ā
  rdrā-03-19🌞🌌  \,  Nabhaḥ-05-12🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190703T055026
 DTEND;TZID=Asia/Calcutta:20190704T055044
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190703_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-12\, Islamic: 1440-10-29 Shawwāl
  \, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, प- Hā
@@ -31899,7 +31899,7 @@ BEGIN:VEVENT
 SUMMARY:āṣāḍha-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āṣāḍha-māsa-ārambhaḥ_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/04/01/ASADha-mA
@@ -31921,7 +31921,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -31967,7 +31967,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē rajata-r̥ṣabha-vāhanam
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarērajata-r̥ṣabha-vāhanam_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
  around the Aani Thirumanjana festival each year\, for ten days. On this da
@@ -31988,7 +31988,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -32008,7 +32008,7 @@ SUMMARY:kāñcī 25 jagadguru-śrī-saccidānandaghanēndra-sarasvatī-ār
  ādhanā #1472
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī25jagadguru-śrī-saccidānandaghanēndra-sarasvatī-ārādhan
  ā#1472_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -32033,7 +32033,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-07-03T05:50:26.880008
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -32059,7 +32059,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -32080,7 +32080,7 @@ BEGIN:VEVENT
 SUMMARY:vārāhī-navarātra-ārambhaḥ
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vārāhī-navarātra-ārambhaḥ_2019-07-03T05:50:26.880008+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Āṣāḍhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>vandē vārāhavaktrāṁ v
@@ -32105,7 +32105,7 @@ SUMMARY:Āṣāḍhaḥ-04-02  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Mith
  unam-Ārdrā-03-20🌞🌌  \,  Nabhaḥ-05-13🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190704T055044
 DTEND;TZID=Asia/Calcutta:20190705T055101
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190704_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-13\, Islamic: 1440-11-01 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -32161,7 +32161,7 @@ BEGIN:VEVENT
 SUMMARY:amr̥talakṣmī-vratam
 DTSTART;VALUE=DATE:20190704
 DTEND;VALUE=DATE:20190705
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:amr̥talakṣmī-vratam_2019-07-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Āṣāḍhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -32181,7 +32181,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190704T183548
 DTEND;TZID=Asia/Calcutta:20190704T201409
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-07-04T18:35:48.480012+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -32200,7 +32200,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē rajata-gajavāhanam
 DTSTART;VALUE=DATE:20190704
 DTEND;VALUE=DATE:20190705
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarērajata-gajavāhanam_2019-07-04T05:50:44.160019+05:30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
  around the Aani Thirumanjana festival each year\, for ten days. On this si
@@ -32222,7 +32222,7 @@ BEGIN:VEVENT
 SUMMARY:gurupuṣya-yōgaḥ
 DTSTART;VALUE=DATE:20190703
 DTEND;VALUE=DATE:20190704
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:gurupuṣya-yōgaḥ_2019-07-03T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/gurupuS
@@ -32243,7 +32243,7 @@ BEGIN:VEVENT
 SUMMARY:jagannātha-ratha-yātrā
 DTSTART;VALUE=DATE:20190704
 DTEND;VALUE=DATE:20190705
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:jagannātha-ratha-yātrā_2019-07-04T05:50:44.160019+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Āṣāḍhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -32264,7 +32264,7 @@ SUMMARY:Āṣāḍhaḥ-04-03  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Mi
  thunam-Ārdrā-03-21🌞🌌  \,  Nabhaḥ-05-14🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190705T055101
 DTEND;TZID=Asia/Calcutta:20190706T055110
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190705_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-14\, Islamic: 1440-11-02 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -32320,7 +32320,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē kailāsa-vāhanam
 DTSTART;VALUE=DATE:20190705
 DTEND;VALUE=DATE:20190706
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarēkailāsa-vāhanam_2019-07-05T05:51:01.439990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/relative_event/naTarAjar_An2i_tirum
@@ -32342,7 +32342,7 @@ BEGIN:VEVENT
 SUMMARY:Pugaḻttuṇai Nāyanmār (56) Gurupūjai
 DTSTART;VALUE=DATE:20190705
 DTEND;VALUE=DATE:20190706
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:PugaḻttuṇaiNāyanmār(56)Gurupūjai_2019-07-05T05:51:01.439990+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -32367,7 +32367,7 @@ SUMMARY:Āṣāḍhaḥ-04-04  \,Siṁhaḥ-Maghā🌛🌌  \,  Mithunam-
  Ārdrā-03-22🌞🌌  \,  Nabhaḥ-05-15🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190706T055110
 DTEND;TZID=Asia/Calcutta:20190707T055127
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190706_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-15\, Islamic: 1440-11-03 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -32422,7 +32422,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē bhikṣāṭana-svarṇarathaḥ
 DTSTART;VALUE=DATE:20190706
 DTEND;VALUE=DATE:20190707
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarēbhikṣāṭana-svarṇarathaḥ_2019-07-06T05:51:10.080015+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -32445,7 +32445,7 @@ BEGIN:VEVENT
 SUMMARY:Māṇikkavāchakar Gurupūjai
 DTSTART;VALUE=DATE:20190706
 DTEND;VALUE=DATE:20190707
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:MāṇikkavāchakarGurupūjai_2019-07-06T05:51:10.080015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -32468,7 +32468,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190706
 DTEND;VALUE=DATE:20190707
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-07-06T05:51:10.080015+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -32490,7 +32490,7 @@ SUMMARY:Āṣāḍhaḥ-04-05  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  M
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190707T055127
 DTEND;TZID=Asia/Calcutta:20190708T055144
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190707_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-16\, Islamic: 1440-11-04 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -32546,7 +32546,7 @@ BEGIN:VEVENT
 SUMMARY:Amaranīti Nāyanmār (7) Gurupūjai
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:AmaranītiNāyanmār(7)Gurupūjai_2019-07-07T05:51:27.359986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -32569,7 +32569,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē rathōtsavaḥ
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarērathōtsavaḥ_2019-07-07T05:51:27.359986+05:30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
  around the Aani Thirumanjana festival each year\, for ten days. On this da
@@ -32591,7 +32591,7 @@ SUMMARY:kāñcī 35 jagadguru-śrī-citsukhēndra-sarasvatī-ārādhanā #
  1283
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī35jagadguru-śrī-citsukhēndra-sarasvatī-ārādhanā#1283_20
  19-07-07T05:51:27.359986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -32616,7 +32616,7 @@ BEGIN:VEVENT
 SUMMARY:kumāra-ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kumāra-ṣaṣṭhī-vratam_2019-07-07T05:51:27.359986+05:30
 DESCRIPTION:upavāsam with only water and next day pāraṇa gives ārōgy
  am<br/><br/>āṣāḍha śuklaṣaṣṭhī tu tithiḥ kaumārilā smr̥
@@ -32637,7 +32637,7 @@ BEGIN:VEVENT
 SUMMARY:pātārka-yōgaḥ
 DTSTART;VALUE=DATE:20190706
 DTEND;VALUE=DATE:20190707
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pātārka-yōgaḥ_2019-07-06T23:59:57.120005+05:30
 DESCRIPTION:When Vyatipata yoga falls on a Sunday\, it is a special yōga
  ḥ\, which is equal to a thousand Surya grahanas.<br/><br/>bhānōrvārē
@@ -32659,7 +32659,7 @@ BEGIN:VEVENT
 SUMMARY:skanda-pañcamī
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:skanda-pañcamī_2019-07-07T05:51:27.359986+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Āṣāḍhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -32679,7 +32679,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-07-07T05:51:27.359986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -32701,7 +32701,7 @@ BEGIN:VEVENT
 SUMMARY:śamī-gaurī-vratam
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śamī-gaurī-vratam_2019-07-07T05:51:27.359986+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Āṣāḍhaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -32722,7 +32722,7 @@ SUMMARY:śrīnivāsamaṅgāpurē sākṣātkāra-vaibhavōtsava-ārambha
  ḥ
 DTSTART;VALUE=DATE:20190707
 DTEND;VALUE=DATE:20190708
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śrīnivāsamaṅgāpurēsākṣātkāra-vaibhavōtsava-ārambhaḥ_20
  19-07-07T05:51:27.359986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -32748,7 +32748,7 @@ SUMMARY:Āṣāḍhaḥ-04-06  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Mithu
  nam-Punarvasuḥ-03-24🌞🌌  \,  Nabhaḥ-05-17🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190708T055144
 DTEND;TZID=Asia/Calcutta:20190709T055201
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190708_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-17\, Islamic: 1440-11-05 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -32804,7 +32804,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190708T183605
 DTEND;TZID=Asia/Calcutta:20190709T055201
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-08T18:36:05.759982+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -32825,7 +32825,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē naṭarājasya rājasabhāyāṁ mahābhiṣēkaḥ
 DTSTART;VALUE=DATE:20190708
 DTEND;VALUE=DATE:20190709
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarēnaṭarājasyarājasabhāyāṁmahābhiṣēkaḥ_2019-07-08
  T05:51:44.639997+05:30
 DESCRIPTION:Mahābhiṣeka (ceremonial bath) of Naṭarāja performed in t
@@ -32853,7 +32853,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190708
 DTEND;VALUE=DATE:20190709
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-07-08T05:51:44.639997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -32874,7 +32874,7 @@ BEGIN:VEVENT
 SUMMARY:Naṭarājar Āni Tirumañchanam
 DTSTART;VALUE=DATE:20190708
 DTEND;VALUE=DATE:20190709
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:NaṭarājarĀniTirumañchanam_2019-07-08T05:51:44.639997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/sidereal_solar_month/nakshatra/03/1
@@ -32896,7 +32896,7 @@ BEGIN:VEVENT
 SUMMARY:vaivasvata-saptamī
 DTSTART;VALUE=DATE:20190708
 DTEND;VALUE=DATE:20190709
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vaivasvata-saptamī_2019-07-08T05:51:44.639997+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Āṣāḍhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Mitra rupa Surya Pooja<br/><
@@ -32921,7 +32921,7 @@ BEGIN:VEVENT
 SUMMARY:śrīnivāsamaṅgāpurē sākṣātkāra-vaibhavōtsavaḥ
 DTSTART;VALUE=DATE:20190708
 DTEND;VALUE=DATE:20190709
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śrīnivāsamaṅgāpurēsākṣātkāra-vaibhavōtsavaḥ_2019-07-08T
  05:51:44.639997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -32946,7 +32946,7 @@ SUMMARY:Āṣāḍhaḥ-04-08  \,Kanyā-Hastaḥ🌛🌌  \,  Mithunam-Pun
  arvasuḥ-03-25🌞🌌  \,  Nabhaḥ-05-18🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190709T055201
 DTEND;TZID=Asia/Calcutta:20190710T055219
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190709_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-18\, Islamic: 1440-11-06 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -33002,7 +33002,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190709
 DTEND;VALUE=DATE:20190710
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-09T05:52:01.920007+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -33037,7 +33037,7 @@ BEGIN:VEVENT
 SUMMARY:cidambarē muttuppallakku
 DTSTART;VALUE=DATE:20190709
 DTEND;VALUE=DATE:20190710
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cidambarēmuttuppallakku_2019-07-09T05:52:01.920007+05:30
 DESCRIPTION:The Brahmotsavam of Nataraja at Chidambaram happens specially 
  around the Aani Thirumanjana festival each year\, for ten days. On this da
@@ -33058,7 +33058,7 @@ BEGIN:VEVENT
 SUMMARY:mahiṣaghnī-pūjā
 DTSTART;VALUE=DATE:20190709
 DTEND;VALUE=DATE:20190710
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:mahiṣaghnī-pūjā_2019-07-09T05:52:01.920007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/04/08/mahiSaghnI-pUjA.t
@@ -33079,7 +33079,7 @@ BEGIN:VEVENT
 SUMMARY:śrīnivāsamaṅgāpurē sākṣātkāra-vaibhavōtsavaḥ
 DTSTART;VALUE=DATE:20190706
 DTEND;VALUE=DATE:20190710
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śrīnivāsamaṅgāpurēsākṣātkāra-vaibhavōtsavaḥ_2019-07-06T
  23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -33104,7 +33104,7 @@ SUMMARY:śrīnivāsamaṅgāpurē sākṣātkāra-vaibhavōtsava-samāpana
  m
 DTSTART;VALUE=DATE:20190709
 DTEND;VALUE=DATE:20190710
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śrīnivāsamaṅgāpurēsākṣātkāra-vaibhavōtsava-samāpanam_201
  9-07-09T05:52:01.920007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -33130,7 +33130,7 @@ SUMMARY:Āṣāḍhaḥ-04-09  \,Tulā-Citrā🌛🌌  \,  Mithunam-Punarv
  asuḥ-03-26🌞🌌  \,  Nabhaḥ-05-19🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190710T055219
 DTEND;TZID=Asia/Calcutta:20190711T055236
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190710_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-19\, Islamic: 1440-11-07 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -33185,7 +33185,7 @@ BEGIN:VEVENT
 SUMMARY:aindrī-durgā-pūjā
 DTSTART;VALUE=DATE:20190710
 DTEND;VALUE=DATE:20190711
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:aindrī-durgā-pūjā_2019-07-10T05:52:19.200018+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Āṣāḍhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>bhaviṣyē---  <br/>upavāsa
@@ -33210,7 +33210,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190710T183605
 DTEND;TZID=Asia/Calcutta:20190711T055236
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-10T18:36:05.759982+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -33232,7 +33232,7 @@ SUMMARY:kāñcī 12 jagadguru-śrī-candraśēkharēndra-sarasvatī-ārād
  hanā #1785
 DTSTART;VALUE=DATE:20190710
 DTEND;VALUE=DATE:20190711
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī12jagadguru-śrī-candraśēkharēndra-sarasvatī-ārādhanā#
  1785_2019-07-10T05:52:19.200018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -33257,7 +33257,7 @@ BEGIN:VEVENT
 SUMMARY:sudarśana-jayantī
 DTSTART;VALUE=DATE:20190710
 DTEND;VALUE=DATE:20190711
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sudarśana-jayantī_2019-07-10T05:52:19.200018+05:30
 DESCRIPTION:Observed on Citrā nakshatra of Mithunam (sidereal solar) mont
  h (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit confi
@@ -33277,7 +33277,7 @@ BEGIN:VEVENT
 SUMMARY:upēndra-navamī
 DTSTART;VALUE=DATE:20190710
 DTEND;VALUE=DATE:20190711
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:upēndra-navamī_2019-07-10T05:52:19.200018+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Āṣāḍhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -33297,7 +33297,7 @@ BEGIN:VEVENT
 SUMMARY:vārāhī-navarātraḥ
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190711
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vārāhī-navarātraḥ_2019-07-02T23:59:57.120005+05:30
 DESCRIPTION:vandē vārāhavaktrāṁ varamaṇimakuṭāṁ vidrumaśrōt
  rabhūṣām  <br/>hārāgraivēyatuṅgastanabharanamitāṁ pītakauśē
@@ -33320,7 +33320,7 @@ BEGIN:VEVENT
 SUMMARY:vārāhī-navarātra-samāpanam
 DTSTART;VALUE=DATE:20190710
 DTEND;VALUE=DATE:20190711
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vārāhī-navarātra-samāpanam_2019-07-10T05:52:19.200018+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Āṣāḍhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -33341,7 +33341,7 @@ SUMMARY:Āṣāḍhaḥ-04-10  \,Tulā-Svātī🌛🌌  \,  Mithunam-Punar
  vasuḥ-03-27🌞🌌  \,  Nabhaḥ-05-20🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190711T055236
 DTEND;TZID=Asia/Calcutta:20190712T055253
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190711_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-20\, Islamic: 1440-11-08 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -33397,7 +33397,7 @@ BEGIN:VEVENT
 SUMMARY:āśā-daśamī
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20190712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āśā-daśamī_2019-07-11T05:52:36.479989+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āṣāḍhaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Puja of āśā dēvī (pārv
@@ -33417,7 +33417,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20190712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-11T05:52:36.479989+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -33447,7 +33447,7 @@ SUMMARY:kāñcī 48 jagadguru-śrī-advaitānandabōdhēndra-sarasvatī-ā
  rādhanā #820
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20190712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī48jagadguru-śrī-advaitānandabōdhēndra-sarasvatī-ārādha
  nā#820_2019-07-11T05:52:36.479989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -33472,7 +33472,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(vaivasvataḥ-[7])
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20190712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(vaivasvataḥ-[7])_2019-07-11T05:52:36.479989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/04/10/manvA
@@ -33494,7 +33494,7 @@ BEGIN:VEVENT
 SUMMARY:Periyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20190712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:PeriyāḻvārTirunakṣattiram_2019-07-11T05:52:36.479989+05:30
 DESCRIPTION:Observed on Svātī nakshatra of Mithunam (sidereal solar) mon
  th (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit conf
@@ -33515,7 +33515,7 @@ SUMMARY:Āṣāḍhaḥ-04-11  \,Tulā-Viśākhā🌛🌌  \,  Mithunam-Pu
  narvasuḥ-03-28🌞🌌  \,  Nabhaḥ-05-21🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190712T055253
 DTEND;TZID=Asia/Calcutta:20190713T055311
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190712_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-21\, Islamic: 1440-11-09 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -33572,7 +33572,7 @@ BEGIN:VEVENT
 SUMMARY:āḷandī-vārī-samāpanam
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āḷandī-vārī-samāpanam_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:On this day\, From Wākharī\, both the Āl̤andī and Dehu P
  ālkhīs—along with hundreds of others from across Maharashtra—walk th
@@ -33596,7 +33596,7 @@ BEGIN:VEVENT
 SUMMARY:āṣāḍhī-vārī
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āṣāḍhī-vārī_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:On this day\, From Wākharī\, both Pālkhīs—along with hun
  dreds of others from across Maharashtra—walk the final stretch together 
@@ -33620,7 +33620,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:Anadhyayana on account of viṣṇuśayanōtsava. On the days 
  of Ayana (solstices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu go
@@ -33644,7 +33644,7 @@ BEGIN:VEVENT
 SUMMARY:cāturmāsyavrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cāturmāsyavrata-ārambhaḥ_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/04/11/cAturmAsy
@@ -33666,7 +33666,7 @@ BEGIN:VEVENT
 SUMMARY:dēhū-vārī-samāpanam
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dēhū-vārī-samāpanam_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:On this day\, From Wākharī\, both the Dehu and Āl̤andī P
  ālkhīs—along with hundreds of others from across Maharashtra—walk th
@@ -33690,7 +33690,7 @@ BEGIN:VEVENT
 SUMMARY:gōpadma-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:gōpadma-vrata-ārambhaḥ_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Āṣāḍhaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of Mahalaksh
@@ -33713,7 +33713,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-śayana-ēkādaśī
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarva-śayana-ēkādaśī_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of āṣāḍha month is known as 
  śayana-ēkādaśī. Bhagavan Vishnu goes to sleep for four months beginni
@@ -33854,7 +33854,7 @@ BEGIN:VEVENT
 SUMMARY:viṣṇu-śayanōtsavaḥ
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190713
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:viṣṇu-śayanōtsavaḥ_2019-07-12T05:52:53.760000+05:30
 DESCRIPTION:Perform Vishnu Shayanotsava in the night.<br/><br/>## Details<
  br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/maste
@@ -33873,7 +33873,7 @@ BEGIN:VEVENT
 SUMMARY:śukraḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190712T194027
 DTEND;TZID=Asia/Calcutta:20190712T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukraḥ–astamayaḥ(prāk)_2019-07-12T19:40:27.840020+05:30
 DESCRIPTION:śukraḥ sets into combustion (astamayaH)\, heading prāk (ea
  st)\, on 2019-Jul-12 19:40. At this moment śukraḥ is at ārdrā-4 mithu
@@ -33892,7 +33892,7 @@ BEGIN:VEVENT
 SUMMARY:śukrasya vārdhakya-samāpanam
 DTSTART;TZID=Asia/Calcutta:20190712T194027
 DTEND;TZID=Asia/Calcutta:20190712T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukrasyavārdhakya-samāpanam_2019-07-12T19:40:27.840020+05:30
 DESCRIPTION:śukraḥ's vArdhakya ends on 2019-Jul-12 19:40\, as it sets i
  nto combustion (mAudhyam). At this moment śukraḥ is at ārdrā-4 mithun
@@ -33909,7 +33909,7 @@ SUMMARY:Āṣāḍhaḥ-04-12  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Mi
  thunam-Punarvasuḥ-03-29🌞🌌  \,  Nabhaḥ-05-22🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190713T055311
 DTEND;TZID=Asia/Calcutta:20190714T055328
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190713_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-22\, Islamic: 1440-11-10 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -33965,7 +33965,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190713T003111
 DTEND;TZID=Asia/Calcutta:20190713T162529
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-13T00:31:11.999998+05:30
 DESCRIPTION:In the three months of āṣāḍha\, bhādrapada and kārtika
  \, if the śukla-dvādaśī tithi touches the asterisms of anurādha\, śr
@@ -33986,7 +33986,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190712T235957
 DTEND;TZID=Asia/Calcutta:20190713T062753
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-07-12T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -34005,7 +34005,7 @@ SUMMARY:kāñcī 31 jagadguru-śrī-brahmānandaghanēndra-sarasvatī-ār
  ādhanā #1352
 DTSTART;VALUE=DATE:20190713
 DTEND;VALUE=DATE:20190714
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī31jagadguru-śrī-brahmānandaghanēndra-sarasvatī-ārādhan
  ā#1352_2019-07-13T05:53:11.040011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -34031,7 +34031,7 @@ SUMMARY:kāñcī 63 jagadguru-śrī-mahādēvēndra-sarasvatī-5-ārādhan
  ā #206
 DTSTART;VALUE=DATE:20190713
 DTEND;VALUE=DATE:20190714
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī63jagadguru-śrī-mahādēvēndra-sarasvatī-5-ārādhanā#206
  _2019-07-13T05:53:11.040011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -34056,7 +34056,7 @@ BEGIN:VEVENT
 SUMMARY:vāsudēva-dvādaśī
 DTSTART;VALUE=DATE:20190713
 DTEND;VALUE=DATE:20190714
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vāsudēva-dvādaśī_2019-07-13T05:53:11.040011+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Āṣāḍhaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -34076,7 +34076,7 @@ BEGIN:VEVENT
 SUMMARY:śākavrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190713
 DTEND;VALUE=DATE:20190714
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śākavrata-ārambhaḥ_2019-07-13T05:53:11.040011+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Āṣāḍhaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>vāsudēva śucau māsē 
@@ -34100,7 +34100,7 @@ SUMMARY:Āṣāḍhaḥ-04-13  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190714T055328
 DTEND;TZID=Asia/Calcutta:20190715T055345
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190714_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-23\, Islamic: 1440-11-11 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -34157,7 +34157,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190714T183557
 DTEND;TZID=Asia/Calcutta:20190715T055345
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-14T18:35:57.119997+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -34178,7 +34178,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190714T205512
 DTEND;TZID=Asia/Calcutta:20190714T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-07-14T20:55:12.000006+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Jul-14 20:55. At this moment budhaḥ is at puṣyaḥ-2 kark
@@ -34197,7 +34197,7 @@ BEGIN:VEVENT
 SUMMARY:jyēṣṭhābhiṣēkaḥ
 DTSTART;VALUE=DATE:20190714
 DTEND;VALUE=DATE:20190715
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:jyēṣṭhābhiṣēkaḥ_2019-07-14T05:53:28.319981+05:30
 DESCRIPTION:Observed on Jyēṣṭhā nakshatra of Mithunam (sidereal sola
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>चन्द्रमस
@@ -34220,7 +34220,7 @@ BEGIN:VEVENT
 SUMMARY:ravivāra-śukla-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190714T183557
 DTEND;TZID=Asia/Calcutta:20190714T200046
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ravivāra-śukla-pradōṣa-vratam_2019-07-14T18:35:57.119997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/ravi
@@ -34240,7 +34240,7 @@ SUMMARY:Āṣāḍhaḥ-04-14  \,Dhanuḥ-Mūlā🌛🌌  \,  Mithunam-Pun
  arvasuḥ-03-31🌞🌌  \,  Nabhaḥ-05-24🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190715T055345
 DTEND;TZID=Asia/Calcutta:20190716T055402
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190715_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-24\, Islamic: 1440-11-12 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -34296,7 +34296,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190715
 DTEND;VALUE=DATE:20190716
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-15T05:53:45.599992+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -34336,7 +34336,7 @@ BEGIN:VEVENT
 SUMMARY:pavitra-caturdaśī
 DTSTART;VALUE=DATE:20190715
 DTEND;VALUE=DATE:20190716
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pavitra-caturdaśī_2019-07-15T05:53:45.599992+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Āṣāḍhaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -34358,7 +34358,7 @@ SUMMARY:Āṣāḍhaḥ-04-15  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,
  alaḥ
 DTSTART;TZID=Asia/Calcutta:20190716T055402
 DTEND;TZID=Asia/Calcutta:20190717T055420
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190716_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-25\, Islamic: 1440-11-13 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Mithunam\, तं- Āni\, म- Mithunaṁ\, 
@@ -34415,7 +34415,7 @@ BEGIN:VEVENT
 SUMMARY:āṣāḍha-pūrṇimā-snānam
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āṣāḍha-pūrṇimā-snānam_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/04/15/ASADha-pUrNimA-sn
@@ -34436,7 +34436,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgārakaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190716T203720
 DTEND;TZID=Asia/Calcutta:20190716T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:aṅgārakaḥ–astamayaḥ(prāk)_2019-07-16T20:37:20.640016+05:30
 DESCRIPTION:aṅgārakaḥ sets into combustion (astamayaH)\, heading prā
  k (east)\, on 2019-Jul-16 20:37. At this moment aṅgārakaḥ is at puṣ
@@ -34455,7 +34455,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -34490,7 +34490,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -34513,7 +34513,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -34538,7 +34538,7 @@ BEGIN:VEVENT
 SUMMARY:candra-grahaṇam (rāhupucchagrasta)
 DTSTART;TZID=Asia/Calcutta:20190717T013140
 DTEND;TZID=Asia/Calcutta:20190717T042939
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:candra-grahaṇam(rāhupucchagrasta)_2019-07-17T01:31:40.799990+05:30
 DESCRIPTION:Partial lunar eclipse (parimāṇa ≈7.8 of 12 aṅgulas)\, M
  oon at the Rahu node (puccha/descending). <br/><br/>Umbral magnitude: 0.65
@@ -34569,7 +34569,7 @@ BEGIN:VEVENT
 SUMMARY:guru-pūrṇimā/vyāsa-pūjā
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:guru-pūrṇimā/vyāsa-pūjā_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/04/15/guru-pUrNimA_or_v
@@ -34591,7 +34591,7 @@ SUMMARY:kāñcī 10 jagadguru-śrī-surēśvarēndra-sarasvatī-ārādhan
  ā #1893
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī10jagadguru-śrī-surēśvarēndra-sarasvatī-ārādhanā#1893
  _2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -34616,7 +34616,7 @@ BEGIN:VEVENT
 SUMMARY:kōkilā-vratam
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kōkilā-vratam_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/04/15/kOkilA-vratam.tom
@@ -34637,7 +34637,7 @@ BEGIN:VEVENT
 SUMMARY:karkaṭa-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190716T160930
 DTEND;TZID=Asia/Calcutta:20190716T183548
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:karkaṭa-saṅkramaṇa-puṇyakālaḥ_2019-07-16T16:09:30.239997+05
  :30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -34657,7 +34657,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(brahma-sāvarṇiḥ-[10])
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(brahma-sāvarṇiḥ-[10])_2019-07-16T05:54:02.880003+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -34681,7 +34681,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -34702,7 +34702,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -34726,7 +34726,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -34746,7 +34746,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -34765,7 +34765,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190716T121455
 DTEND;TZID=Asia/Calcutta:20190716T183548
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-07-16T12:14:55.68
  0007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -34785,7 +34785,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-07-16T05:54:02.8800
  03+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -34808,7 +34808,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -34830,7 +34830,7 @@ BEGIN:VEVENT
 SUMMARY:yaticāturmāsyavrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:yaticāturmāsyavrata-ārambhaḥ_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āṣāḍhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -34850,7 +34850,7 @@ BEGIN:VEVENT
 SUMMARY:śiva-śayanōtsavaḥ
 DTSTART;VALUE=DATE:20190716
 DTEND;VALUE=DATE:20190717
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śiva-śayanōtsavaḥ_2019-07-16T05:54:02.880003+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āṣāḍhaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -34872,7 +34872,7 @@ SUMMARY:Āṣāḍhaḥ-04-16  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,
  udhaḥ
 DTSTART;TZID=Asia/Calcutta:20190717T055420
 DTEND;TZID=Asia/Calcutta:20190718T055428
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190717_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-26\, Islamic: 1440-11-14 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -34929,7 +34929,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -34975,7 +34975,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:One should not perform adhyayana for three days\, commencing f
  rom the pūrṇimā of the three months\, āṣāḍha\, kārtika and phā
@@ -34998,7 +34998,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190717T055420
 DTEND;TZID=Asia/Calcutta:20190717T183548
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -35021,7 +35021,7 @@ SUMMARY:kāñcī 54 jagadguru-śrī-vyāsācala-mahādēvēndra-sarasvatī
  -ārādhanā #513
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī54jagadguru-śrī-vyāsācala-mahādēvēndra-sarasvatī-ārā
  dhanā#513_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -35046,7 +35046,7 @@ BEGIN:VEVENT
 SUMMARY:mr̥gaśīrṣa-vratam
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:mr̥gaśīrṣa-vratam_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of Āṣāḍhaḥ (lu
  nar) month (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -35066,7 +35066,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-07-17T05:54:
  20.160014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -35093,7 +35093,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -35112,7 +35112,7 @@ BEGIN:VEVENT
 SUMMARY:sarvanadī-rajasvalā
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarvanadī-rajasvalā_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/nadI/sidereal_solar_month/day/04/01/sarvan
@@ -35134,7 +35134,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190717
 DTEND;VALUE=DATE:20190718
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-07-17T05:54:20.160014+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -35157,7 +35157,7 @@ SUMMARY:Āṣāḍhaḥ-04-17  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Kark
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190718T055428
 DTEND;TZID=Asia/Calcutta:20190719T055446
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190718_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-27\, Islamic: 1440-11-15 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35213,7 +35213,7 @@ BEGIN:VEVENT
 SUMMARY:aṣṭanāga-pūjā
 DTSTART;VALUE=DATE:20190718
 DTEND;VALUE=DATE:20190719
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:aṣṭanāga-pūjā_2019-07-18T05:54:28.799999+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvitīyā tithi of Āṣāḍhaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -35233,7 +35233,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190718
 DTEND;VALUE=DATE:20190719
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-18T05:54:28.799999+05:30
 DESCRIPTION:On the kr̥ṣṇa-pakṣa-dvitīyā days in the months of ā
  ṣāḍha\, kārtika and phālguna\, one must not perform adhyayana.<br/>
@@ -35262,7 +35262,7 @@ BEGIN:VEVENT
 SUMMARY:aśūnyaśayana-vratam
 DTSTART;VALUE=DATE:20190718
 DTEND;VALUE=DATE:20190719
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:aśūnyaśayana-vratam_2019-07-18T05:54:28.799999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/04/17/azUnyaza
@@ -35283,7 +35283,7 @@ BEGIN:VEVENT
 SUMMARY:cāturmāsya-dvitīyā
 DTSTART;VALUE=DATE:20190718
 DTEND;VALUE=DATE:20190719
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cāturmāsya-dvitīyā_2019-07-18T05:54:28.799999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/04/17/cAturmAsya-dv
@@ -35304,7 +35304,7 @@ BEGIN:VEVENT
 SUMMARY:sarvanadī-rajasvalā
 DTSTART;VALUE=DATE:20190718
 DTEND;VALUE=DATE:20190719
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarvanadī-rajasvalā_2019-07-18T05:54:28.799999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/nadI/sidereal_solar_month/day/04/02/sarvan
@@ -35326,7 +35326,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190718
 DTEND;VALUE=DATE:20190719
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-07-18T05:54:28.799999+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -35347,7 +35347,7 @@ SUMMARY:Āṣāḍhaḥ-04-17  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Ka
  raḥ
 DTSTART;TZID=Asia/Calcutta:20190719T055446
 DTEND;TZID=Asia/Calcutta:20190720T055503
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190719_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-28\, Islamic: 1440-11-16 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35404,7 +35404,7 @@ BEGIN:VEVENT
 SUMMARY:Āḍi Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190719
 DTEND;VALUE=DATE:20190720
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ĀḍiVeḷḷikkiḻamai_2019-07-19T05:54:46.080010+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of āḍi are special for propitiating Shakti Devi.<br/><br/>## Deta
@@ -35424,7 +35424,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190719
 DTEND;VALUE=DATE:20190720
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-19T05:54:46.080010+05:30
 DESCRIPTION:On the kr̥ṣṇa-pakṣa-tr̥tīyā days in the months of ā
  ṣāḍha\, kārtika and phālguna\, one must not perform adhyayana\, as 
@@ -35449,7 +35449,7 @@ BEGIN:VEVENT
 SUMMARY:sarvanadī-rajasvalā
 DTSTART;VALUE=DATE:20190719
 DTEND;VALUE=DATE:20190720
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarvanadī-rajasvalā_2019-07-19T05:54:46.080010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/nadI/sidereal_solar_month/day/04/03/sarvan
@@ -35473,7 +35473,7 @@ SUMMARY:Āṣāḍhaḥ-04-18  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Kark
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190720T055503
 DTEND;TZID=Asia/Calcutta:20190721T055520
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190720_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-29\, Islamic: 1440-11-17 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35529,7 +35529,7 @@ BEGIN:VEVENT
 SUMMARY:gajānana-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20190720
 DTEND;VALUE=DATE:20190721
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:gajānana-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-07-20T
  05:55:03.359981+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -35559,7 +35559,7 @@ SUMMARY:Āṣāḍhaḥ-04-19  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Kark
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190721T055520
 DTEND;TZID=Asia/Calcutta:20190722T055537
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190721_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-30\, Islamic: 1440-11-18 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35618,7 +35618,7 @@ SUMMARY:Āṣāḍhaḥ-04-20  \,Mīnaḥ-Pūrvaprōṣṭhapadā🌛🌌
   Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190722T055537
 DTEND;TZID=Asia/Calcutta:20190723T055546
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190722_day_summary
 DESCRIPTION:- Indian civil date: 1941-04-31\, Islamic: 1440-11-19 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35675,7 +35675,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190722T183505
 DTEND;TZID=Asia/Calcutta:20190723T055546
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-22T18:35:05.280004+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -35699,7 +35699,7 @@ SUMMARY:Āṣāḍhaḥ-04-21  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌
   \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190723T055546
 DTEND;TZID=Asia/Calcutta:20190724T055603
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190723_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-01\, Islamic: 1440-11-20 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35756,7 +35756,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190723
 DTEND;VALUE=DATE:20190724
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-23T05:55:46.559988+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -35781,7 +35781,7 @@ BEGIN:VEVENT
 SUMMARY:nabhasya-māsaḥ
 DTSTART;TZID=Asia/Calcutta:20190723T082021
 DTEND;TZID=Asia/Calcutta:20190723T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:nabhasya-māsaḥ_2019-07-23T08:20:21.120018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -35800,7 +35800,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190723T055546
 DTEND;TZID=Asia/Calcutta:20190723T121521
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-07-23T05
  :55:46.559988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -35821,7 +35821,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190723T055546
 DTEND;TZID=Asia/Calcutta:20190723T144423
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-viṣṇupadī-puṇyakālaḥ_2019-07-23T05:55:46.559988+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -35841,7 +35841,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190723T122954
 DTEND;TZID=Asia/Calcutta:20190723T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-07-23T12:29:54.240010+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -35858,7 +35858,7 @@ SUMMARY:Āṣāḍhaḥ-04-22  \,Mīnaḥ-Rēvatī🌛🌌  \,  Karkaṭa
  ḥ-Puṣyaḥ-04-08🌞🌌  \,  Nabhasyaḥ-06-02🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190724T055603
 DTEND;TZID=Asia/Calcutta:20190725T055621
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190724_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-02\, Islamic: 1440-11-21 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -35915,7 +35915,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190724T183439
 DTEND;TZID=Asia/Calcutta:20190725T055621
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-24T18:34:39.360008+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -35936,7 +35936,7 @@ BEGIN:VEVENT
 SUMMARY:cāmuṇḍēśvarī-jayantī
 DTSTART;VALUE=DATE:20190724
 DTEND;VALUE=DATE:20190725
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:cāmuṇḍēśvarī-jayantī_2019-07-24T05:56:03.839999+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Saptamī tithi of Āṣāḍhaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -35957,7 +35957,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190724
 DTEND;VALUE=DATE:20190725
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-07-24T05:56:03.839999+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -35977,7 +35977,7 @@ SUMMARY:Āṣāḍhaḥ-04-23  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Karkaṭ
  aḥ-Puṣyaḥ-04-09🌞🌌  \,  Nabhasyaḥ-06-03🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190725T055621
 DTEND;TZID=Asia/Calcutta:20190726T055629
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190725_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-03\, Islamic: 1440-11-22 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36034,7 +36034,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190725
 DTEND;VALUE=DATE:20190726
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-25T05:56:21.120010+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -36071,7 +36071,7 @@ SUMMARY:Āṣāḍhaḥ-04-24  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Kar
  raḥ
 DTSTART;TZID=Asia/Calcutta:20190726T055629
 DTEND;TZID=Asia/Calcutta:20190727T055647
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190726_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-04\, Islamic: 1440-11-23 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36128,7 +36128,7 @@ BEGIN:VEVENT
 SUMMARY:Āḍi Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190726
 DTEND;VALUE=DATE:20190727
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ĀḍiVeḷḷikkiḻamai_2019-07-26T05:56:29.759995+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of āḍi are special for propitiating Shakti Devi.<br/><br/>## Deta
@@ -36150,7 +36150,7 @@ SUMMARY:Āṣāḍhaḥ-04-25  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Ka
  niḥ
 DTSTART;TZID=Asia/Calcutta:20190727T055647
 DTEND;TZID=Asia/Calcutta:20190728T055655
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190727_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-05\, Islamic: 1440-11-24 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36206,7 +36206,7 @@ BEGIN:VEVENT
 SUMMARY:karkaṭa-kārttika-pūjā
 DTSTART;VALUE=DATE:20190727
 DTEND;VALUE=DATE:20190728
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:karkaṭa-kārttika-pūjā_2019-07-27T05:56:47.040006+05:30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Karkaṭaḥ (sidereal sol
  ar) month (Sūryāstamayaḥ/puurvaviddha). <br/><br/>Special puja for Sub
@@ -36227,7 +36227,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190727
 DTEND;VALUE=DATE:20190728
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-07-27T05:56:47.040006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -36248,7 +36248,7 @@ BEGIN:VEVENT
 SUMMARY:Mūrtti Nāyanmār (15) Gurupūjai
 DTSTART;VALUE=DATE:20190727
 DTEND;VALUE=DATE:20190728
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:MūrttiNāyanmār(15)Gurupūjai_2019-07-27T05:56:47.040006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -36271,7 +36271,7 @@ BEGIN:VEVENT
 SUMMARY:Pugaḻchchōḻa Nāyanmār (40) Gurupūjai
 DTSTART;VALUE=DATE:20190727
 DTEND;VALUE=DATE:20190728
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:PugaḻchchōḻaNāyanmār(40)Gurupūjai_2019-07-27T05:56:47.040006+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -36295,7 +36295,7 @@ BEGIN:VEVENT
 SUMMARY:śanirōhiṇī-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190727T192813
 DTEND;TZID=Asia/Calcutta:20190727T194622
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śanirōhiṇī-yōgaḥ_2019-07-27T19:28:13.440020+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/zanirOh
@@ -36315,7 +36315,7 @@ SUMMARY:Āṣāḍhaḥ-04-26  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Ka
  ānuḥ
 DTSTART;TZID=Asia/Calcutta:20190728T055655
 DTEND;TZID=Asia/Calcutta:20190729T055712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190728_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-06\, Islamic: 1440-11-25 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36372,7 +36372,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-4
 DTSTART;VALUE=DATE:20190728
 DTEND;VALUE=DATE:20190729
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-4_2019-07-28T05:56:55.679991+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Āṣāḍhaḥ (l
  unar) month (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -36392,7 +36392,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190728T191559
 DTEND;TZID=Asia/Calcutta:20190729T055712
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-07-28T19:15:59.039980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -36411,7 +36411,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-kāmikā-ēkādaśī
 DTSTART;VALUE=DATE:20190728
 DTEND;VALUE=DATE:20190729
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarva-kāmikā-ēkādaśī_2019-07-28T05:56:55.679991+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of āṣāḍha month is known as 
  kāmikā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are gre
@@ -36506,7 +36506,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruppāṇāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20190728
 DTEND;VALUE=DATE:20190729
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:TiruppāṇāḻvārTirunakṣattiram_2019-07-28T05:56:55.679991+05:30
 DESCRIPTION:Observed on Rōhiṇī nakshatra of Karkaṭaḥ (sidereal sol
  ar) month (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -36528,7 +36528,7 @@ SUMMARY:Āṣāḍhaḥ-04-27  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛🌌
  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190729T055712
 DTEND;TZID=Asia/Calcutta:20190730T055730
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190729_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-07\, Islamic: 1440-11-26 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36585,7 +36585,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–udayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190728T235957
 DTEND;TZID=Asia/Calcutta:20190729T062710
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–udayaḥ(prāk)_2019-07-28T23:59:57.120005+05:30
 DESCRIPTION:budhaḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Jul-29 06:27. At this moment budhaḥ is at punarvasuḥ-4 ka
@@ -36604,7 +36604,7 @@ BEGIN:VEVENT
 SUMMARY:sōma-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190729T183330
 DTEND;TZID=Asia/Calcutta:20190729T195902
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sōma-pradōṣa-vratam_2019-07-29T18:33:30.240005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/sOma
@@ -36622,7 +36622,7 @@ BEGIN:VEVENT
 SUMMARY:sōmamr̥gaśīrṣa-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190728T235957
 DTEND;TZID=Asia/Calcutta:20190729T182006
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sōmamr̥gaśīrṣa-yōgaḥ_2019-07-28T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmamRg
@@ -36643,7 +36643,7 @@ SUMMARY:Āṣāḍhaḥ-04-28  \,Mithunam-Ārdrā🌛🌌  \,  Karkaṭa
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190730T055730
 DTEND;TZID=Asia/Calcutta:20190731T055738
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190730_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-08\, Islamic: 1440-11-27 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36700,7 +36700,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190730T183312
 DTEND;TZID=Asia/Calcutta:20190731T055738
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-30T18:33:12.959994+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -36721,7 +36721,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190730T141728
 DTEND;TZID=Asia/Calcutta:20190730T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-07-30T14:17:28.319989+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -36737,7 +36737,7 @@ BEGIN:VEVENT
 SUMMARY:Kūṟṟuva Nāyanmār (39) Gurupūjai
 DTSTART;VALUE=DATE:20190730
 DTEND;VALUE=DATE:20190731
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:KūṟṟuvaNāyanmār(39)Gurupūjai_2019-07-30T05:57:30.240013+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -36760,7 +36760,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190730
 DTEND;VALUE=DATE:20190731
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-07-30T05:57:30.240013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -36780,7 +36780,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190730
 DTEND;VALUE=DATE:20190731
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-07-30T05:57:30.240013+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -36801,7 +36801,7 @@ SUMMARY:Āṣāḍhaḥ-04-29  \,Mithunam-Punarvasuḥ🌛🌌  \,  Karka
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190731T055738
 DTEND;TZID=Asia/Calcutta:20190801T055747
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190731_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-09\, Islamic: 1440-11-28 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -36858,7 +36858,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190801
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-07-31T05:57:38.879998+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -36899,7 +36899,7 @@ SUMMARY:kāñcī 38 jagadguru-śrī-abhinavaśaṅkarēndra-sarasvatī-ār
  ādhanā #1180
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190801
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī38jagadguru-śrī-abhinavaśaṅkarēndra-sarasvatī-ārādhan
  ā#1180_2019-07-31T05:57:38.879998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -36925,7 +36925,7 @@ SUMMARY:kāñcī 46 jagadguru-śrī-sāndrānandabōdhēndra-sarasvatī-ā
  rādhanā #922
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190801
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī46jagadguru-śrī-sāndrānandabōdhēndra-sarasvatī-ārādha
  nā#922_2019-07-31T05:57:38.879998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -36950,7 +36950,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190801
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-07-31T05:57:38.879998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -36971,7 +36971,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190801
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-07-31T05:57:38.879998+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -36991,7 +36991,7 @@ SUMMARY:sarva-āṣāḍha (karkaṭa) amāvāsyā (alabhyam–punarvasu
  ḥ)
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190801
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarva-āṣāḍha(karkaṭa)amāvāsyā(alabhyam–punarvasuḥ)_2019
  -07-31T05:57:38.879998+05:30
 DESCRIPTION:amāvāsyā of āṣāḍha month\, which also falls in the si
@@ -37021,7 +37021,7 @@ SUMMARY:Āṣāḍhaḥ-04-30  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Kark
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190801T055747
 DTEND;TZID=Asia/Calcutta:20190802T055804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190801_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-10\, Islamic: 1440-11-29 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -37078,7 +37078,7 @@ BEGIN:VEVENT
 SUMMARY:āṣāḍha-māsaḥ
 DTSTART;VALUE=DATE:20190702
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āṣāḍha-māsaḥ_2019-07-02T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/ASADha-mAsaH.tom
@@ -37100,7 +37100,7 @@ BEGIN:VEVENT
 SUMMARY:āṣāḍha-māsa-samāpanam
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āṣāḍha-māsa-samāpanam_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āṣāḍhaḥ (lunar) month
   (Sūryōdayaḥ/paraviddha). <br/><br/>āṣāḍha-māsaḥ ends today<b
@@ -37120,7 +37120,7 @@ BEGIN:VEVENT
 SUMMARY:āṣāḍha-snānapūrtiḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:āṣāḍha-snānapūrtiḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āṣāḍhaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -37139,7 +37139,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -37185,7 +37185,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -37220,7 +37220,7 @@ BEGIN:VEVENT
 SUMMARY:dīpa-pūjā
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dīpa-pūjā_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āṣāḍhaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -37239,7 +37239,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -37258,7 +37258,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -37279,7 +37279,7 @@ BEGIN:VEVENT
 SUMMARY:gurupuṣya-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190731T235957
 DTEND;TZID=Asia/Calcutta:20190801T120953
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:gurupuṣya-yōgaḥ_2019-07-31T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/gurupuS
@@ -37298,7 +37298,7 @@ SUMMARY:kāñcī 41 jagadguru-śrī-gaṅgādharēndra-sarasvatī-2-ārād
  hanā #1070
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī41jagadguru-śrī-gaṅgādharēndra-sarasvatī-2-ārādhanā#
  1070_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -37323,7 +37323,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-08-01T05:57:47.519984
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -37349,7 +37349,7 @@ BEGIN:VEVENT
 SUMMARY:pati-sañjīvanī-vratam
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pati-sañjīvanī-vratam_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āṣāḍhaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refer
@@ -37369,7 +37369,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -37390,7 +37390,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -37411,7 +37411,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -37433,7 +37433,7 @@ BEGIN:VEVENT
 SUMMARY:śrāvaṇa-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190801
 DTEND;VALUE=DATE:20190802
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śrāvaṇa-māsa-ārambhaḥ_2019-08-01T05:57:47.519984+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/05/01/zrAvaNa-m
@@ -37457,7 +37457,7 @@ SUMMARY:Śrāvaṇaḥ-05-02  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Kar
  raḥ
 DTSTART;TZID=Asia/Calcutta:20190802T055804
 DTEND;TZID=Asia/Calcutta:20190803T055813
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190802_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-11\, Islamic: 1440-11-30 Ḏū al
  -Qaʿdah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -37514,7 +37514,7 @@ BEGIN:VEVENT
 SUMMARY:Āḍi Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190802
 DTEND;VALUE=DATE:20190803
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ĀḍiVeḷḷikkiḻamai_2019-08-02T05:58:04.799995+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of āḍi are special for propitiating Shakti Devi.<br/><br/>## Deta
@@ -37534,7 +37534,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190803T034610
 DTEND;TZID=Asia/Calcutta:20190802T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-08-03T03:46:10.560001+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -37550,7 +37550,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190802T183212
 DTEND;TZID=Asia/Calcutta:20190802T195058
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-08-02T18:32:12.480016+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -37569,7 +37569,7 @@ BEGIN:VEVENT
 SUMMARY:manōratha-dvitīyā
 DTSTART;VALUE=DATE:20190802
 DTEND;VALUE=DATE:20190803
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:manōratha-dvitīyā_2019-08-02T05:58:04.799995+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Śrāvaṇaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>VasudevaPooja\, ChandraArghy
@@ -37589,7 +37589,7 @@ BEGIN:VEVENT
 SUMMARY:satyanārāyaṇa-jayantī
 DTSTART;VALUE=DATE:20190802
 DTEND;VALUE=DATE:20190803
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:satyanārāyaṇa-jayantī_2019-08-02T05:58:04.799995+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Śrāvaṇaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Satyanarayana Swami Jayanti 
@@ -37613,7 +37613,7 @@ SUMMARY:Śrāvaṇaḥ-05-03  \,Siṁhaḥ-Maghā🌛🌌  \,  Karkaṭa
  ḥ-Puṣyaḥ-04-18🌞🌌  \,  Nabhasyaḥ-06-12🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190803T055813
 DTEND;TZID=Asia/Calcutta:20190804T055822
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190803_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-12\, Islamic: 1440-12-01 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -37670,7 +37670,7 @@ BEGIN:VEVENT
 SUMMARY:Āḍip Perukku
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ĀḍipPerukku_2019-08-03T05:58:13.440020+05:30
 DESCRIPTION:Observed on day 18 of Karkaṭaḥ (sidereal solar) month (Sū
  ryōdayaḥ/puurvaviddha). <br/><br/>Offer naivedyam of citrAnnam<br/><br/
@@ -37690,7 +37690,7 @@ BEGIN:VEVENT
 SUMMARY:hariyālī-tr̥tīyā
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:hariyālī-tr̥tīyā_2019-08-03T05:58:13.440020+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -37710,7 +37710,7 @@ BEGIN:VEVENT
 SUMMARY:madhuśrāvaṇi-vratam
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:madhuśrāvaṇi-vratam_2019-08-03T05:58:13.440020+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -37730,7 +37730,7 @@ BEGIN:VEVENT
 SUMMARY:pārvatī-pavitrārōpaṇam
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pārvatī-pavitrārōpaṇam_2019-08-03T05:58:13.440020+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -37750,7 +37750,7 @@ BEGIN:VEVENT
 SUMMARY:svarṇa-gaurī-vratam
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:svarṇa-gaurī-vratam_2019-08-03T05:58:13.440020+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -37770,7 +37770,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruvāḍippūram
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190804
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:Tiruvāḍippūram_2019-08-03T05:58:13.440020+05:30
 DESCRIPTION:Observed on Pūrvaphalgunī nakshatra of Karkaṭaḥ (siderea
  l solar) month (Prātaḥ/paraviddha). <br/><br/>śrīviṣṇucitta-kulak
@@ -37795,7 +37795,7 @@ SUMMARY:Śrāvaṇaḥ-05-04  \,Siṁhaḥ-Uttaraphalgunī🌛🌌  \,  Ka
  hānuḥ
 DTSTART;TZID=Asia/Calcutta:20190804T055822
 DTEND;TZID=Asia/Calcutta:20190805T055839
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190804_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-13\, Islamic: 1440-12-02 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -37852,7 +37852,7 @@ BEGIN:VEVENT
 SUMMARY:ēkaviṁśati-divasa-gaṇapati-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190804
 DTEND;VALUE=DATE:20190805
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ēkaviṁśati-divasa-gaṇapati-vrata-ārambhaḥ_2019-08-04T05:58:22
  .080005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Śrāvaṇaḥ (lunar) m
@@ -37873,7 +37873,7 @@ BEGIN:VEVENT
 SUMMARY:dūrvā-gaṇapati-vratam
 DTSTART;VALUE=DATE:20190804
 DTEND;VALUE=DATE:20190805
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dūrvā-gaṇapati-vratam_2019-08-04T05:58:22.080005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Śrāvaṇaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of Ganapati wit
@@ -37893,7 +37893,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190804
 DTEND;VALUE=DATE:20190805
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-08-04T05:58:22.080005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -37914,7 +37914,7 @@ SUMMARY:Śrāvaṇaḥ-05-05  \,Kanyā-Hastaḥ🌛🌌  \,  Karkaṭaḥ-
  Āśrēṣā-04-20🌞🌌  \,  Nabhasyaḥ-06-14🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190805T055839
 DTEND;TZID=Asia/Calcutta:20190806T055848
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190805_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-14\, Islamic: 1440-12-03 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -37970,7 +37970,7 @@ BEGIN:VEVENT
 SUMMARY:garuḍa-pañcamī
 DTSTART;VALUE=DATE:20190805
 DTEND;VALUE=DATE:20190806
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:garuḍa-pañcamī_2019-08-05T05:58:39.360016+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Śrāvaṇaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>* Day Garuda brought Amrutam
@@ -37992,7 +37992,7 @@ BEGIN:VEVENT
 SUMMARY:nāga-pañcamī
 DTSTART;VALUE=DATE:20190805
 DTEND;VALUE=DATE:20190806
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:nāga-pañcamī_2019-08-05T05:58:39.360016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-fauna/lunar_month/tithi/05/05/nAga-pa
@@ -38013,7 +38013,7 @@ BEGIN:VEVENT
 SUMMARY:taittirīya-upākarma hastē
 DTSTART;VALUE=DATE:20190805
 DTEND;VALUE=DATE:20190806
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:taittirīya-upākarmahastē_2019-08-05T05:58:39.360016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/Apastamba/lunar_month/nakshatra/05/13/taitt
@@ -38034,7 +38034,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-yajurvēda-upākarma
 DTSTART;VALUE=DATE:20190805
 DTEND;VALUE=DATE:20190806
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śukla-yajurvēda-upākarma_2019-08-05T05:58:39.360016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/description_only/zukla-yajurvEda-up
@@ -38056,7 +38056,7 @@ SUMMARY:Śrāvaṇaḥ-05-06  \,Kanyā-Citrā🌛🌌  \,  Karkaṭaḥ-Ā
  śrēṣā-04-21🌞🌌  \,  Nabhasyaḥ-06-15🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190806T055848
 DTEND;TZID=Asia/Calcutta:20190807T055856
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190806_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-15\, Islamic: 1440-12-04 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -38113,7 +38113,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190806
 DTEND;VALUE=DATE:20190807
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-08-06T05:58:48.000002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -38134,7 +38134,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190806T133014
 DTEND;TZID=Asia/Calcutta:20190806T222110
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-08-06T13:30:14.400016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -38153,7 +38153,7 @@ BEGIN:VEVENT
 SUMMARY:Perumiḻalaik Kuṟumba Nāyanmār (23) Gurupūjai
 DTSTART;VALUE=DATE:20190806
 DTEND;VALUE=DATE:20190807
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:PerumiḻalaikKuṟumbaNāyanmār(23)Gurupūjai_2019-08-06T05:58:48.00
  0002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -38178,7 +38178,7 @@ BEGIN:VEVENT
 SUMMARY:sūpaudana-vratam
 DTSTART;VALUE=DATE:20190806
 DTEND;VALUE=DATE:20190807
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sūpaudana-vratam_2019-08-06T05:58:48.000002+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Śrāvaṇaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Shiva Puja<br/><br/>## D
@@ -38199,7 +38199,7 @@ SUMMARY:Śrāvaṇaḥ-05-07  \,Tulā-Svātī🌛🌌  \,  Karkaṭaḥ-Ā
  śrēṣā-04-22🌞🌌  \,  Nabhasyaḥ-06-16🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190807T055856
 DTEND;TZID=Asia/Calcutta:20190808T055905
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190807_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-16\, Islamic: 1440-12-05 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -38255,7 +38255,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190807T183028
 DTEND;TZID=Asia/Calcutta:20190808T055905
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-07T18:30:28.799991+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -38276,7 +38276,7 @@ BEGIN:VEVENT
 SUMMARY:avyaṅga-saptamī
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:avyaṅga-saptamī_2019-08-07T05:58:56.639987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/05/07/avyaGga-saptamI.t
@@ -38297,7 +38297,7 @@ BEGIN:VEVENT
 SUMMARY:dvādaśa-saptamī
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dvādaśa-saptamī_2019-08-07T05:58:56.639987+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Śrāvaṇaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Surya Puja\, Danam to please 
@@ -38318,7 +38318,7 @@ SUMMARY:Kaḻaṟiṟṟaṟivār/Chēramān Perumāḷ Nāyanmār (37) Gu
  rupūjai
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:Kaḻaṟiṟṟaṟivār/ChēramānPerumāḷNāyanmār(37)Gurupūjai
  _2019-08-07T05:58:56.639987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -38344,7 +38344,7 @@ BEGIN:VEVENT
 SUMMARY:pāpanāśanī-saptamī
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:pāpanāśanī-saptamī_2019-08-07T05:58:56.639987+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Śrāvaṇaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -38364,7 +38364,7 @@ BEGIN:VEVENT
 SUMMARY:Sundaramūrtti Nāyanmār (1) Gurupūjai/Tiruvāḍi Svāti
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:SundaramūrttiNāyanmār(1)Gurupūjai/TiruvāḍiSvāti_2019-08-07T05:
  58:56.639987+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -38389,7 +38389,7 @@ BEGIN:VEVENT
 SUMMARY:tulasīdāsa-jayantī
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:tulasīdāsa-jayantī_2019-08-07T05:58:56.639987+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Śrāvaṇaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -38409,7 +38409,7 @@ BEGIN:VEVENT
 SUMMARY:śītalā-saptamī
 DTSTART;VALUE=DATE:20190807
 DTEND;VALUE=DATE:20190808
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:śītalā-saptamī_2019-08-07T05:58:56.639987+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Śrāvaṇaḥ (lunar) mo
  nth (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Ref
@@ -38430,7 +38430,7 @@ SUMMARY:Śrāvaṇaḥ-05-08  \,Tulā-Viśākhā🌛🌌  \,  Karkaṭaḥ
  -Āśrēṣā-04-23🌞🌌  \,  Nabhasyaḥ-06-17🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190808T055905
 DTEND;TZID=Asia/Calcutta:20190809T055913
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190808_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-17\, Islamic: 1440-12-06 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -38487,7 +38487,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190809T040611
 DTEND;TZID=Asia/Calcutta:20190808T235957
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-08-09T04:06:11.520013+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -38503,7 +38503,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190808
 DTEND;VALUE=DATE:20190809
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-08T05:59:05.280012+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -38538,7 +38538,7 @@ BEGIN:VEVENT
 SUMMARY:durgā-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190808
 DTEND;VALUE=DATE:20190809
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:durgā-vrata-ārambhaḥ_2019-08-08T05:59:05.280012+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Śrāvaṇaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -38560,7 +38560,7 @@ SUMMARY:Śrāvaṇaḥ-05-09  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Kar
  ukraḥ
 DTSTART;TZID=Asia/Calcutta:20190809T055913
 DTEND;TZID=Asia/Calcutta:20190810T055922
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190809_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-18\, Islamic: 1440-12-07 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -38617,7 +38617,7 @@ BEGIN:VEVENT
 SUMMARY:Āḍi Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190809
 DTEND;VALUE=DATE:20190810
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:ĀḍiVeḷḷikkiḻamai_2019-08-09T05:59:13.919998+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of āḍi are special for propitiating Shakti Devi.<br/><br/>## Deta
@@ -38638,7 +38638,7 @@ SUMMARY:kāñcī 57 jagadguru-śrī-paramaśivēndra-sarasvatī-2-ārādha
  nā #434
 DTSTART;VALUE=DATE:20190809
 DTEND;VALUE=DATE:20190810
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī57jagadguru-śrī-paramaśivēndra-sarasvatī-2-ārādhanā#43
  4_2019-08-09T05:59:13.919998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -38663,7 +38663,7 @@ BEGIN:VEVENT
 SUMMARY:kaumārī-pūjā
 DTSTART;VALUE=DATE:20190809
 DTEND;VALUE=DATE:20190810
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kaumārī-pūjā_2019-08-09T05:59:13.919998+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -38683,7 +38683,7 @@ BEGIN:VEVENT
 SUMMARY:sēṅgālipuram anantarāma-dīkṣita-jayantī #117
 DTSTART;VALUE=DATE:20190809
 DTEND;VALUE=DATE:20190810
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sēṅgālipuramanantarāma-dīkṣita-jayantī#117_2019-08-09T05:59:1
  3.919998+05:30
 DESCRIPTION:Observed on Anūrādhā nakshatra of Karkaṭaḥ (sidereal so
@@ -38707,7 +38707,7 @@ BEGIN:VEVENT
 SUMMARY:varalakṣmī-vratam
 DTSTART;VALUE=DATE:20190809
 DTEND;VALUE=DATE:20190810
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:varalakṣmī-vratam_2019-08-09T05:59:13.919998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/lakShmI/description_only/varalakSmI-vratam
@@ -38731,7 +38731,7 @@ SUMMARY:Śrāvaṇaḥ-05-10  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  K
  Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190810T055922
 DTEND;TZID=Asia/Calcutta:20190811T055931
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190810_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-19\, Islamic: 1440-12-08 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -38789,7 +38789,7 @@ SUMMARY:kāñcī 29 jagadguru-śrī-pūrṇabōdhēndra-sarasvatī-ārādh
  anā #1402
 DTSTART;VALUE=DATE:20190810
 DTEND;VALUE=DATE:20190811
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī29jagadguru-śrī-pūrṇabōdhēndra-sarasvatī-ārādhanā#1
  402_2019-08-10T05:59:22.559983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -38814,7 +38814,7 @@ BEGIN:VEVENT
 SUMMARY:Kōṭpuli Nāyanmār (57) Gurupūjai
 DTSTART;VALUE=DATE:20190810
 DTEND;VALUE=DATE:20190811
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:KōṭpuliNāyanmār(57)Gurupūjai_2019-08-10T05:59:22.559983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -38837,7 +38837,7 @@ BEGIN:VEVENT
 SUMMARY:Kaliya Nāyanmār (44) Gurupūjai
 DTSTART;VALUE=DATE:20190810
 DTEND;VALUE=DATE:20190811
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:KaliyaNāyanmār(44)Gurupūjai_2019-08-10T05:59:22.559983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -38860,7 +38860,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190810
 DTEND;VALUE=DATE:20190811
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-08-10T05:59:22.559983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -38883,7 +38883,7 @@ SUMMARY:Śrāvaṇaḥ-05-11  \,Dhanuḥ-Mūlā🌛🌌  \,  Karkaṭaḥ-
  Āśrēṣā-04-26🌞🌌  \,  Nabhasyaḥ-06-20🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190811T055931
 DTEND;TZID=Asia/Calcutta:20190812T055939
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190811_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-20\, Islamic: 1440-12-09 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -38940,7 +38940,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-śravaṇa-putradā-ēkādaśī
 DTSTART;VALUE=DATE:20190811
 DTEND;VALUE=DATE:20190812
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:sarva-śravaṇa-putradā-ēkādaśī_2019-08-11T05:59:31.200009+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of śrāvaṇa month is known as ś
  ravaṇa-putradā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaś
@@ -39037,7 +39037,7 @@ SUMMARY:Śrāvaṇaḥ-05-12  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  K
  Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190812T055939
 DTEND;TZID=Asia/Calcutta:20190813T055948
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:20190812_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-21\, Islamic: 1440-12-10 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -39094,7 +39094,7 @@ BEGIN:VEVENT
 SUMMARY:dāmōdara-dvādaśī
 DTSTART;VALUE=DATE:20190812
 DTEND;VALUE=DATE:20190813
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dāmōdara-dvādaśī_2019-08-12T05:59:39.839994+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform Vishnu Pratima Dana
@@ -39114,7 +39114,7 @@ BEGIN:VEVENT
 SUMMARY:dadhi-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190812
 DTEND;VALUE=DATE:20190813
-DTSTAMP:20260822T115607Z
+DTSTAMP:20200101T000000Z
 UID:dadhi-vrata-ārambhaḥ_2019-08-12T05:59:39.839994+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>saṅkarṣaṇāravindāk
@@ -39136,7 +39136,7 @@ BEGIN:VEVENT
 SUMMARY:sōma-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190812T182810
 DTEND;TZID=Asia/Calcutta:20190812T195443
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sōma-pradōṣa-vratam_2019-08-12T18:28:10.559985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/sOma
@@ -39154,7 +39154,7 @@ BEGIN:VEVENT
 SUMMARY:śākavratam
 DTSTART;VALUE=DATE:20190712
 DTEND;VALUE=DATE:20190813
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śākavratam_2019-07-12T23:59:57.120005+05:30
 DESCRIPTION:vāsudēva śucau māsē śākavratamanuttamam।  <br/>tvatpr
  ītyarthaṁ kariṣyē'haṁ nirvighnaṁ kuru mādhava॥<br/><br/><br/>
@@ -39174,7 +39174,7 @@ BEGIN:VEVENT
 SUMMARY:śākavrata-samāpanam
 DTSTART;VALUE=DATE:20190812
 DTEND;VALUE=DATE:20190813
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śākavrata-samāpanam_2019-08-12T05:59:39.839994+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Śrāvaṇaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>vāsudēva namastubhyaṁ p
@@ -39200,7 +39200,7 @@ SUMMARY:Śrāvaṇaḥ-05-13  \,Dhanuḥ-Uttarāṣāḍhā🌛🌌  \,  K
  Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190813T055948
 DTEND;TZID=Asia/Calcutta:20190814T055957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190813_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-22\, Islamic: 1440-12-11 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -39257,7 +39257,7 @@ BEGIN:VEVENT
 SUMMARY:anaṅga-trayōdaśī
 DTSTART;VALUE=DATE:20190813
 DTEND;VALUE=DATE:20190814
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anaṅga-trayōdaśī_2019-08-13T05:59:48.480020+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Śrāvaṇaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -39277,7 +39277,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190813T182744
 DTEND;TZID=Asia/Calcutta:20190814T055957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-13T18:27:44.639989+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -39300,7 +39300,7 @@ SUMMARY:Śrāvaṇaḥ-05-14  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Karka
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190814T055957
 DTEND;TZID=Asia/Calcutta:20190815T060005
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190814_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-23\, Islamic: 1440-12-12 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -39356,7 +39356,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190814
 DTEND;VALUE=DATE:20190815
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-14T05:59:57.120005+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -39396,7 +39396,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190814
 DTEND;VALUE=DATE:20190815
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-08-14T05:59:57.120005+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -39420,7 +39420,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190814
 DTEND;VALUE=DATE:20190815
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-08-14T05:59:57.120005+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -39439,7 +39439,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190814
 DTEND;VALUE=DATE:20190815
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-08-14T05:59:57.120005+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -39460,7 +39460,7 @@ SUMMARY:Śrāvaṇaḥ-05-15  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Karka
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190815T060005
 DTEND;TZID=Asia/Calcutta:20190816T060014
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190815_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-24\, Islamic: 1440-12-13 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -39517,7 +39517,7 @@ BEGIN:VEVENT
 SUMMARY:r̥gvēda-upākarma
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:r̥gvēda-upākarma_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Date is computed in code (ūpakarmaFestivalāssigner.assign_ri
  gveda_upakarma\, in jyotisha) rather than by this file: the first occurren
@@ -39539,7 +39539,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -39574,7 +39574,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -39597,7 +39597,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -39620,7 +39620,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-yajurvēda-upākarma
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-yajurvēda-upākarma_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/description_only/bOdhAyana-yajurvEda-upAk
@@ -39641,7 +39641,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-yajurvēda-upākarma śāntipūrvakam
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-yajurvēda-upākarmaśāntipūrvakam_2019-08-15T06:00:05.7
  59990+05:30
 DESCRIPTION:
@@ -39658,7 +39658,7 @@ BEGIN:VEVENT
 SUMMARY:balabhadra-janmōtsavaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:balabhadra-janmōtsavaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Janmotsava of Balabhadra (Balaram
@@ -39682,7 +39682,7 @@ BEGIN:VEVENT
 SUMMARY:gāyatrī-jayantī
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:gāyatrī-jayantī_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -39702,7 +39702,7 @@ BEGIN:VEVENT
 SUMMARY:hayagrīva-jayantī
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:hayagrīva-jayantī_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/05/15/hayagrIv
@@ -39724,7 +39724,7 @@ SUMMARY:kāñcī 20 jagadguru-śrī-mūkaśaṅkarēndra-sarasvatī-ārād
  hanā #1583
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī20jagadguru-śrī-mūkaśaṅkarēndra-sarasvatī-ārādhanā#
  1583_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -39749,7 +39749,7 @@ BEGIN:VEVENT
 SUMMARY:mahāśrāvaṇī-yōgaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:mahāśrāvaṇī-yōgaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/mahA-z
@@ -39771,7 +39771,7 @@ BEGIN:VEVENT
 SUMMARY:nārikēla-pūrṇimā
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:nārikēla-pūrṇimā_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Offer coconut to sea God Varun
@@ -39791,7 +39791,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -39812,7 +39812,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -39832,7 +39832,7 @@ BEGIN:VEVENT
 SUMMARY:rakṣābandhanam
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:rakṣābandhanam_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/05/15/rakSAbandhanam.to
@@ -39853,7 +39853,7 @@ BEGIN:VEVENT
 SUMMARY:saṁskr̥ta-divasaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:saṁskr̥ta-divasaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>World Sanskrit Day is celebrat
@@ -39873,7 +39873,7 @@ BEGIN:VEVENT
 SUMMARY:sarpa-bali-prārambhaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sarpa-bali-prārambhaḥ_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Offer bali to serpents on (fro
@@ -39896,7 +39896,7 @@ BEGIN:VEVENT
 SUMMARY:śrāvaṇyupavāsaḥ prāyaścittārthaḥ
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrāvaṇyupavāsaḥprāyaścittārthaḥ_2019-08-15T06:00:05.759990
  +05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
@@ -39922,7 +39922,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-08-15T06:00:05.7599
  90+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -39945,7 +39945,7 @@ BEGIN:VEVENT
 SUMMARY:vaikhānasa-maharṣi-jayantī
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vaikhānasa-maharṣi-jayantī_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Śrāvaṇaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -39965,7 +39965,7 @@ BEGIN:VEVENT
 SUMMARY:yajurvēda-upākarma
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:yajurvēda-upākarma_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/description_only/yajurvEda-upAkarma
@@ -39986,7 +39986,7 @@ BEGIN:VEVENT
 SUMMARY:yajurvēda-upākarma śāntipūrvakam
 DTSTART;VALUE=DATE:20190815
 DTEND;VALUE=DATE:20190816
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:yajurvēda-upākarmaśāntipūrvakam_2019-08-15T06:00:05.759990+05:30
 DESCRIPTION:
 TRANSP:TRANSPARENT
@@ -40004,7 +40004,7 @@ SUMMARY:Śrāvaṇaḥ-05-16  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,  Kar
  ukraḥ
 DTSTART;TZID=Asia/Calcutta:20190816T060014
 DTEND;TZID=Asia/Calcutta:20190817T060014
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190816_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-25\, Islamic: 1440-12-14 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Karkaṭaḥ\, तं- Āḍi\, म- Karkka
@@ -40061,7 +40061,7 @@ BEGIN:VEVENT
 SUMMARY:Āḍi Veḷḷikkiḻamai
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ĀḍiVeḷḷikkiḻamai_2019-08-16T06:00:14.400016+05:30
 DESCRIPTION:Very widely celebrated in Tamil Nadu temples\, Fridays in the 
  month of āḍi are special for propitiating Shakti Devi.<br/><br/>## Deta
@@ -40081,7 +40081,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-16T06:00:14.400016+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -40127,7 +40127,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-16T06:00:14.400016+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -40150,7 +40150,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190816T182618
 DTEND;TZID=Asia/Calcutta:20190817T060014
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-16T18:26:18.240015+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -40172,7 +40172,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-16T06:00:14.400016+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -40195,7 +40195,7 @@ BEGIN:VEVENT
 SUMMARY:kāñcī 69 jagadguru-śrī-jayēndra-sarasvatī-jayantī #85
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī69jagadguru-śrī-jayēndra-sarasvatī-jayantī#85_2019-08-16T
  06:00:14.400016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -40220,7 +40220,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-08-16T06:00:
  14.400016+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -40247,7 +40247,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-08-16T06:00:14.400016+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -40266,7 +40266,7 @@ BEGIN:VEVENT
 SUMMARY:sahasragāyatrījapaḥ prāyaścittārthaḥ
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sahasragāyatrījapaḥprāyaścittārthaḥ_2019-08-16T06:00:14.40001
  6+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of Śrāvaṇaḥ (lun
@@ -40292,7 +40292,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190816
 DTEND;VALUE=DATE:20190817
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-08-16T06:00:14.400016+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -40313,7 +40313,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190816T201728
 DTEND;TZID=Asia/Calcutta:20190816T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-08-16T20:17:28.319989+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -40331,7 +40331,7 @@ SUMMARY:Śrāvaṇaḥ-05-17  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Siṁ
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190817T060014
 DTEND;TZID=Asia/Calcutta:20190818T060023
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190817_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-26\, Islamic: 1440-12-15 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -40388,7 +40388,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -40411,7 +40411,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -40436,7 +40436,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -40459,7 +40459,7 @@ BEGIN:VEVENT
 SUMMARY:aśūnyaśayana-vratam
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:aśūnyaśayana-vratam_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/05/17/azUnyaza
@@ -40480,7 +40480,7 @@ BEGIN:VEVENT
 SUMMARY:br̥hatī-vr̥kṣaka-pūjā
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:br̥hatī-vr̥kṣaka-pūjā_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvitīyā tithi of Śrāvaṇaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>VaakuduChettu Puja<br/>
@@ -40500,7 +40500,7 @@ BEGIN:VEVENT
 SUMMARY:bhīma-caṇḍī-jayantī
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bhīma-caṇḍī-jayantī_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvitīyā tithi of Śrāvaṇaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -40521,7 +40521,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥tayugāntaḥ
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kr̥tayugāntaḥ_2019-08-17T06:00:14.400016+05:30
 DESCRIPTION:The day on which Simha sankranti happens is also the Krtayugan
  ta day. Shraadhams offered on this day beget endless fruit.<br/><br/>hēm
@@ -40547,7 +40547,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190817T121303
 DTEND;TZID=Asia/Calcutta:20190817T182543
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-08-17T12:13:03.35
  9997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -40567,7 +40567,7 @@ BEGIN:VEVENT
 SUMMARY:siṁha-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190817T060944
 DTEND;TZID=Asia/Calcutta:20190817T182543
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:siṁha-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ_2019-08-17T
  06:09:44.640013+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -40588,7 +40588,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190817T135242
 DTEND;TZID=Asia/Calcutta:20190817T224848
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-08-17T13:52:42.240019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -40607,7 +40607,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-rāghavēndra-svāmi-ārādhanā #348
 DTSTART;VALUE=DATE:20190817
 DTEND;VALUE=DATE:20190818
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrī-rāghavēndra-svāmi-ārādhanā#348_2019-08-17T06:00:14.400016+
  05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvitīyā tithi of Śrāvaṇaḥ (lun
@@ -40632,7 +40632,7 @@ SUMMARY:Śrāvaṇaḥ-05-18  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌
  ānuḥ
 DTSTART;TZID=Asia/Calcutta:20190818T060023
 DTEND;TZID=Asia/Calcutta:20190819T060031
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190818_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-27\, Islamic: 1440-12-16 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -40689,7 +40689,7 @@ BEGIN:VEVENT
 SUMMARY:Āvaṇi Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20190818
 DTEND;VALUE=DATE:20190819
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ĀvaṇiÑāyiṟṟukkiḻamai_2019-08-18T06:00:23.040001+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -40708,7 +40708,7 @@ BEGIN:VEVENT
 SUMMARY:kajjalī-tr̥tīyā
 DTSTART;VALUE=DATE:20190818
 DTEND;VALUE=DATE:20190819
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kajjalī-tr̥tīyā_2019-08-18T06:00:23.040001+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Śrāvaṇaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -40728,7 +40728,7 @@ BEGIN:VEVENT
 SUMMARY:tuṣṭi-prāpti-tr̥tīyā
 DTSTART;VALUE=DATE:20190818
 DTEND;VALUE=DATE:20190819
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tuṣṭi-prāpti-tr̥tīyā_2019-08-18T06:00:23.040001+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Śrāvaṇaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -40750,7 +40750,7 @@ SUMMARY:Śrāvaṇaḥ-05-19  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌
  maḥ
 DTSTART;TZID=Asia/Calcutta:20190819T060031
 DTEND;TZID=Asia/Calcutta:20190820T060031
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190819_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-28\, Islamic: 1440-12-17 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -40806,7 +40806,7 @@ BEGIN:VEVENT
 SUMMARY:bahulā-caturthī
 DTSTART;VALUE=DATE:20190819
 DTEND;VALUE=DATE:20190820
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bahulā-caturthī_2019-08-19T06:00:31.679986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturthī tithi of Śrāvaṇaḥ (lun
  ar) month (Sāyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -40826,7 +40826,7 @@ BEGIN:VEVENT
 SUMMARY:hēramba-mahāgaṇapati-mahāsaṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20190819
 DTEND;VALUE=DATE:20190820
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:hēramba-mahāgaṇapati-mahāsaṅkaṭahara-caturthī-vratam_2019-08
  -19T06:00:31.679986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -40852,7 +40852,7 @@ SUMMARY:Śrāvaṇaḥ-05-20  \,Mīnaḥ-Rēvatī🌛🌌  \,  Siṁhaḥ-
  Maghā-05-04🌞🌌  \,  Nabhasyaḥ-06-29🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190820T060031
 DTEND;TZID=Asia/Calcutta:20190821T060040
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190820_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-29\, Islamic: 1440-12-18 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -40909,7 +40909,7 @@ BEGIN:VEVENT
 SUMMARY:rakṣā-pañcamī
 DTSTART;VALUE=DATE:20190820
 DTEND;VALUE=DATE:20190821
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:rakṣā-pañcamī_2019-08-20T06:00:31.679986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Śrāvaṇaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Naga (Manasa) Puja<br/>
@@ -40930,7 +40930,7 @@ SUMMARY:Śrāvaṇaḥ-05-21  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Siṁha
  ḥ-Maghā-05-05🌞🌌  \,  Nabhasyaḥ-06-30🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190821T060040
 DTEND;TZID=Asia/Calcutta:20190822T060040
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190821_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-30\, Islamic: 1440-12-19 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -40986,7 +40986,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190821T183907
 DTEND;TZID=Asia/Calcutta:20190821T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-08-21T18:39:07.199996+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Aug-21 18:39. At this moment budhaḥ is at āśrēṣā-2 ka
@@ -41005,7 +41005,7 @@ BEGIN:VEVENT
 SUMMARY:hala-ṣaṣṭhī/lalahī-chaṭha
 DTSTART;VALUE=DATE:20190821
 DTEND;VALUE=DATE:20190822
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:hala-ṣaṣṭhī/lalahī-chaṭha_2019-08-21T06:00:40.320012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/05/21/hala-SaS
@@ -41028,7 +41028,7 @@ SUMMARY:Śrāvaṇaḥ-05-21  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Si
  ṁhaḥ-Maghā-05-06🌞🌌  \,  Nabhasyaḥ-06-31🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190822T060040
 DTEND;TZID=Asia/Calcutta:20190823T060048
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190822_day_summary
 DESCRIPTION:- Indian civil date: 1941-05-31\, Islamic: 1440-12-20 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -41084,7 +41084,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190822T182259
 DTEND;TZID=Asia/Calcutta:20190823T060048
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-22T18:22:59.519990+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -41107,7 +41107,7 @@ SUMMARY:Śrāvaṇaḥ-05-22  \,Mēṣaḥ-Kr̥ttikā🌛🌌  \,  Siṁha
  ḥ-Maghā-05-07🌞🌌  \,  Iṣaḥ-07-01🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190823T060048
 DTEND;TZID=Asia/Calcutta:20190824T060048
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190823_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-01\, Islamic: 1440-12-21 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -41164,7 +41164,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -41199,7 +41199,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -41224,7 +41224,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -41247,7 +41247,7 @@ BEGIN:VEVENT
 SUMMARY:iṣa-māsaḥ/śaradr̥tuḥ
 DTSTART;TZID=Asia/Calcutta:20190823T153203
 DTEND;TZID=Asia/Calcutta:20190823T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:iṣa-māsaḥ/śaradr̥tuḥ_2019-08-23T15:32:03.839991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/iSa-mAsaH_o
@@ -41267,7 +41267,7 @@ SUMMARY:kāñcī 21 jagadguru-śrī-sārvabhaumaguruḥ-candracūḍēndra
  -sarasvatī-ārādhanā #1573
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī21jagadguru-śrī-sārvabhaumaguruḥ-candracūḍēndra-saras
  vatī-ārādhanā#1573_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -41292,7 +41292,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -41313,7 +41313,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(dakṣaḥ-[9])
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(dakṣaḥ-[9])_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/05/23/manvA
@@ -41335,7 +41335,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -41354,7 +41354,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190823T153203
 DTEND;TZID=Asia/Calcutta:20190823T182224
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ṣaḍaśīti-puṇyakālaḥ_2019-08-23T15:32:03.839991+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -41374,7 +41374,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190823T090800
 DTEND;TZID=Asia/Calcutta:20190823T182224
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-08-23T09:08:00.959988
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -41393,7 +41393,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190823T121136
 DTEND;TZID=Asia/Calcutta:20190823T182224
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-08-23T12:
  11:36.959983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -41414,7 +41414,7 @@ BEGIN:VEVENT
 SUMMARY:śrīkr̥ṣṇajanmāṣṭamī
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrīkr̥ṣṇajanmāṣṭamī_2019-08-23T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/05/23/zrIkRSNa
@@ -41437,7 +41437,7 @@ SUMMARY:Śrāvaṇaḥ-05-23  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Si
  ṁhaḥ-Maghā-05-08🌞🌌  \,  Iṣaḥ-07-02🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190824T060048
 DTEND;TZID=Asia/Calcutta:20190825T060057
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190824_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-02\, Islamic: 1440-12-22 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -41493,7 +41493,7 @@ BEGIN:VEVENT
 SUMMARY:ēkaviṁśati-divasa-gaṇapati-vratam
 DTSTART;VALUE=DATE:20190803
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ēkaviṁśati-divasa-gaṇapati-vratam_2019-08-03T23:59:57.120005+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -41512,7 +41512,7 @@ BEGIN:VEVENT
 SUMMARY:ēkaviṁśati-divasa-gaṇapati-vrata-samāpanam
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ēkaviṁśati-divasa-gaṇapati-vrata-samāpanam_2019-08-24T06:00:48.
  959997+05:30
 DESCRIPTION:End of the 21-day Ganapati Vratam.<br/><br/>## Details<br/>- [
@@ -41533,7 +41533,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-24T06:00:48.959997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -41568,7 +41568,7 @@ BEGIN:VEVENT
 SUMMARY:graha-yuddhaḥ (★śukraḥ-aṅgārakaḥ\, maghā siṁhaḥ)
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190826
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:graha-yuddhaḥ(★śukraḥ-aṅgārakaḥ\,maghāsiṁhaḥ)_2019-08
  -23T08:15:01.439998+05:30
 DESCRIPTION:Graha-yuddha (amshu-vimarda) between aṅgārakaḥ and śukra
@@ -41630,7 +41630,7 @@ SUMMARY:kāñcī 24 jagadguru-śrī-citsukhēndra-sarasvatī-ārādhanā #
  1493
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī24jagadguru-śrī-citsukhēndra-sarasvatī-ārādhanā#1493_20
  19-08-24T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -41655,7 +41655,7 @@ BEGIN:VEVENT
 SUMMARY:nandōtsavaḥ
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:nandōtsavaḥ_2019-08-24T06:00:48.959997+05:30
 DESCRIPTION:Since Bhagavan Krishna was taken by Sri Vasudeva to Gokul in t
  he night\, the next day is celebrated as Nandotsava in “Vraja Kshetra”
@@ -41679,7 +41679,7 @@ SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā Toḍakkam/Koḍiyē
  ṟṟam
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻāToḍakkam/Koḍiyēṟṟam_
  2019-08-24T06:00:48.959997+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -41703,7 +41703,7 @@ BEGIN:VEVENT
 SUMMARY:Varagūr Uṟiyaḍi Utsavam
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:VaragūrUṟiyaḍiUtsavam_2019-08-24T06:00:48.959997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/relative_event/zrIkRSNajanmASTamI/o
@@ -41725,7 +41725,7 @@ BEGIN:VEVENT
 SUMMARY:śanirōhiṇī-yōgaḥ
 DTSTART;VALUE=DATE:20190823
 DTEND;VALUE=DATE:20190824
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śanirōhiṇī-yōgaḥ_2019-08-23T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/zanirOh
@@ -41746,7 +41746,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-jayantī (niśītha-kālānusāram)
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrī-jayantī(niśītha-kālānusāram)_2019-08-24T06:00:48.959997+05
  :30
 DESCRIPTION:Observed on Rōhiṇī nakshatra of Siṁhaḥ (sidereal solar
@@ -41767,7 +41767,7 @@ BEGIN:VEVENT
 SUMMARY:śrīkr̥ṣṇadēvarāya-rājyābhiṣēkaḥ
 DTSTART;VALUE=DATE:20190824
 DTEND;VALUE=DATE:20190825
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrīkr̥ṣṇadēvarāya-rājyābhiṣēkaḥ_2019-08-24T06:00:48.95
  9997+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Śrāvaṇaḥ (l
@@ -41790,7 +41790,7 @@ SUMMARY:Śrāvaṇaḥ-05-24  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛🌌  \
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190825T060057
 DTEND;TZID=Asia/Calcutta:20190826T060057
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190825_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-03\, Islamic: 1440-12-23 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -41847,7 +41847,7 @@ BEGIN:VEVENT
 SUMMARY:Āvaṇi Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20190825
 DTEND;VALUE=DATE:20190826
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ĀvaṇiÑāyiṟṟukkiḻamai_2019-08-25T06:00:57.599983+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -41866,7 +41866,7 @@ BEGIN:VEVENT
 SUMMARY:caṇḍikā-pūjā
 DTSTART;VALUE=DATE:20190825
 DTEND;VALUE=DATE:20190826
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:caṇḍikā-pūjā_2019-08-25T06:00:57.599983+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Śrāvaṇaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -41886,7 +41886,7 @@ BEGIN:VEVENT
 SUMMARY:kaumāra-pūjā
 DTSTART;VALUE=DATE:20190825
 DTEND;VALUE=DATE:20190826
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kaumāra-pūjā_2019-08-25T06:00:57.599983+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Śrāvaṇaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -41906,7 +41906,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 2M Nāḷ
 DTSTART;VALUE=DATE:20190825
 DTEND;VALUE=DATE:20190826
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā2MNāḷ_2019-08-25T06:00:57.
  599983+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -41930,7 +41930,7 @@ SUMMARY:Śrāvaṇaḥ-05-25  \,Mithunam-Ārdrā🌛🌌  \,  Siṁhaḥ-M
  aghā-05-10🌞🌌  \,  Iṣaḥ-07-04🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190826T060057
 DTEND;TZID=Asia/Calcutta:20190827T060106
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190826_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-04\, Islamic: 1440-12-24 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -41987,7 +41987,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190826T135308
 DTEND;TZID=Asia/Calcutta:20190826T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-08-26T13:53:08.160016+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -42003,7 +42003,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190826
 DTEND;VALUE=DATE:20190827
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-08-26T06:00:57.599983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -42024,7 +42024,7 @@ BEGIN:VEVENT
 SUMMARY:smārta-ajā-ēkādaśī
 DTSTART;VALUE=DATE:20190826
 DTEND;VALUE=DATE:20190827
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:smārta-ajā-ēkādaśī_2019-08-26T06:00:57.599983+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of śrāvaṇa month is known as a
  jā-ēkādaśī. Satya Harishchandra performed this to get back family and
@@ -42121,7 +42121,7 @@ SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 3M Nāḷ—Murugan B
  havani
 DTSTART;VALUE=DATE:20190826
 DTEND;VALUE=DATE:20190827
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā3MNāḷ—MuruganBhavani_201
  9-08-26T06:00:57.599983+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -42146,7 +42146,7 @@ SUMMARY:Śrāvaṇaḥ-05-27  \,Mithunam-Punarvasuḥ🌛🌌  \,  Siṁha
  ḥ-Maghā-05-11🌞🌌  \,  Iṣaḥ-07-05🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190827T060106
 DTEND;TZID=Asia/Calcutta:20190828T060106
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190827_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-05\, Islamic: 1440-12-25 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -42203,7 +42203,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190826T235957
 DTEND;TZID=Asia/Calcutta:20190827T103508
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-08-26T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -42221,7 +42221,7 @@ BEGIN:VEVENT
 SUMMARY:jayā-mahādvādaśī
 DTSTART;VALUE=DATE:20190827
 DTEND;VALUE=DATE:20190828
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:jayā-mahādvādaśī_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/jayA
@@ -42243,7 +42243,7 @@ BEGIN:VEVENT
 SUMMARY:rōhiṇī-dvādaśī
 DTSTART;VALUE=DATE:20190827
 DTEND;VALUE=DATE:20190828
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:rōhiṇī-dvādaśī_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Śrāvaṇaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -42264,7 +42264,7 @@ SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 4M Nāḷ—Yānai V
  āhanattil Murugan-Ambāḷ Bhavani
 DTSTART;VALUE=DATE:20190827
 DTEND;VALUE=DATE:20190828
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā4MNāḷ—YānaiVāhanattilM
  urugan-AmbāḷBhavani_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -42288,7 +42288,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;VALUE=DATE:20190827
 DTEND;VALUE=DATE:20190828
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -42310,7 +42310,7 @@ BEGIN:VEVENT
 SUMMARY:vaiṣṇava-ajā-ēkādaśī
 DTSTART;VALUE=DATE:20190827
 DTEND;VALUE=DATE:20190828
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vaiṣṇava-ajā-ēkādaśī_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of śrāvaṇa month is known as a
  jā-ēkādaśī. Satya Harishchandra performed this to get back family and
@@ -42406,7 +42406,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190827
 DTEND;VALUE=DATE:20190828
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -42429,7 +42429,7 @@ SUMMARY:Śrāvaṇaḥ-05-28  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Siṁ
  haḥ-Maghā-05-12🌞🌌  \,  Iṣaḥ-07-06🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190828T060106
 DTEND;TZID=Asia/Calcutta:20190829T060106
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190828_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-06\, Islamic: 1440-12-26 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -42486,7 +42486,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190828T181914
 DTEND;TZID=Asia/Calcutta:20190829T060106
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-28T18:19:14.880010+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -42507,7 +42507,7 @@ BEGIN:VEVENT
 SUMMARY:Cheruttuṇai Nāyanmār (54) Gurupūjai
 DTSTART;VALUE=DATE:20190828
 DTEND;VALUE=DATE:20190829
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:CheruttuṇaiNāyanmār(54)Gurupūjai_2019-08-28T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -42530,7 +42530,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190828
 DTEND;VALUE=DATE:20190829
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-08-28T06:01:06.240008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -42550,7 +42550,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190828
 DTEND;VALUE=DATE:20190829
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-08-28T06:01:06.240008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -42569,7 +42569,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190828T181914
 DTEND;TZID=Asia/Calcutta:20190828T194705
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-08-28T18:19:14.880010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -42587,7 +42587,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 5M Nāḷ
 DTSTART;VALUE=DATE:20190828
 DTEND;VALUE=DATE:20190829
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā5MNāḷ_2019-08-28T06:01:06.
  240008+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -42611,7 +42611,7 @@ SUMMARY:Śrāvaṇaḥ-05-29  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Si
  ṁhaḥ-Maghā-05-13🌞🌌  \,  Iṣaḥ-07-07🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190829T060106
 DTEND;TZID=Asia/Calcutta:20190830T060106
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190829_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-07\, Islamic: 1440-12-27 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -42668,7 +42668,7 @@ BEGIN:VEVENT
 SUMMARY:aghōra-caturdaśī
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:aghōra-caturdaśī_2019-08-29T06:01:06.240008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of Śrāvaṇaḥ (l
  unar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<
@@ -42688,7 +42688,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-29T06:01:06.240008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -42728,7 +42728,7 @@ BEGIN:VEVENT
 SUMMARY:Atipatta Nāyanmār (42) Gurupūjai
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:AtipattaNāyanmār(42)Gurupūjai_2019-08-29T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -42751,7 +42751,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-śrāvaṇa-amāvāsyā
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-śrāvaṇa-amāvāsyā_2019-08-29T06:01:06.24
  0008+05:30
 DESCRIPTION:
@@ -42768,7 +42768,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-5
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-5_2019-08-29T06:01:06.240008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Śrāvaṇaḥ (lunar) month 
  (Pūrvarātriḥ##~##(Trēdhā)/paraviddha). <br/><br/><br/><br/>## Detail
@@ -42788,7 +42788,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-08-29T06:01:06.240008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -42808,7 +42808,7 @@ SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 6M Nāḷ—Veḷḷi
  t Tēr Bhavani
 DTSTART;VALUE=DATE:20190829
 DTEND;VALUE=DATE:20190830
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā6MNāḷ—VeḷḷitTērBhav
  ani_2019-08-29T06:01:06.240008+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -42833,7 +42833,7 @@ SUMMARY:Śrāvaṇaḥ-05-30  \,Siṁhaḥ-Maghā🌛🌌  \,  Siṁhaḥ-
  Maghā-05-14🌞🌌  \,  Iṣaḥ-07-08🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20190830T060106
 DTEND;TZID=Asia/Calcutta:20190831T060114
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190830_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-08\, Islamic: 1440-12-28 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -42889,7 +42889,7 @@ BEGIN:VEVENT
 SUMMARY:64 yōginī-pūjā
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:64yōginī-pūjā_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Śrāvaṇaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -42909,7 +42909,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -42944,7 +42944,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-iṣṭiḥ
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-iṣṭiḥ_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:iṣṭiḥ is performed on this day by those following the b
  ōdhāyana/kātyāyana sūtras. This difference happens because chandradar
@@ -42966,7 +42966,7 @@ BEGIN:VEVENT
 SUMMARY:darbha-saṅgrahaḥ
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:darbha-saṅgrahaḥ_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-flora/sidereal_solar_month/tithi/05/3
@@ -42988,7 +42988,7 @@ BEGIN:VEVENT
 SUMMARY:Iḷaiyānkuḍi Māṟa Nāyanmār (4) Gurupūjai
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:IḷaiyānkuḍiMāṟaNāyanmār(4)Gurupūjai_2019-08-30T06:01:06.240
  008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -43012,7 +43012,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -43033,7 +43033,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -43055,7 +43055,7 @@ SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 7M Nāḷ—Chigappu
  Chātti Alaṅkāram
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā7MNāḷ—ChigappuChāttiAla
  ṅkāram_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -43080,7 +43080,7 @@ BEGIN:VEVENT
 SUMMARY:vr̥ṣabha-pūjā
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vr̥ṣabha-pūjā_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Śrāvaṇaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vrushabha puja\; Nandi born to Sh
@@ -43100,7 +43100,7 @@ BEGIN:VEVENT
 SUMMARY:śrāvaṇa-amāvāsyā
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrāvaṇa-amāvāsyā_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:amāvāsyā of śrāvaṇa month<br/><br/>## Details<br/>- [Ed
  it config file](https://github.com/jyotisham/adyatithi/blob/master/time_fo
@@ -43119,7 +43119,7 @@ BEGIN:VEVENT
 SUMMARY:śrāvaṇa-māsaḥ
 DTSTART;VALUE=DATE:20190731
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrāvaṇa-māsaḥ_2019-07-31T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/zrAvaNa-mAsaH.to
@@ -43141,7 +43141,7 @@ BEGIN:VEVENT
 SUMMARY:śrāvaṇa-māsa-samāpanam
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190831
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrāvaṇa-māsa-samāpanam_2019-08-30T06:01:06.240008+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Śrāvaṇaḥ (lunar) month 
  (Sūryōdayaḥ/paraviddha). <br/><br/>śrāvaṇa-māsaḥ ends today<br/
@@ -43162,7 +43162,7 @@ SUMMARY:Bhādrapadaḥ-06-01  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Si
  ṁhaḥ-Maghā-05-15🌞🌌  \,  Iṣaḥ-07-09🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190831T060114
 DTEND;TZID=Asia/Calcutta:20190901T060114
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190831_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-09\, Islamic: 1440-12-29 Ḏū al
  -Ḥijjah\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅ
@@ -43219,7 +43219,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-08-31T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -43265,7 +43265,7 @@ BEGIN:VEVENT
 SUMMARY:bhādrapada-candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190831T181722
 DTEND;TZID=Asia/Calcutta:20190831T191900
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bhādrapada-candra-darśanam_2019-08-31T18:17:22.559999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/graha/description_only/bhAdrapada-candra-d
@@ -43283,7 +43283,7 @@ BEGIN:VEVENT
 SUMMARY:bhādrapada-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bhādrapada-māsa-ārambhaḥ_2019-08-31T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/06/01/bhAdrapad
@@ -43305,7 +43305,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-08-31T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -43324,7 +43324,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-08-31T06:01:14.879993
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -43350,7 +43350,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-08-31T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -43372,7 +43372,7 @@ SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 8M Nāḷ—Pachchai
  Chātti Alaṅkāram
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā8MNāḷ—PachchaiChāttiAla
  ṅkāram_2019-08-31T06:01:14.879993+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -43397,7 +43397,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190831T140522
 DTEND;TZID=Asia/Calcutta:20190901T060114
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-08-31T14:05:22.560015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -43418,7 +43418,7 @@ SUMMARY:Bhādrapadaḥ-06-02  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Siṁh
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190901T060114
 DTEND;TZID=Asia/Calcutta:20190902T060114
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190901_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-10\, Islamic: 1441-01-01 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -43475,7 +43475,7 @@ BEGIN:VEVENT
 SUMMARY:ādityahasta-nakta-vrata-yōgaḥ
 DTSTART;VALUE=DATE:20190831
 DTEND;VALUE=DATE:20190901
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ādityahasta-nakta-vrata-yōgaḥ_2019-08-31T23:59:57.120005+05:30
 DESCRIPTION:The Aditya-Hasta combination is also special for observing nak
  ta-vratams as per Agni Purana.<br/><br/>agnipurāṇē---  <br/>vāravrat
@@ -43497,7 +43497,7 @@ BEGIN:VEVENT
 SUMMARY:ādityahasta-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190901T110841
 DTEND;TZID=Asia/Calcutta:20190901T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ādityahasta-yōgaḥ_2019-09-01T11:08:41.280000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/Adityah
@@ -43516,7 +43516,7 @@ BEGIN:VEVENT
 SUMMARY:Āvaṇi Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ĀvaṇiÑāyiṟṟukkiḻamai_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -43535,7 +43535,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-jayantī
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-jayantī_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Bhādrapadaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -43555,7 +43555,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -43578,7 +43578,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -43601,7 +43601,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -43622,7 +43622,7 @@ BEGIN:VEVENT
 SUMMARY:haritālikā-vratam
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:haritālikā-vratam_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Bhādrapadaḥ (lunar) 
  month (Prātaḥ/paraviddha). <br/><br/>Puja of Gauri-Maheshwara on Vrisha
@@ -43645,7 +43645,7 @@ BEGIN:VEVENT
 SUMMARY:kalki-jayantī
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kalki-jayantī_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/06/02/kalki~ja
@@ -43666,7 +43666,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(tāmasaḥ-[4])
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(tāmasaḥ-[4])_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/06/03/manvA
@@ -43688,7 +43688,7 @@ BEGIN:VEVENT
 SUMMARY:sāmavēda-upākarma
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sāmavēda-upākarma_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:Date is computed in code (ūpakarmaFestivalāssigner.assign_sa
  amopakarma\, in jyotisha) rather than by this file: the first occurrence o
@@ -43710,7 +43710,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 9M Nāḷ
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā9MNāḷ_2019-09-01T06:01:14.
  879993+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -43733,7 +43733,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190901T060114
 DTEND;TZID=Asia/Calcutta:20190901T082641
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -43752,7 +43752,7 @@ BEGIN:VEVENT
 SUMMARY:vipattāra-gaurī-vratam
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vipattāra-gaurī-vratam_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Bhādrapadaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -43773,7 +43773,7 @@ SUMMARY:Bhādrapadaḥ-06-04  \,Kanyā-Hastaḥ🌛🌌  \,  Siṁhaḥ-P
  ūrvaphalgunī-05-17🌞🌌  \,  Iṣaḥ-07-11🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190902T060114
 DTEND;TZID=Asia/Calcutta:20190903T060114
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190902_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-11\, Islamic: 1441-01-02 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -43829,7 +43829,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190902
 DTEND;VALUE=DATE:20190903
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-02T06:01:14.879993+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -43852,7 +43852,7 @@ BEGIN:VEVENT
 SUMMARY:sōmacitrā-naktavrata-yōgaḥ
 DTSTART;VALUE=DATE:20190901
 DTEND;VALUE=DATE:20190902
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sōmacitrā-naktavrata-yōgaḥ_2019-09-01T23:59:57.120005+05:30
 DESCRIPTION:The Soma-Chitra combination is also special for observing nakt
  a-vratams as per Agni Purana.<br/><br/>agnipurāṇē---  <br/>vāravratā
@@ -43874,7 +43874,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 10M Nāḷ—Tēr
 DTSTART;VALUE=DATE:20190902
 DTEND;VALUE=DATE:20190903
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā10MNāḷ—Tēr_2019-09-02T0
  6:01:14.879993+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -43898,7 +43898,7 @@ BEGIN:VEVENT
 SUMMARY:śrīvināyaka-caturthī
 DTSTART;VALUE=DATE:20190902
 DTEND;VALUE=DATE:20190903
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śrīvināyaka-caturthī_2019-09-02T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/gaNapati/lunar_month/tithi/06/04/zrIvinAya
@@ -43919,7 +43919,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20190902
 DTEND;VALUE=DATE:20190903
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-09-02T06:01:14.879993+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -43940,7 +43940,7 @@ SUMMARY:Bhādrapadaḥ-06-05  \,Tulā-Citrā🌛🌌  \,  Siṁhaḥ-Pūrv
  aphalgunī-05-18🌞🌌  \,  Iṣaḥ-07-12🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190903T060114
 DTEND;TZID=Asia/Calcutta:20190904T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190903_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-12\, Islamic: 1441-01-03 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -43997,7 +43997,7 @@ BEGIN:VEVENT
 SUMMARY:r̥ṣi-pañcamī-vratam
 DTSTART;VALUE=DATE:20190903
 DTEND;VALUE=DATE:20190904
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:r̥ṣi-pañcamī-vratam_2019-09-03T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/06/05/RSi-paJcamI-vrata
@@ -44019,7 +44019,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgārakasvātī-naktavrata-yōgaḥ
 DTSTART;VALUE=DATE:20190902
 DTEND;VALUE=DATE:20190903
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:aṅgārakasvātī-naktavrata-yōgaḥ_2019-09-02T23:59:57.120005+05:3
  0
 DESCRIPTION:The Tuesday-Svati combination is also special for observing na
@@ -44043,7 +44043,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190903
 DTEND;VALUE=DATE:20190904
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-03T06:01:14.879993+05:30
 DESCRIPTION:The three days around upākarma and utsarga are anadhyayana da
  ys\, where one is not supposed to learn the Vedas.<br/><br/>उपाक
@@ -44066,7 +44066,7 @@ BEGIN:VEVENT
 SUMMARY:bhādrapadika-nāga-pañcamī
 DTSTART;VALUE=DATE:20190903
 DTEND;VALUE=DATE:20190904
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bhādrapadika-nāga-pañcamī_2019-09-03T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-fauna/lunar_month/tithi/06/05/bhAdrap
@@ -44088,7 +44088,7 @@ SUMMARY:graha-yuddhaḥ (★budhaḥ-aṅgārakaḥ\, pūrvaphalgunī si
  ṁhaḥ)
 DTSTART;VALUE=DATE:20190903
 DTEND;VALUE=DATE:20190904
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:graha-yuddhaḥ(★budhaḥ-aṅgārakaḥ\,pūrvaphalgunīsiṁhaḥ)
  _2019-09-03T07:13:23.520003+05:30
 DESCRIPTION:Graha-yuddha (amshu-vimarda) between aṅgārakaḥ and budha
@@ -44150,7 +44150,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Murugan Āvaṇit Tiruviḻā 11M Nāḷ
 DTSTART;VALUE=DATE:20190903
 DTEND;VALUE=DATE:20190904
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrMuruganĀvaṇitTiruviḻā11MNāḷ_2019-09-03T06:01:14
  .879993+05:30
 DESCRIPTION:The Tiruchendur Brahmotsavam of Avani each year is very specia
@@ -44174,7 +44174,7 @@ SUMMARY:Bhādrapadaḥ-06-06  \,Tulā-Viśākhā🌛🌌  \,  Siṁhaḥ-P
  ūrvaphalgunī-05-19🌞🌌  \,  Iṣaḥ-07-13🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190904T060123
 DTEND;TZID=Asia/Calcutta:20190905T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190904_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-13\, Islamic: 1441-01-04 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -44231,7 +44231,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhīdēvī-ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhīdēvī-ṣaṣṭhī-vratam_2019-09-04T06:01:23.520019+05
  :30
 DESCRIPTION:Skanda darshanam is recommended\, removes sins including brahm
@@ -44253,7 +44253,7 @@ BEGIN:VEVENT
 SUMMARY:balarāma-jayantī
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:balarāma-jayantī_2019-09-04T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/06/06/balarAma
@@ -44275,7 +44275,7 @@ BEGIN:VEVENT
 SUMMARY:budhaviśākhā-naktavrata-yōgaḥ
 DTSTART;VALUE=DATE:20190903
 DTEND;VALUE=DATE:20190904
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:budhaviśākhā-naktavrata-yōgaḥ_2019-09-03T23:59:57.120005+05:30
 DESCRIPTION:The Budha-Vishaka combination is also special for observing na
  kta-vratams as per Agni Purana.<br/><br/>agnipurāṇē---  <br/>vāravrat
@@ -44297,7 +44297,7 @@ BEGIN:VEVENT
 SUMMARY:kumārikā-svapanam
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kumārikā-svapanam_2019-09-04T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Bhādrapadaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -44317,7 +44317,7 @@ BEGIN:VEVENT
 SUMMARY:lalitā-ṣaṣṭhī
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:lalitā-ṣaṣṭhī_2019-09-04T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Bhādrapadaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -44337,7 +44337,7 @@ BEGIN:VEVENT
 SUMMARY:manthana-ṣaṣṭhī
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:manthana-ṣaṣṭhī_2019-09-04T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Bhādrapadaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -44357,7 +44357,7 @@ BEGIN:VEVENT
 SUMMARY:sūrya-ṣaṣṭhī
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sūrya-ṣaṣṭhī_2019-09-04T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Bhādrapadaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform puja of Surya\, 
@@ -44380,7 +44380,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruchchendūr Āvaṇit Tiruviḻā Niṟaivu
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:TiruchchendūrĀvaṇitTiruviḻāNiṟaivu_2019-09-04T06:01:23.520019
  +05:30
 DESCRIPTION:Observed on Viśākhā nakshatra of Siṁhaḥ (sidereal solar
@@ -44405,7 +44405,7 @@ SUMMARY:Bhādrapadaḥ-06-07  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Si
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190905T060123
 DTEND;TZID=Asia/Calcutta:20190906T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190905_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-14\, Islamic: 1441-01-05 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -44462,7 +44462,7 @@ BEGIN:VEVENT
 SUMMARY:amuktābharaṇa-saptamī
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:amuktābharaṇa-saptamī_2019-09-05T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Bhādrapadaḥ (lunar) mo
  nth (Madhyāhnaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -44482,7 +44482,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190905T181403
 DTEND;TZID=Asia/Calcutta:20190906T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-05T18:14:03.840015+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -44503,7 +44503,7 @@ BEGIN:VEVENT
 SUMMARY:anantaphala-saptamī
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anantaphala-saptamī_2019-09-05T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Bhādrapadaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -44523,7 +44523,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-6
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-6_2019-09-05T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Bhādrapadaḥ (lunar)
   month (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -44542,7 +44542,7 @@ BEGIN:VEVENT
 SUMMARY:guru-anurādhā-naktavrata-yōgaḥ
 DTSTART;VALUE=DATE:20190904
 DTEND;VALUE=DATE:20190905
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:guru-anurādhā-naktavrata-yōgaḥ_2019-09-04T23:59:57.120005+05:30
 DESCRIPTION:The Guru-Anuradha combination is also special for observing na
  kta-vratams as per Agni Purana.<br/><br/>agnipurāṇē---  <br/>vāravrat
@@ -44564,7 +44564,7 @@ BEGIN:VEVENT
 SUMMARY:kukkuṭī-vratam
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kukkuṭī-vratam_2019-09-05T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Bhādrapadaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Shiva Puja<br/><br/>## Detail
@@ -44584,7 +44584,7 @@ BEGIN:VEVENT
 SUMMARY:Kulachchiṟai Nāyanmār (22) Gurupūjai
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:KulachchiṟaiNāyanmār(22)Gurupūjai_2019-09-05T06:01:23.520019+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -44608,7 +44608,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-09-05T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -44632,7 +44632,7 @@ SUMMARY:Bhādrapadaḥ-06-08  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  S
  ukraḥ
 DTSTART;TZID=Asia/Calcutta:20190906T060123
 DTEND;TZID=Asia/Calcutta:20190907T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190906_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-15\, Islamic: 1441-01-06 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -44689,7 +44689,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190906
 DTEND;VALUE=DATE:20190907
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-06T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -44724,7 +44724,7 @@ BEGIN:VEVENT
 SUMMARY:bhr̥gujyēṣṭha-naktavrata-yōgaḥ
 DTSTART;VALUE=DATE:20190905
 DTEND;VALUE=DATE:20190906
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bhr̥gujyēṣṭha-naktavrata-yōgaḥ_2019-09-05T23:59:57.120005+05:
  30
 DESCRIPTION:The Bhrigu-Jyeshtha combination is also special for observing 
@@ -44748,7 +44748,7 @@ BEGIN:VEVENT
 SUMMARY:dūrvāṣṭamī
 DTSTART;VALUE=DATE:20190906
 DTEND;VALUE=DATE:20190907
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dūrvāṣṭamī_2019-09-06T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Bhādrapadaḥ (lunar)
   month (Aparāhṇaḥ/puurvaviddha). <br/><br/>Do pūjā *of* dūrva!<br/
@@ -44768,7 +44768,7 @@ BEGIN:VEVENT
 SUMMARY:dadhīci-maharṣi-jayanti
 DTSTART;VALUE=DATE:20190906
 DTEND;VALUE=DATE:20190907
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dadhīci-maharṣi-jayanti_2019-09-06T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Bhādrapadaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -44789,7 +44789,7 @@ BEGIN:VEVENT
 SUMMARY:rādhāṣṭamī
 DTSTART;VALUE=DATE:20190906
 DTEND;VALUE=DATE:20190907
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:rādhāṣṭamī_2019-09-06T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Bhādrapadaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -44810,7 +44810,7 @@ SUMMARY:Bhādrapadaḥ-06-09  \,Dhanuḥ-Mūlā🌛🌌  \,  Siṁhaḥ-P
  ūrvaphalgunī-05-22🌞🌌  \,  Iṣaḥ-07-16🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190907T060123
 DTEND;TZID=Asia/Calcutta:20190908T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190907_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-16\, Islamic: 1441-01-07 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -44866,7 +44866,7 @@ BEGIN:VEVENT
 SUMMARY:aduḥkhanavamī
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:aduḥkhanavamī_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -44886,7 +44886,7 @@ BEGIN:VEVENT
 SUMMARY:gōdhūmā-navamī
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:gōdhūmā-navamī_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Durga Puja<br/><br/>## Details
@@ -44906,7 +44906,7 @@ BEGIN:VEVENT
 SUMMARY:gajēndra-mōkṣaḥ
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:gajēndra-mōkṣaḥ_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Mūlā nakshatra of Siṁhaḥ (sidereal solar) mo
  nth (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit con
@@ -44926,7 +44926,7 @@ BEGIN:VEVENT
 SUMMARY:Kuṅgiliyakkalaya Nāyanmār (11) Gurupūjai
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:KuṅgiliyakkalayaNāyanmār(11)Gurupūjai_2019-09-07T06:01:23.520019+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -44950,7 +44950,7 @@ BEGIN:VEVENT
 SUMMARY:mahālakṣmī-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:mahālakṣmī-vrata-ārambhaḥ_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Ref
@@ -44971,7 +44971,7 @@ BEGIN:VEVENT
 SUMMARY:nandā-navamī
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:nandā-navamī_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Durga Puja<br/><br/>## Details
@@ -44991,7 +44991,7 @@ BEGIN:VEVENT
 SUMMARY:Piṭṭukku Maṇ Chumanda Līlai
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:PiṭṭukkuMaṇChumandaLīlai_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Mūlā nakshatra of Siṁhaḥ (sidereal solar) mo
  nth (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit con
@@ -45011,7 +45011,7 @@ BEGIN:VEVENT
 SUMMARY:tālanavamī
 DTSTART;VALUE=DATE:20190907
 DTEND;VALUE=DATE:20190908
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tālanavamī_2019-09-07T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -45030,7 +45030,7 @@ BEGIN:VEVENT
 SUMMARY:śanimūlā-naktavrata-yōgaḥ
 DTSTART;VALUE=DATE:20190906
 DTEND;VALUE=DATE:20190907
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śanimūlā-naktavrata-yōgaḥ_2019-09-06T23:59:57.120005+05:30
 DESCRIPTION:The Aditya-Hasta combination is also special for observing nak
  ta-vratams as per Agni Purana.<br/><br/>agnipurāṇē---  <br/>vāravrat
@@ -45053,7 +45053,7 @@ SUMMARY:Bhādrapadaḥ-06-10  \,Dhanuḥ-Mūlā🌛🌌  \,  Siṁhaḥ-P
  ūrvaphalgunī-05-23🌞🌌  \,  Iṣaḥ-07-17🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190908T060123
 DTEND;TZID=Asia/Calcutta:20190909T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190908_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-17\, Islamic: 1441-01-08 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -45109,7 +45109,7 @@ BEGIN:VEVENT
 SUMMARY:Āvaṇi Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20190908
 DTEND;VALUE=DATE:20190909
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ĀvaṇiÑāyiṟṟukkiḻamai_2019-09-08T06:01:23.520019+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -45128,7 +45128,7 @@ BEGIN:VEVENT
 SUMMARY:daśāvatāra-vratam
 DTSTART;VALUE=DATE:20190908
 DTEND;VALUE=DATE:20190909
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:daśāvatāra-vratam_2019-09-08T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/06/10/dazAvatA
@@ -45150,7 +45150,7 @@ BEGIN:VEVENT
 SUMMARY:vitastōtsavaḥ
 DTSTART;VALUE=DATE:20190908
 DTEND;VALUE=DATE:20190909
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vitastōtsavaḥ_2019-09-08T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Bhādrapadaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>This is the day when the sacr
@@ -45177,7 +45177,7 @@ SUMMARY:Bhādrapadaḥ-06-11  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  S
  ōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190909T060123
 DTEND;TZID=Asia/Calcutta:20190910T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190909_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-18\, Islamic: 1441-01-09 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -45234,7 +45234,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190909T181119
 DTEND;TZID=Asia/Calcutta:20190910T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-09T18:11:19.680012+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -45255,7 +45255,7 @@ BEGIN:VEVENT
 SUMMARY:bhuvanēśvarī-jayantī
 DTSTART;VALUE=DATE:20190909
 DTEND;VALUE=DATE:20190910
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:bhuvanēśvarī-jayantī_2019-09-09T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Bhādrapadaḥ (lunar) 
  month (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Bhuvaneshwari is 4th 
@@ -45278,7 +45278,7 @@ BEGIN:VEVENT
 SUMMARY:kaṭadānōtsavaḥ
 DTSTART;VALUE=DATE:20190909
 DTEND;VALUE=DATE:20190910
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kaṭadānōtsavaḥ_2019-09-09T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Bhādrapadaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>As per Smruti-Kaustubham\,
@@ -45299,7 +45299,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-parivartinī-ēkādaśī
 DTSTART;VALUE=DATE:20190909
 DTEND;VALUE=DATE:20190910
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:sarva-parivartinī-ēkādaśī_2019-09-09T06:01:23.520019+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of bhādrapada month is known as pa
  rivartinī-ēkādaśī. Sideways turn inside sleep of Bhagavan Vishnu midw
@@ -45398,7 +45398,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190910T011716
 DTEND;TZID=Asia/Calcutta:20190909T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-09-10T01:17:16.800009+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -45416,7 +45416,7 @@ SUMMARY:Bhādrapadaḥ-06-12  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,
  aṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190910T060123
 DTEND;TZID=Asia/Calcutta:20190911T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190910_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-19\, Islamic: 1441-01-10 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -45473,7 +45473,7 @@ BEGIN:VEVENT
 SUMMARY:agastyārghyam
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:agastyārghyam_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:Offering of arghya (a ceremonial water oblation) to sage Agast
  ya\, performed seven days before the Sun's transit into Kanyā (Virgo) rā
@@ -45498,7 +45498,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190910T110640
 DTEND;TZID=Asia/Calcutta:20190911T024240
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-10T11:06:40.320004+05:30
 DESCRIPTION:In the three months of āṣāḍha\, bhādrapada and kārtika
  \, if the śukla-dvādaśī tithi touches the asterisms of anurādha\, śr
@@ -45519,7 +45519,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:On the days when the flag of Indra is hoisted or taken down\, 
  one must observe anadhyayana.<br/><br/>याज्ञवल्क्य
@@ -45550,7 +45550,7 @@ BEGIN:VEVENT
 SUMMARY:ananta-dvādaśī
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ananta-dvādaśī_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Bhādrapadaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vanjuli (Cow giving lots of
@@ -45571,7 +45571,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190911T044228
 DTEND;TZID=Asia/Calcutta:20190910T235957
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-09-11T04:42:28.800015+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -45587,7 +45587,7 @@ BEGIN:VEVENT
 SUMMARY:dadhi-vratam
 DTSTART;VALUE=DATE:20190811
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dadhi-vratam_2019-08-11T23:59:57.120005+05:30
 DESCRIPTION:saṅkarṣaṇāravindākṣa kariṣyē'haṁ dadhivratam।
    <br/>dvitīyē māsi dēvēśa nirvighnaṁ kuru mē prabhō॥<br/><br/
@@ -45607,7 +45607,7 @@ BEGIN:VEVENT
 SUMMARY:dadhi-vrata-samāpanam
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dadhi-vrata-samāpanam_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Bhādrapadaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>On this day the DadhiVratam
@@ -45633,7 +45633,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20190909T235957
 DTEND;TZID=Asia/Calcutta:20190910T070218
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-09-09T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -45651,7 +45651,7 @@ BEGIN:VEVENT
 SUMMARY:payōvrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:payōvrata-ārambhaḥ_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Bhādrapadaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/>payōvratam in chāturmāsy
@@ -45674,7 +45674,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190910T060123
 DTEND;TZID=Asia/Calcutta:20190910T110640
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -45693,7 +45693,7 @@ BEGIN:VEVENT
 SUMMARY:vāmana-jayantī
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vāmana-jayantī_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/06/12/vAmana~j
@@ -45715,7 +45715,7 @@ BEGIN:VEVENT
 SUMMARY:vijayā śravaṇa-mahādvādaśī
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vijayāśravaṇa-mahādvādaśī_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/vija
@@ -45737,7 +45737,7 @@ BEGIN:VEVENT
 SUMMARY:śakradhvajōtthāpanam
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śakradhvajōtthāpanam_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/06/12/zakradhv
@@ -45761,7 +45761,7 @@ SUMMARY:Bhādrapadaḥ-06-13  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Siṁ
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190911T060123
 DTEND;TZID=Asia/Calcutta:20190912T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190911_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-20\, Islamic: 1441-01-11 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -45818,7 +45818,7 @@ BEGIN:VEVENT
 SUMMARY:Ōṇam
 DTSTART;VALUE=DATE:20190911
 DTEND;VALUE=DATE:20190912
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:Ōṇam_2019-09-11T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śravaṇaḥ nakshatra of Siṁhaḥ (sidereal so
  lar) month (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -45838,7 +45838,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190911T180953
 DTEND;TZID=Asia/Calcutta:20190912T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-11T18:09:53.279998+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -45859,7 +45859,7 @@ BEGIN:VEVENT
 SUMMARY:dūrva-tri-vratam
 DTSTART;VALUE=DATE:20190911
 DTEND;VALUE=DATE:20190912
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:dūrva-tri-vratam_2019-09-11T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Bhādrapadaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -45879,7 +45879,7 @@ BEGIN:VEVENT
 SUMMARY:gō-trirātra-vratam
 DTSTART;VALUE=DATE:20190911
 DTEND;VALUE=DATE:20190912
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:gō-trirātra-vratam_2019-09-11T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Trayōdaśī tithi of Bhādrapadaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Agastya arghya danam<br/>
@@ -45899,7 +45899,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190911T180953
 DTEND;TZID=Asia/Calcutta:20190911T193844
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-09-11T18:09:53.279998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -45917,7 +45917,7 @@ BEGIN:VEVENT
 SUMMARY:vivēkānanda-bhāṣaṇaṁ cikāgōnagarē #126
 DTSTART;VALUE=DATE:20190910
 DTEND;VALUE=DATE:20190911
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:vivēkānanda-bhāṣaṇaṁcikāgōnagarē#126_2019-09-10T23:59:57.1
  20005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -45939,7 +45939,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20190911
 DTEND;VALUE=DATE:20190912
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-09-11T06:01:23.520019+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -45960,7 +45960,7 @@ SUMMARY:Bhādrapadaḥ-06-14  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,  Si
  uḥ
 DTSTART;TZID=Asia/Calcutta:20190912T060123
 DTEND;TZID=Asia/Calcutta:20190913T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190912_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-21\, Islamic: 1441-01-12 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -46016,7 +46016,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190912
 DTEND;VALUE=DATE:20190913
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-12T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -46056,7 +46056,7 @@ BEGIN:VEVENT
 SUMMARY:ananta-caturdaśī
 DTSTART;VALUE=DATE:20190912
 DTEND;VALUE=DATE:20190913
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ananta-caturdaśī_2019-09-12T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Bhādrapadaḥ (lunar)
   month (Chaitraḥ/puurvaviddha). <br/><br/>Visarjan of Ganesha idols<br/>
@@ -46076,7 +46076,7 @@ BEGIN:VEVENT
 SUMMARY:ananta-padmanābha-vratam
 DTSTART;VALUE=DATE:20190912
 DTEND;VALUE=DATE:20190913
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:ananta-padmanābha-vratam_2019-09-12T06:01:23.520019+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Bhādrapadaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Puja of Ananta Padmanabha.
@@ -46096,7 +46096,7 @@ BEGIN:VEVENT
 SUMMARY:Naṭarājar Mahābhiṣēkam
 DTSTART;VALUE=DATE:20190912
 DTEND;VALUE=DATE:20190913
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:NaṭarājarMahābhiṣēkam_2019-09-12T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/sidereal_solar_month/tithi/05/14/na
@@ -46119,7 +46119,7 @@ SUMMARY:Bhādrapadaḥ-06-14  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Siṁ
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190913T060123
 DTEND;TZID=Asia/Calcutta:20190914T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190913_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-22\, Islamic: 1441-01-13 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -46176,7 +46176,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190913
 DTEND;VALUE=DATE:20190914
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-13T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -46211,7 +46211,7 @@ BEGIN:VEVENT
 SUMMARY:graha-yuddhaḥ (★śukraḥ-budhaḥ\, uttaraphalgunī kanyā)
 DTSTART;VALUE=DATE:20190911
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:graha-yuddhaḥ(★śukraḥ-budhaḥ\,uttaraphalgunīkanyā)_2019-09-
  11T23:22:22.080013+05:30
 DESCRIPTION:Graha-yuddha (amshu-vimarda) between budhaḥ and śukraḥ in
@@ -46273,7 +46273,7 @@ SUMMARY:kāñcī 59 jagadguru-śrī-bhagavannāma-bōdhēndra-sarasvatī-
  ārādhanā #328
 DTSTART;VALUE=DATE:20190913
 DTEND;VALUE=DATE:20190914
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī59jagadguru-śrī-bhagavannāma-bōdhēndra-sarasvatī-ārādh
  anā#328_2019-09-13T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -46298,7 +46298,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20190913
 DTEND;VALUE=DATE:20190914
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-09-13T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -46319,7 +46319,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20190913
 DTEND;VALUE=DATE:20190914
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-09-13T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -46343,7 +46343,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20190913
 DTEND;VALUE=DATE:20190914
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-09-13T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -46364,7 +46364,7 @@ SUMMARY:Bhādrapadaḥ-06-15  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌
   \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190914T060123
 DTEND;TZID=Asia/Calcutta:20190915T060123
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:20190914_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-23\, Islamic: 1441-01-14 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -46421,7 +46421,7 @@ BEGIN:VEVENT
 SUMMARY:agastyārghyam
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115608Z
+DTSTAMP:20200101T000000Z
 UID:agastyārghyam_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/RShi/relative_event/kanyA-ravi-saGkra
@@ -46444,7 +46444,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -46479,7 +46479,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -46525,7 +46525,7 @@ BEGIN:VEVENT
 SUMMARY:dikpāla-pūjā
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dikpāla-pūjā_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Spend this day in Badarikashra
@@ -46545,7 +46545,7 @@ BEGIN:VEVENT
 SUMMARY:mahālaya-pakṣa-ārambhaḥ
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālaya-pakṣa-ārambhaḥ_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/06/16/mahAlaya-pakS
@@ -46567,7 +46567,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-09-14T06:01:
  23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -46594,7 +46594,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -46613,7 +46613,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -46633,7 +46633,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -46654,7 +46654,7 @@ BEGIN:VEVENT
 SUMMARY:umā-mahēśvara-vratam
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:umā-mahēśvara-vratam_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/umA/lunar_month/tithi/06/15/umA-mahEzvara-
@@ -46676,7 +46676,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-09-14T06:01:23.5200
  19+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -46699,7 +46699,7 @@ BEGIN:VEVENT
 SUMMARY:viśvarūpa-yātrā
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:viśvarūpa-yātrā_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Shankaracharyas will resume th
@@ -46720,7 +46720,7 @@ BEGIN:VEVENT
 SUMMARY:yaticāturmāsyavratam
 DTSTART;VALUE=DATE:20190715
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:yaticāturmāsyavratam_2019-07-15T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/yaticAturmAsyavr
@@ -46738,7 +46738,7 @@ BEGIN:VEVENT
 SUMMARY:yaticāturmāsyavrata-samāpanam
 DTSTART;VALUE=DATE:20190914
 DTEND;VALUE=DATE:20190915
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:yaticāturmāsyavrata-samāpanam_2019-09-14T06:01:23.520019+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Bhādrapadaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -46760,7 +46760,7 @@ SUMMARY:Bhādrapadaḥ-06-16  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌
  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190915T060123
 DTEND;TZID=Asia/Calcutta:20190916T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190915_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-24\, Islamic: 1441-01-15 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -46817,7 +46817,7 @@ BEGIN:VEVENT
 SUMMARY:Āvaṇi Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20190915
 DTEND;VALUE=DATE:20190916
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ĀvaṇiÑāyiṟṟukkiḻamai_2019-09-15T06:01:23.520019+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -46836,7 +46836,7 @@ BEGIN:VEVENT
 SUMMARY:agastyārghyam
 DTSTART;VALUE=DATE:20190915
 DTEND;VALUE=DATE:20190916
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:agastyārghyam_2019-09-15T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/RShi/relative_event/kanyA-ravi-saGkra
@@ -46859,7 +46859,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190915
 DTEND;VALUE=DATE:20190916
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-15T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -46905,7 +46905,7 @@ BEGIN:VEVENT
 SUMMARY:aśūnyaśayana-vratam
 DTSTART;VALUE=DATE:20190915
 DTEND;VALUE=DATE:20190916
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aśūnyaśayana-vratam_2019-09-15T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/06/17/azUnyaza
@@ -46927,7 +46927,7 @@ SUMMARY:Bhādrapadaḥ-06-17  \,Mīnaḥ-Rēvatī🌛🌌  \,  Siṁhaḥ-
  Uttaraphalgunī-05-31🌞🌌  \,  Iṣaḥ-07-25🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190916T060123
 DTEND;TZID=Asia/Calcutta:20190917T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190916_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-25\, Islamic: 1441-01-16 Al-Muḥ
  arram\, 🌌🌞: सं- Siṁhaḥ\, तं- Āvaṇi\, म- Chiṅṅa
@@ -46983,7 +46983,7 @@ BEGIN:VEVENT
 SUMMARY:agastyārghyam
 DTSTART;VALUE=DATE:20190916
 DTEND;VALUE=DATE:20190917
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:agastyārghyam_2019-09-16T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/RShi/relative_event/kanyA-ravi-saGkra
@@ -47006,7 +47006,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190916T180617
 DTEND;TZID=Asia/Calcutta:20190917T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-16T18:06:17.280003+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -47029,7 +47029,7 @@ SUMMARY:Bhādrapadaḥ-06-18  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Kanyā-Ut
  taraphalgunī-06-01🌞🌌  \,  Iṣaḥ-07-26🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20190917T060123
 DTEND;TZID=Asia/Calcutta:20190918T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190917_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-26\, Islamic: 1441-01-17 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -47086,7 +47086,7 @@ SUMMARY:aṅgārakī vighnarāja-mahāgaṇapati-saṅkaṭahara-caturthī
  -vratam
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190918
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aṅgārakīvighnarāja-mahāgaṇapati-saṅkaṭahara-caturthī-vrat
  am_2019-09-17T06:01:23.520019+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -47109,7 +47109,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190918
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-17T06:01:23.520019+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -47134,7 +47134,7 @@ BEGIN:VEVENT
 SUMMARY:bhaumāśvinī-yōgaḥ
 DTSTART;VALUE=DATE:20190916
 DTEND;VALUE=DATE:20190917
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhaumāśvinī-yōgaḥ_2019-09-16T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/bhaumAz
@@ -47156,7 +47156,7 @@ BEGIN:VEVENT
 SUMMARY:gaurī-vratam
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190918
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:gaurī-vratam_2019-09-17T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Bhādrapadaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Undralla Taddi (Telugu
@@ -47176,7 +47176,7 @@ BEGIN:VEVENT
 SUMMARY:kajarī-tr̥tīyā
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190918
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kajarī-tr̥tīyā_2019-09-17T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Bhādrapadaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -47196,7 +47196,7 @@ BEGIN:VEVENT
 SUMMARY:kanyā-ravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190917T123137
 DTEND;TZID=Asia/Calcutta:20190917T180534
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kanyā-ravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ_2019-09-17T1
  2:31:37.919995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -47217,7 +47217,7 @@ BEGIN:VEVENT
 SUMMARY:ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190917T060743
 DTEND;TZID=Asia/Calcutta:20190917T180534
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ravi-saṅkramaṇa-puṇyakālaḥ_2019-09-17T06:07:43.680017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/ravi-saGkra
@@ -47235,7 +47235,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190917T120333
 DTEND;TZID=Asia/Calcutta:20190917T180534
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-09-17T12:03:33.12
  0000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -47255,7 +47255,7 @@ BEGIN:VEVENT
 SUMMARY:sukhā aṅgārakī caturthī
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190918
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sukhāaṅgārakīcaturthī_2019-09-17T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/tithi-vara-combinations/description_on
@@ -47277,7 +47277,7 @@ BEGIN:VEVENT
 SUMMARY:viśvakarma-jayantī
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190918
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:viśvakarma-jayantī_2019-09-17T06:01:23.520019+05:30
 DESCRIPTION:Observed on day 1 of Kanyā (sidereal solar) month (Sūryōday
  aḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -47297,7 +47297,7 @@ SUMMARY:Bhādrapadaḥ-06-19  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Kanyā-Ut
  taraphalgunī-06-02🌞🌌  \,  Iṣaḥ-07-27🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190918T060123
 DTEND;TZID=Asia/Calcutta:20190919T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190918_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-27\, Islamic: 1441-01-18 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -47353,7 +47353,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190918
 DTEND;VALUE=DATE:20190919
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-18T06:01:23.520019+05:30
 DESCRIPTION:Anadhyayana on account of mahābharaṇī. On the days of Maha
  navami\, (Shravana\, i.e. Bhadrapada) Dvadashi\, (Maha)Bharani and Parvas\
@@ -47380,7 +47380,7 @@ BEGIN:VEVENT
 SUMMARY:dikpāla-pūjā
 DTSTART;VALUE=DATE:20190918
 DTEND;VALUE=DATE:20190919
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dikpāla-pūjā_2019-09-18T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturthī tithi of Bhādrapadaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -47400,7 +47400,7 @@ BEGIN:VEVENT
 SUMMARY:mahābharaṇī
 DTSTART;VALUE=DATE:20190918
 DTEND;VALUE=DATE:20190919
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahābharaṇī_2019-09-18T06:01:23.520019+05:30
 DESCRIPTION:Observed on Apabharaṇī nakshatra of Bhādrapadaḥ (lunar) 
  month (Aparāhṇaḥ/vyaapti). <br/><br/>Bharanī (nakṣatra) during Pit
@@ -47425,7 +47425,7 @@ BEGIN:VEVENT
 SUMMARY:śukraḥ–udayaḥ (prāk)
 DTSTART;VALUE=DATE:20190917
 DTEND;VALUE=DATE:20190919
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śukraḥ–udayaḥ(prāk)_2019-09-17T23:59:57.120005+05:30
 DESCRIPTION:śukraḥ rises out of combustion (udayaH)\, heading prāk (ea
  st)\, on 2019-Sep-19 00:52. At this moment śukraḥ is at hastaḥ-1 kany
@@ -47446,7 +47446,7 @@ BEGIN:VEVENT
 SUMMARY:śukrasya bālya-prārambhaḥ
 DTSTART;TZID=Asia/Calcutta:20190919T005222
 DTEND;TZID=Asia/Calcutta:20190918T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śukrasyabālya-prārambhaḥ_2019-09-19T00:52:22.080013+05:30
 DESCRIPTION:śukraḥ emerges from combustion into bAlya (infancy) on 2019
  -Sep-19 00:52. At this moment śukraḥ is at hastaḥ-1 kanyā (latitude 
@@ -47464,7 +47464,7 @@ SUMMARY:Bhādrapadaḥ-06-20  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Kany
  ā-Uttaraphalgunī-06-03🌞🌌  \,  Iṣaḥ-07-28🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190919T060123
 DTEND;TZID=Asia/Calcutta:20190920T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190919_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-28\, Islamic: 1441-01-19 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -47521,7 +47521,7 @@ BEGIN:VEVENT
 SUMMARY:candra-ṣaṣṭhī
 DTSTART;VALUE=DATE:20190919
 DTEND;VALUE=DATE:20190920
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:candra-ṣaṣṭhī_2019-09-19T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ṣaṣṭhī tithi of Bhādrapadaḥ 
  (lunar) month (Chandrōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Detai
@@ -47541,7 +47541,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20190919
 DTEND;VALUE=DATE:20190920
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-09-19T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -47562,7 +47562,7 @@ BEGIN:VEVENT
 SUMMARY:nāga-pūjā
 DTSTART;VALUE=DATE:20190919
 DTEND;VALUE=DATE:20190920
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:nāga-pūjā_2019-09-19T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Bhādrapadaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -47582,7 +47582,7 @@ BEGIN:VEVENT
 SUMMARY:saptarṣi-pūjā/arghyam
 DTSTART;VALUE=DATE:20190919
 DTEND;VALUE=DATE:20190920
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:saptarṣi-pūjā/arghyam_2019-09-19T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Bhādrapadaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -47604,7 +47604,7 @@ SUMMARY:Bhādrapadaḥ-06-21  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Kan
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190920T060123
 DTEND;TZID=Asia/Calcutta:20190921T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190920_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-29\, Islamic: 1441-01-20 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -47661,7 +47661,7 @@ SUMMARY:kāñcī 33 jagadguru-śrī-saccidānandaghanēndra-sarasvatī-2-
  ārādhanā #1328
 DTSTART;VALUE=DATE:20190920
 DTEND;VALUE=DATE:20190921
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī33jagadguru-śrī-saccidānandaghanēndra-sarasvatī-2-ārādh
  anā#1328_2019-09-20T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -47686,7 +47686,7 @@ BEGIN:VEVENT
 SUMMARY:kapila-ṣaṣṭhī
 DTSTART;VALUE=DATE:20190920
 DTEND;VALUE=DATE:20190921
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kapila-ṣaṣṭhī_2019-09-20T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ṣaṣṭhī tithi of Bhādrapadaḥ 
  (lunar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>prabhākara namastu
@@ -47708,7 +47708,7 @@ SUMMARY:Bhādrapadaḥ-06-22  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Kan
  yā-Uttaraphalgunī-06-05🌞🌌  \,  Iṣaḥ-07-30🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190921T060123
 DTEND;TZID=Asia/Calcutta:20190922T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190921_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-30\, Islamic: 1441-01-21 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -47764,7 +47764,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190921T180241
 DTEND;TZID=Asia/Calcutta:20190922T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-21T18:02:41.280008+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -47785,7 +47785,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–udayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20190920T235957
 DTEND;TZID=Asia/Calcutta:20190921T170321
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–udayaḥ(prāk)_2019-09-20T23:59:57.120005+05:30
 DESCRIPTION:budhaḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Sep-21 17:03. At this moment budhaḥ is at hastaḥ-3 kanyā
@@ -47803,7 +47803,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190921T111920
 DTEND;TZID=Asia/Calcutta:20190921T202055
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-09-21T11:19:20.640000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -47822,7 +47822,7 @@ BEGIN:VEVENT
 SUMMARY:mahākālī-jayantī
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahākālī-jayantī_2019-09-21T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Bhādrapadaḥ (l
  unar) month (Madhyarātriḥ/paraviddha). <br/><br/>Devi Mahakali is 1st o
@@ -47842,7 +47842,7 @@ BEGIN:VEVENT
 SUMMARY:mahālakṣmī-vratam
 DTSTART;VALUE=DATE:20190906
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālakṣmī-vratam_2019-09-06T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/lakShmI/lunar_month/tithi/07/23/mahAlakSmI
@@ -47863,7 +47863,7 @@ BEGIN:VEVENT
 SUMMARY:mahālakṣmī-vrata-samāpanam
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālakṣmī-vrata-samāpanam_2019-09-21T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Saptamī tithi of Bhādrapadaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -47883,7 +47883,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-09-21T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -47902,7 +47902,7 @@ BEGIN:VEVENT
 SUMMARY:Puraṭṭāchi Chanikkiḻamai
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:PuraṭṭāchiChanikkiḻamai_2019-09-21T06:01:23.520019+05:30
 DESCRIPTION:Perform special puja and naivedyam (e.g. tilānnam) to Shri Ve
  nkateshwara.<br/><br/>## Details<br/>- [Edit config file](https://github.c
@@ -47921,7 +47921,7 @@ BEGIN:VEVENT
 SUMMARY:Tirunāḷaippōvār Nāyanmār (18) Gurupūjai
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:TirunāḷaippōvārNāyanmār(18)Gurupūjai_2019-09-21T06:01:23.52001
  9+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -47946,7 +47946,7 @@ SUMMARY:śr̥ṅgērī 35 jagadguru-śrī-abhinava vidyātīrtha mahāsvā
  mī-ārādhanā
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śr̥ṅgērī35jagadguru-śrī-abhinavavidyātīrthamahāsvāmī-ār
  ādhanā_2019-09-21T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Saptamī tithi of Bhādrapadaḥ (luna
@@ -47971,7 +47971,7 @@ BEGIN:VEVENT
 SUMMARY:śanirōhiṇī-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190920T235957
 DTEND;TZID=Asia/Calcutta:20190921T111920
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śanirōhiṇī-yōgaḥ_2019-09-20T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/zanirOh
@@ -47991,7 +47991,7 @@ SUMMARY:Bhādrapadaḥ-06-23  \,Mithunam-Mr̥gaśīrṣam🌛🌌  \,  Kan
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190922T060123
 DTEND;TZID=Asia/Calcutta:20190923T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190922_day_summary
 DESCRIPTION:- Indian civil date: 1941-06-31\, Islamic: 1441-01-22 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -48047,7 +48047,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190922
 DTEND;VALUE=DATE:20190923
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-22T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -48082,7 +48082,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190922T180158
 DTEND;TZID=Asia/Calcutta:20190923T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-22T18:01:58.080001+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -48104,7 +48104,7 @@ BEGIN:VEVENT
 SUMMARY:aśōkāṣṭamī-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20190922
 DTEND;VALUE=DATE:20190923
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aśōkāṣṭamī-vrata-ārambhaḥ_2019-09-22T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Bhādrapadaḥ (l
  unar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<
@@ -48125,7 +48125,7 @@ BEGIN:VEVENT
 SUMMARY:jīvaputrikāṣṭamī/jīmūtavāhana-pūjā
 DTSTART;VALUE=DATE:20190922
 DTEND;VALUE=DATE:20190923
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:jīvaputrikāṣṭamī/jīmūtavāhana-pūjā_2019-09-22T06:01:23.520
  019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -48148,7 +48148,7 @@ BEGIN:VEVENT
 SUMMARY:madhyāṣṭamī
 DTSTART;VALUE=DATE:20190922
 DTEND;VALUE=DATE:20190923
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:madhyāṣṭamī_2019-09-22T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Bhādrapadaḥ (l
  unar) month (Aparāhṇaḥ/vyaapti). <br/><br/><br/><br/>## Details<br/>-
@@ -48167,7 +48167,7 @@ BEGIN:VEVENT
 SUMMARY:mahāvyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20190922
 DTEND;VALUE=DATE:20190923
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahāvyatīpāta-śrāddham_2019-09-22T06:01:23.520019+05:30
 DESCRIPTION:vyatīpāta is regarded as the king of yōgas. Though it occur
  s 13 times every year\, the occurrences in dhanurmāsa and mahālayapakṣ
@@ -48193,7 +48193,7 @@ BEGIN:VEVENT
 SUMMARY:pātārka-yōgaḥ
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pātārka-yōgaḥ_2019-09-21T23:59:57.120005+05:30
 DESCRIPTION:When Vyatipata yoga falls on a Sunday\, it is a special yōga
  ḥ\, which is equal to a thousand Surya grahanas.<br/><br/>bhānōrvārē
@@ -48215,7 +48215,7 @@ BEGIN:VEVENT
 SUMMARY:vana-rakṣaka-vaiṣṇava-hatyā #289
 DTSTART;VALUE=DATE:20190921
 DTEND;VALUE=DATE:20190922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vana-rakṣaka-vaiṣṇava-hatyā#289_2019-09-21T23:59:57.120005+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -48238,7 +48238,7 @@ SUMMARY:Bhādrapadaḥ-06-24  \,Mithunam-Ārdrā🌛🌌  \,  Kanyā-Uttar
  aphalgunī-06-07🌞🌌  \,  Ūrjaḥ-08-01🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190923T060123
 DTEND;TZID=Asia/Calcutta:20190924T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190923_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-01\, Islamic: 1441-01-23 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -48295,7 +48295,7 @@ BEGIN:VEVENT
 SUMMARY:ūrja-māsaḥ
 DTSTART;TZID=Asia/Calcutta:20190923T132009
 DTEND;TZID=Asia/Calcutta:20190923T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ūrja-māsaḥ_2019-09-23T13:20:09.599997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -48314,7 +48314,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190923
 DTEND;VALUE=DATE:20190924
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-23T06:01:23.520019+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -48339,7 +48339,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190923
 DTEND;VALUE=DATE:20190924
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-23T06:01:23.520019+05:30
 DESCRIPTION:Anadhyayana on account of viṣu. On the days of Ayana (solsti
  ces)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (Sha
@@ -48362,7 +48362,7 @@ BEGIN:VEVENT
 SUMMARY:avidhavā-navamī
 DTSTART;VALUE=DATE:20190923
 DTEND;VALUE=DATE:20190924
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:avidhavā-navamī_2019-09-23T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Bhādrapadaḥ (lunar
  ) month (Aparāhṇaḥ/vyaapti). <br/><br/>In honour of Avidhavaas (in th
@@ -48385,7 +48385,7 @@ BEGIN:VEVENT
 SUMMARY:dakṣiṇa-viṣuva-dinam
 DTSTART;VALUE=DATE:20190923
 DTEND;VALUE=DATE:20190924
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dakṣiṇa-viṣuva-dinam_2019-09-23T06:01:23.520019+05:30
 DESCRIPTION:Observed on day 1 of Ūrjaḥ (tropical) month (Sūryōdayaḥ
  /puurvaviddha). <br/><br/>Vernal equinox<br/><br/>## Details<br/>- [Edit c
@@ -48405,7 +48405,7 @@ BEGIN:VEVENT
 SUMMARY:durgā/gaurī-pūjā
 DTSTART;VALUE=DATE:20190923
 DTEND;VALUE=DATE:20190924
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:durgā/gaurī-pūjā_2019-09-23T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Bhādrapadaḥ (lunar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>
@@ -48425,7 +48425,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190923T065606
 DTEND;TZID=Asia/Calcutta:20190923T180114
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-09-23T06:56:06.719994
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -48444,7 +48444,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190923T120123
 DTEND;TZID=Asia/Calcutta:20190923T180114
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-09-23T12:
  01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -48465,7 +48465,7 @@ BEGIN:VEVENT
 SUMMARY:viṣu-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20190923T092006
 DTEND;TZID=Asia/Calcutta:20190923T172012
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:viṣu-puṇyakālaḥ_2019-09-23T09:20:06.720002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/viSu-puNyak
@@ -48484,7 +48484,7 @@ BEGIN:VEVENT
 SUMMARY:śukrasya bālya-samāpanam
 DTSTART;TZID=Asia/Calcutta:20190924T005222
 DTEND;TZID=Asia/Calcutta:20190923T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śukrasyabālya-samāpanam_2019-09-24T00:52:22.080013+05:30
 DESCRIPTION:śukraḥ's bAlya ends on 2019-Sep-24 00:52\, regaining full s
  trength. At this moment śukraḥ is at hastaḥ-3 kanyā (latitude 1°07
@@ -48502,7 +48502,7 @@ SUMMARY:Bhādrapadaḥ-06-25  \,Karkaṭaḥ-Punarvasuḥ🌛🌌  \,  Kan
  aḥ
 DTSTART;TZID=Asia/Calcutta:20190924T060123
 DTEND;TZID=Asia/Calcutta:20190925T060123
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190924_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-02\, Islamic: 1441-01-24 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -48558,7 +48558,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190925T054524
 DTEND;TZID=Asia/Calcutta:20190924T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-09-25T05:45:24.479999+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -48575,7 +48575,7 @@ SUMMARY:Bhādrapadaḥ-06-26  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Kany
  ā-Uttaraphalgunī-06-09🌞🌌  \,  Ūrjaḥ-08-03🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20190925T060123
 DTEND;TZID=Asia/Calcutta:20190926T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190925_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-03\, Islamic: 1441-01-25 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -48631,7 +48631,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20190925T175948
 DTEND;TZID=Asia/Calcutta:20190926T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-25T17:59:48.480020+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -48652,7 +48652,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-indirā-ēkādaśī
 DTSTART;VALUE=DATE:20190925
 DTEND;VALUE=DATE:20190926
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarva-indirā-ēkādaśī_2019-09-25T06:01:23.520019+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of bhādrapada month is known as i
  ndirā-ēkādaśī. Indrasena's son did Ekadashi and as a result he was sh
@@ -48748,7 +48748,7 @@ BEGIN:VEVENT
 SUMMARY:yati-mahālayam
 DTSTART;VALUE=DATE:20190925
 DTEND;VALUE=DATE:20190926
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:yati-mahālayam_2019-09-25T06:01:23.520019+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Bhādrapadaḥ (lu
  nar) month (Aparāhṇaḥ/vyaapti). <br/><br/><br/><br/>## Details<br/>- 
@@ -48769,7 +48769,7 @@ SUMMARY:Bhādrapadaḥ-06-27  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Kan
  yā-Uttaraphalgunī-06-10🌞🌌  \,  Ūrjaḥ-08-04🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20190926T060132
 DTEND;TZID=Asia/Calcutta:20190927T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190926_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-04\, Islamic: 1441-01-26 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -48826,7 +48826,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190926
 DTEND;VALUE=DATE:20190927
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-26T06:01:32.160004+05:30
 DESCRIPTION:Anadhyayana on account of yugādi. On the days of Ayana (solst
  ices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (Sh
@@ -48849,7 +48849,7 @@ BEGIN:VEVENT
 SUMMARY:dvāparayugādiḥ
 DTSTART;VALUE=DATE:20190926
 DTEND;VALUE=DATE:20190927
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dvāparayugādiḥ_2019-09-26T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/yugAdiH/lunar_month/tithi/06/28/dvApar
@@ -48872,7 +48872,7 @@ SUMMARY:kāñcī 44 jagadguru-śrī-pūrṇabōdhēndra-sarasvatī-2-ārā
  dhanā #980
 DTSTART;VALUE=DATE:20190926
 DTEND;VALUE=DATE:20190927
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī44jagadguru-śrī-pūrṇabōdhēndra-sarasvatī-2-ārādhanā
  #980_2019-09-26T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -48897,7 +48897,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20190926T175905
 DTEND;TZID=Asia/Calcutta:20190926T192922
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-09-26T17:59:05.280012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -48917,7 +48917,7 @@ SUMMARY:Bhādrapadaḥ-06-28  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Ka
  ḥ
 DTSTART;TZID=Asia/Calcutta:20190927T060132
 DTEND;TZID=Asia/Calcutta:20190928T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190927_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-05\, Islamic: 1441-01-27 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -48974,7 +48974,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190927
 DTEND;VALUE=DATE:20190928
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-27T06:01:32.160004+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -49014,7 +49014,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20190927
 DTEND;VALUE=DATE:20190928
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-09-27T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -49035,7 +49035,7 @@ BEGIN:VEVENT
 SUMMARY:kātyāyanī-jayantī
 DTSTART;VALUE=DATE:20190927
 DTEND;VALUE=DATE:20190928
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kātyāyanī-jayantī_2019-09-27T06:01:32.160004+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of Bhādrapadaḥ (l
  unar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<
@@ -49056,7 +49056,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20190927
 DTEND;VALUE=DATE:20190928
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-09-27T06:01:32.160004+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -49076,7 +49076,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20190927
 DTEND;VALUE=DATE:20190928
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-09-27T06:01:32.160004+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -49095,7 +49095,7 @@ BEGIN:VEVENT
 SUMMARY:śastrahatacaturdaśī
 DTSTART;VALUE=DATE:20190927
 DTEND;VALUE=DATE:20190928
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śastrahatacaturdaśī_2019-09-27T06:01:32.160004+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of Bhādrapadaḥ (l
  unar) month (Aparāhṇaḥ/vyaapti). <br/><br/>vr̥kṣārōhēṇa lōh
@@ -49122,7 +49122,7 @@ SUMMARY:Bhādrapadaḥ-06-30  \,Siṁhaḥ-Uttaraphalgunī🌛🌌  \,  Ka
  nyā-Hastaḥ-06-12🌞🌌  \,  Ūrjaḥ-08-06🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20190928T060132
 DTEND;TZID=Asia/Calcutta:20190929T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190928_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-06\, Islamic: 1441-01-28 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -49178,7 +49178,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -49213,7 +49213,7 @@ BEGIN:VEVENT
 SUMMARY:aśvaśirō-dēva-pūjā
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aśvaśirō-dēva-pūjā_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Bhādrapadaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refere
@@ -49233,7 +49233,7 @@ BEGIN:VEVENT
 SUMMARY:bhādrapada-māsaḥ
 DTSTART;VALUE=DATE:20190830
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhādrapada-māsaḥ_2019-08-30T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/bhAdrapada-mAsaH
@@ -49255,7 +49255,7 @@ BEGIN:VEVENT
 SUMMARY:bhādrapada-māsa-samāpanam
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhādrapada-māsa-samāpanam_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Bhādrapadaḥ (lunar) month 
  (Sūryōdayaḥ/paraviddha). <br/><br/>bhādrapada-māsaḥ ends today<br/
@@ -49275,7 +49275,7 @@ BEGIN:VEVENT
 SUMMARY:gajacchāyā-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190928T220025
 DTEND;TZID=Asia/Calcutta:20190928T235621
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:gajacchāyā-yōgaḥ_2019-09-28T22:00:25.919996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/gajacc
@@ -49293,7 +49293,7 @@ BEGIN:VEVENT
 SUMMARY:mahālaya-pakṣaḥ
 DTSTART;VALUE=DATE:20190913
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālaya-pakṣaḥ_2019-09-13T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/description_only/mahAlaya-pakSaH.toml
@@ -49314,7 +49314,7 @@ BEGIN:VEVENT
 SUMMARY:mahālaya-pakṣa-samāpanam
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālaya-pakṣa-samāpanam_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/06/30/mahAlaya-pakS
@@ -49336,7 +49336,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -49357,7 +49357,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -49376,7 +49376,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -49397,7 +49397,7 @@ BEGIN:VEVENT
 SUMMARY:Puraṭṭāchi Chanikkiḻamai
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:PuraṭṭāchiChanikkiḻamai_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Perform special puja and naivedyam (e.g. tilānnam) to Shri Ve
  nkateshwara.<br/><br/>## Details<br/>- [Edit config file](https://github.c
@@ -49416,7 +49416,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-(bhādrapada) mahālaya amāvāsyā
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarva-(bhādrapada)mahālayaamāvāsyā_2019-09-28T06:01:32.160004+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -49440,7 +49440,7 @@ BEGIN:VEVENT
 SUMMARY:sujanmaprāpti-vratam
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sujanmaprāpti-vratam_2019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Bhādrapadaḥ (lunar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -49460,7 +49460,7 @@ SUMMARY:śr̥ṅgērī 34 jagadguru-śrī-candraśēkhara bhāratī-ārād
  hanā
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śr̥ṅgērī34jagadguru-śrī-candraśēkharabhāratī-ārādhanā_2
  019-09-28T06:01:32.160004+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Bhādrapadaḥ (lunar) month 
@@ -49485,7 +49485,7 @@ SUMMARY:Āśvayujaḥ-07-01  \,Kanyā-Hastaḥ🌛🌌  \,  Kanyā-Hasta
  ḥ-06-13🌞🌌  \,  Ūrjaḥ-08-07🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20190929T060132
 DTEND;TZID=Asia/Calcutta:20190930T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190929_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-07\, Islamic: 1441-01-29 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -49541,7 +49541,7 @@ BEGIN:VEVENT
 SUMMARY:ādityahasta-nakta-vrata-yōgaḥ
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20190929
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ādityahasta-nakta-vrata-yōgaḥ_2019-09-28T23:59:57.120005+05:30
 DESCRIPTION:The Aditya-Hasta combination is also special for observing nak
  ta-vratams as per Agni Purana.<br/><br/>agnipurāṇē---  <br/>vāravrat
@@ -49563,7 +49563,7 @@ BEGIN:VEVENT
 SUMMARY:ādityahasta-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190928T235957
 DTEND;TZID=Asia/Calcutta:20190929T190436
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ādityahasta-yōgaḥ_2019-09-28T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/Adityah
@@ -49582,7 +49582,7 @@ BEGIN:VEVENT
 SUMMARY:āśvina-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:āśvina-māsa-ārambhaḥ_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/07/01/Azvina-mA
@@ -49604,7 +49604,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -49650,7 +49650,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20190929T123422
 DTEND;TZID=Asia/Calcutta:20190929T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-09-29T12:34:22.079997+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -49666,7 +49666,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -49685,7 +49685,7 @@ BEGIN:VEVENT
 SUMMARY:dauhitra-pratipat
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dauhitra-pratipat_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/07/01/dauhitra-prat
@@ -49706,7 +49706,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20190929T201343
 DTEND;TZID=Asia/Calcutta:20190930T060132
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-09-29T20:13:43.680009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -49725,7 +49725,7 @@ BEGIN:VEVENT
 SUMMARY:gr̥hadēvī-pūjā
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:gr̥hadēvī-pūjā_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Āśvayujaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Re
@@ -49745,7 +49745,7 @@ BEGIN:VEVENT
 SUMMARY:mahālaya-pakṣa-tarpaṇa-pūrtiḥ
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālaya-pakṣa-tarpaṇa-pūrtiḥ_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Mahalaya Paksha Tarpana of 16 days ends today.<br/><br/>smr̥t
  yantarē---  <br/>amā pātaśca saṅkrāntistathā vaidhr̥tirēva ca।
@@ -49769,7 +49769,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-09-29T06:01:32.160004
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -49795,7 +49795,7 @@ BEGIN:VEVENT
 SUMMARY:stanyavr̥ddhi-gaurī-vratam
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:stanyavr̥ddhi-gaurī-vratam_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Āśvayujaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -49815,7 +49815,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -49836,7 +49836,7 @@ BEGIN:VEVENT
 SUMMARY:śarannavarātra-ārambhaḥ
 DTSTART;VALUE=DATE:20190929
 DTEND;VALUE=DATE:20190930
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śarannavarātra-ārambhaḥ_2019-09-29T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Āśvayujaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -49857,7 +49857,7 @@ SUMMARY:Āśvayujaḥ-07-02  \,Tulā-Citrā🌛🌌  \,  Kanyā-Hastaḥ-0
  6-14🌞🌌  \,  Ūrjaḥ-08-08🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20190930T060132
 DTEND;TZID=Asia/Calcutta:20191001T060140
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20190930_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-08\, Islamic: 1441-01-30 Al-Muḥ
  arram\, 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, 
@@ -49913,7 +49913,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20190930
 DTEND;VALUE=DATE:20191001
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-09-30T06:01:32.160004+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Āśvayujaḥ (lunar) mo
  nth (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana day\, on account of 
@@ -49940,7 +49940,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20190930T175621
 DTEND;TZID=Asia/Calcutta:20190930T192931
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-09-30T17:56:21.120010+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -49959,7 +49959,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20190930
 DTEND;VALUE=DATE:20191001
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-09-30T06:01:32.160004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -49982,7 +49982,7 @@ SUMMARY:Āśvayujaḥ-07-03  \,Tulā-Svātī🌛🌌  \,  Kanyā-Hastaḥ-
  06-15🌞🌌  \,  Ūrjaḥ-08-09🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191001T060140
 DTEND;TZID=Asia/Calcutta:20191002T060140
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191001_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-09\, Islamic: 1441-02-01 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50038,7 +50038,7 @@ BEGIN:VEVENT
 SUMMARY:mēghapālīya-tr̥tīyā
 DTSTART;VALUE=DATE:20191001
 DTEND;VALUE=DATE:20191002
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mēghapālīya-tr̥tīyā_2019-10-01T06:01:40.799990+05:30
 DESCRIPTION:Observed on Śukla-Tr̥tīyā tithi of Āśvayujaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [
@@ -50058,7 +50058,7 @@ BEGIN:VEVENT
 SUMMARY:sukhā aṅgārakī caturthī
 DTSTART;VALUE=DATE:20191001
 DTEND;VALUE=DATE:20191002
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sukhāaṅgārakīcaturthī_2019-10-01T06:01:40.799990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/tithi-vara-combinations/description_on
@@ -50081,7 +50081,7 @@ SUMMARY:Āśvayujaḥ-07-04  \,Tulā-Viśākhā🌛🌌  \,  Kanyā-Hasta
  ḥ-06-16🌞🌌  \,  Ūrjaḥ-08-10🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191002T060140
 DTEND;TZID=Asia/Calcutta:20191003T060140
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191002_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-10\, Islamic: 1441-02-02 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50137,7 +50137,7 @@ BEGIN:VEVENT
 SUMMARY:budhānurādhā-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191002T124937
 DTEND;TZID=Asia/Calcutta:20191002T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:budhānurādhā-yōgaḥ_2019-10-02T12:49:37.920011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/budhAnu
@@ -50156,7 +50156,7 @@ BEGIN:VEVENT
 SUMMARY:dēvatā-suvāsinī-pūjā
 DTSTART;VALUE=DATE:20191002
 DTEND;VALUE=DATE:20191003
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dēvatā-suvāsinī-pūjā_2019-10-02T06:01:40.799990+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Āśvayujaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Re
@@ -50176,7 +50176,7 @@ BEGIN:VEVENT
 SUMMARY:lalitā-pañcamī
 DTSTART;VALUE=DATE:20191002
 DTEND;VALUE=DATE:20191003
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:lalitā-pañcamī_2019-10-02T06:01:40.799990+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Āśvayujaḥ (lunar) mo
  nth (Aparāhṇaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -50196,7 +50196,7 @@ BEGIN:VEVENT
 SUMMARY:upāṅga-lalitā-vratam
 DTSTART;VALUE=DATE:20191002
 DTEND;VALUE=DATE:20191003
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:upāṅga-lalitā-vratam_2019-10-02T06:01:40.799990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shakti/lunar_month/tithi/07/05/upAGga-lali
@@ -50217,7 +50217,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20191002
 DTEND;VALUE=DATE:20191003
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-10-02T06:01:40.799990+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -50238,7 +50238,7 @@ SUMMARY:Āśvayujaḥ-07-05  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Kany
  ā-Hastaḥ-06-17🌞🌌  \,  Ūrjaḥ-08-11🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191003T060140
 DTEND;TZID=Asia/Calcutta:20191004T060140
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191003_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-11\, Islamic: 1441-02-03 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50294,7 +50294,7 @@ BEGIN:VEVENT
 SUMMARY:āśvina-nāga-pañcamī
 DTSTART;VALUE=DATE:20191003
 DTEND;VALUE=DATE:20191004
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:āśvina-nāga-pañcamī_2019-10-03T06:01:40.799990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-fauna/lunar_month/tithi/07/05/Azvina-
@@ -50315,7 +50315,7 @@ BEGIN:VEVENT
 SUMMARY:ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20191003
 DTEND;VALUE=DATE:20191004
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ṣaṣṭhī-vratam_2019-10-03T06:01:40.799990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/SaSThI-vratam.tom
@@ -50336,7 +50336,7 @@ BEGIN:VEVENT
 SUMMARY:śānti-pañcamī-vratam
 DTSTART;VALUE=DATE:20191003
 DTEND;VALUE=DATE:20191004
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śānti-pañcamī-vratam_2019-10-03T06:01:40.799990+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Āśvayujaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -50356,7 +50356,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191004T044914
 DTEND;TZID=Asia/Calcutta:20191003T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-10-04T04:49:14.880010+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -50373,7 +50373,7 @@ SUMMARY:Āśvayujaḥ-07-06  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Ka
  nyā-Hastaḥ-06-18🌞🌌  \,  Ūrjaḥ-08-12🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191004T060140
 DTEND;TZID=Asia/Calcutta:20191005T060149
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191004_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-12\, Islamic: 1441-02-04 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50430,7 +50430,7 @@ SUMMARY:kāñcī 45 jagadguru-śrī-paramaśivēndra-sarasvatī-1-ārādha
  nā #959
 DTSTART;VALUE=DATE:20191004
 DTEND;VALUE=DATE:20191005
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī45jagadguru-śrī-paramaśivēndra-sarasvatī-1-ārādhanā#95
  9_2019-10-04T06:01:40.799990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -50455,7 +50455,7 @@ BEGIN:VEVENT
 SUMMARY:sarasvatī-āvāhanam
 DTSTART;VALUE=DATE:20191004
 DTEND;VALUE=DATE:20191005
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarasvatī-āvāhanam_2019-10-04T06:01:40.799990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shakti/lunar_month/nakshatra/07/19/sarasva
@@ -50477,7 +50477,7 @@ SUMMARY:Āśvayujaḥ-07-07  \,Dhanuḥ-Mūlā🌛🌌  \,  Kanyā-Hasta
  ḥ-06-19🌞🌌  \,  Ūrjaḥ-08-13🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191005T060149
 DTEND;TZID=Asia/Calcutta:20191006T060149
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191005_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-13\, Islamic: 1441-02-05 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50533,7 +50533,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191005T175302
 DTEND;TZID=Asia/Calcutta:20191006T060149
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-05T17:53:02.399985+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -50554,7 +50554,7 @@ BEGIN:VEVENT
 SUMMARY:patrikā-pravēśa-pūjā
 DTSTART;VALUE=DATE:20191005
 DTEND;VALUE=DATE:20191006
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:patrikā-pravēśa-pūjā_2019-10-05T06:01:49.440015+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Pooja of Kapila cow\, eat only
@@ -50574,7 +50574,7 @@ BEGIN:VEVENT
 SUMMARY:Puraṭṭāchi Chanikkiḻamai
 DTSTART;VALUE=DATE:20191005
 DTEND;VALUE=DATE:20191006
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:PuraṭṭāchiChanikkiḻamai_2019-10-05T06:01:49.440015+05:30
 DESCRIPTION:Perform special puja and naivedyam (e.g. tilānnam) to Shri Ve
  nkateshwara.<br/><br/>## Details<br/>- [Edit config file](https://github.c
@@ -50593,7 +50593,7 @@ BEGIN:VEVENT
 SUMMARY:śubha-saptamī
 DTSTART;VALUE=DATE:20191005
 DTEND;VALUE=DATE:20191006
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śubha-saptamī_2019-10-05T06:01:49.440015+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -50613,7 +50613,7 @@ SUMMARY:Āśvayujaḥ-07-08  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Ka
  nyā-Hastaḥ-06-20🌞🌌  \,  Ūrjaḥ-08-14🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191006T060149
 DTEND;TZID=Asia/Calcutta:20191007T060158
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191006_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-14\, Islamic: 1441-02-06 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50669,7 +50669,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -50704,7 +50704,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -50727,7 +50727,7 @@ BEGIN:VEVENT
 SUMMARY:bhadrakālī-pūjā
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhadrakālī-pūjā_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Āśvayujaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -50747,7 +50747,7 @@ BEGIN:VEVENT
 SUMMARY:durgāṣṭamī
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:durgāṣṭamī_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Āśvayujaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -50768,7 +50768,7 @@ SUMMARY:kāñcī 19 jagadguru-śrī-mārtaṇḍa-vidyāghanēndra-sarasva
  tī-ārādhanā #1622
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī19jagadguru-śrī-mārtaṇḍa-vidyāghanēndra-sarasvatī-ā
  rādhanā#1622_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -50793,7 +50793,7 @@ BEGIN:VEVENT
 SUMMARY:kāla-trirātra-vratam
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāla-trirātra-vratam_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Āśvayujaḥ (lunar) 
  month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -50813,7 +50813,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(svāyambhuvaḥ-[1])
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(svāyambhuvaḥ-[1])_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/07/09/manvA
@@ -50835,7 +50835,7 @@ BEGIN:VEVENT
 SUMMARY:sarasvatī-pūjā
 DTSTART;VALUE=DATE:20191006
 DTEND;VALUE=DATE:20191007
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarasvatī-pūjā_2019-10-06T06:01:49.440015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shakti/lunar_month/nakshatra/07/20/sarasva
@@ -50857,7 +50857,7 @@ SUMMARY:Āśvayujaḥ-07-09  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  K
  anyā-Hastaḥ-06-21🌞🌌  \,  Ūrjaḥ-08-15🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191007T060158
 DTEND;TZID=Asia/Calcutta:20191008T060158
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191007_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-15\, Islamic: 1441-02-07 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -50913,7 +50913,7 @@ BEGIN:VEVENT
 SUMMARY:āyudha-pūjā
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:āyudha-pūjā_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:Worship of all weapons\, or rather\, tools related to one's pr
  ofession.<br/><br/>परेद्युर् विजयदशम्य
@@ -50935,7 +50935,7 @@ BEGIN:VEVENT
 SUMMARY:Ēnādinātha Nāyanmār (9) Gurupūjai
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ĒnādināthaNāyanmār(9)Gurupūjai_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -50958,7 +50958,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:On the days of Mahanavami\, (Shravana\, i.e. Bhadrapada) Dvada
  shi\, (Maha)Bharani and Parvas\, the Guru must not teach the Shishya (i.e.
@@ -50982,7 +50982,7 @@ BEGIN:VEVENT
 SUMMARY:bhadrakālī-vratam
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhadrakālī-vratam_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shakti/lunar_month/tithi/07/09/bhadrakALI-
@@ -51003,7 +51003,7 @@ BEGIN:VEVENT
 SUMMARY:buddha-jayantī
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:buddha-jayantī_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/07/10/buddha~j
@@ -51024,7 +51024,7 @@ BEGIN:VEVENT
 SUMMARY:mahānavamī/sarasvatī-pūjā
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahānavamī/sarasvatī-pūjā_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>Daanam is good\, get crore time
@@ -51046,7 +51046,7 @@ BEGIN:VEVENT
 SUMMARY:sōmaśravaṇa-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191007T172230
 DTEND;TZID=Asia/Calcutta:20191007T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sōmaśravaṇa-yōgaḥ_2019-10-07T17:22:30.719999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmazra
@@ -51065,7 +51065,7 @@ BEGIN:VEVENT
 SUMMARY:sarasvatī-visarjanam
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarasvatī-visarjanam_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:Observed on Uttarāṣāḍhā nakshatra of Āśvayujaḥ (lun
  ar) month (Madhyāhnaḥ/puurvaviddha). <br/><br/>परेद्युः
@@ -51087,7 +51087,7 @@ BEGIN:VEVENT
 SUMMARY:vijayadaśamī—yātrā-muhūrtaḥ
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vijayadaśamī—yātrā-muhūrtaḥ_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/07/10/vijayadazamI_yAtr
@@ -51108,7 +51108,7 @@ BEGIN:VEVENT
 SUMMARY:yuddhadēvatā-ārādhanā/aparājitā-pūjā
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:yuddhadēvatā-ārādhanā/aparājitā-pūjā_2019-10-07T06:01:58.0800
  01+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
@@ -51129,7 +51129,7 @@ BEGIN:VEVENT
 SUMMARY:śamī-pūjā
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śamī-pūjā_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-flora/lunar_month/tithi/07/10/zamI-pU
@@ -51150,7 +51150,7 @@ BEGIN:VEVENT
 SUMMARY:śarannavarātraḥ
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śarannavarātraḥ_2019-09-28T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/description_only/zarannavarAtraH.toml)<br
@@ -51168,7 +51168,7 @@ BEGIN:VEVENT
 SUMMARY:śarannavarātra-samāpanam
 DTSTART;VALUE=DATE:20191007
 DTEND;VALUE=DATE:20191008
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śarannavarātra-samāpanam_2019-10-07T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -51189,7 +51189,7 @@ SUMMARY:Āśvayujaḥ-07-10  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Kanyā
  -Hastaḥ-06-22🌞🌌  \,  Ūrjaḥ-08-16🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191008T060158
 DTEND;TZID=Asia/Calcutta:20191009T060206
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191008_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-16\, Islamic: 1441-02-08 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -51245,7 +51245,7 @@ BEGIN:VEVENT
 SUMMARY:daśaharā
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:daśaharā_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Dussehra (Raama wins over Rava
@@ -51265,7 +51265,7 @@ BEGIN:VEVENT
 SUMMARY:durgā-pūjā
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:durgā-pūjā_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Ed
@@ -51285,7 +51285,7 @@ BEGIN:VEVENT
 SUMMARY:gaṅgāvataraṇam
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:gaṅgāvataraṇam_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>According to Agni/Padma Purā
@@ -51305,7 +51305,7 @@ BEGIN:VEVENT
 SUMMARY:kūṣmāṇḍa-daśamī
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kūṣmāṇḍa-daśamī_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>kūṣmāṇḍa Danam<br/><br
@@ -51325,7 +51325,7 @@ BEGIN:VEVENT
 SUMMARY:madhvācārya-jayantī #782
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:madhvācārya-jayantī#782_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). The event occurred in 4339 (Kali era).  
@@ -51346,7 +51346,7 @@ BEGIN:VEVENT
 SUMMARY:vijayadaśamī—vidyārambhaḥ
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vijayadaśamī—vidyārambhaḥ_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Āśvayujaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>An ideal day for starting new 
@@ -51367,7 +51367,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20191008
 DTEND;VALUE=DATE:20191009
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-10-08T06:01:58.080001+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -51387,7 +51387,7 @@ SUMMARY:Āśvayujaḥ-07-11  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Kany
  ā-Hastaḥ-06-23🌞🌌  \,  Ūrjaḥ-08-17🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191009T060206
 DTEND;TZID=Asia/Calcutta:20191010T060206
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191009_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-17\, Islamic: 1441-02-09 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -51443,7 +51443,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191009T175026
 DTEND;TZID=Asia/Calcutta:20191010T060206
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-09T17:50:26.880008+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -51464,7 +51464,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-pāpāṅkuśā-ēkādaśī
 DTSTART;VALUE=DATE:20191009
 DTEND;VALUE=DATE:20191010
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarva-pāpāṅkuśā-ēkādaśī_2019-10-09T06:02:06.719986+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of āśvayuja month is known as pā
  pāṅkuśā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are
@@ -51560,7 +51560,7 @@ SUMMARY:Āśvayujaḥ-07-12  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Kanyā
  -Hastaḥ-06-24🌞🌌  \,  Ūrjaḥ-08-18🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191010T060206
 DTEND;TZID=Asia/Calcutta:20191011T060215
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191010_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-18\, Islamic: 1441-02-10 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -51616,7 +51616,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191010
 DTEND;VALUE=DATE:20191011
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-10T06:02:06.719986+05:30
 DESCRIPTION:On the days when the flag of Indra is hoisted or taken down\, 
  one must observe anadhyayana.<br/><br/>याज्ञवल्क्य
@@ -51637,7 +51637,7 @@ BEGIN:VEVENT
 SUMMARY:dvidala-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20191010
 DTEND;VALUE=DATE:20191011
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dvidala-vrata-ārambhaḥ_2019-10-10T06:02:06.719986+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Āśvayujaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>aniruddha surairvandya dvida
@@ -51659,7 +51659,7 @@ BEGIN:VEVENT
 SUMMARY:Narachiṅgamunaiyaraiya Nāyanmār (41) Gurupūjai
 DTSTART;VALUE=DATE:20191010
 DTEND;VALUE=DATE:20191011
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:NarachiṅgamunaiyaraiyaNāyanmār(41)Gurupūjai_2019-10-10T06:02:06.7
  19986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -51684,7 +51684,7 @@ BEGIN:VEVENT
 SUMMARY:dvidala-vratam
 DTSTART;VALUE=DATE:20190909
 DTEND;VALUE=DATE:20191011
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dvidala-vratam_2019-09-09T23:59:57.120005+05:30
 DESCRIPTION:aniruddha surairvandya dvidalavratamuttamam।  <br/>karōmyah
  amiṣēmāsē nirvighnaṁ kuru mē prabhō॥<br/><br/><br/><br/>## Deta
@@ -51704,7 +51704,7 @@ BEGIN:VEVENT
 SUMMARY:payōvrata-samāpanam
 DTSTART;VALUE=DATE:20191010
 DTEND;VALUE=DATE:20191011
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:payōvrata-samāpanam_2019-10-10T06:02:06.719986+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Āśvayujaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>śrīpradyumna namastubhya
@@ -51728,7 +51728,7 @@ BEGIN:VEVENT
 SUMMARY:śakradhvajapātaḥ
 DTSTART;VALUE=DATE:20191010
 DTEND;VALUE=DATE:20191011
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śakradhvajapātaḥ_2019-10-10T06:02:06.719986+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Āśvayujaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/>The flag hoisted in the hono
@@ -51754,7 +51754,7 @@ SUMMARY:Āśvayujaḥ-07-13  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛🌌
  ḥ
 DTSTART;TZID=Asia/Calcutta:20191011T060215
 DTEND;TZID=Asia/Calcutta:20191012T060223
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191011_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-19\, Islamic: 1441-02-11 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -51811,7 +51811,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191011T174909
 DTEND;TZID=Asia/Calcutta:20191012T060223
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-11T17:49:09.120019+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -51832,7 +51832,7 @@ BEGIN:VEVENT
 SUMMARY:śukravāra-śukla-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20191011T174909
 DTEND;TZID=Asia/Calcutta:20191011T192044
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śukravāra-śukla-pradōṣa-vratam_2019-10-11T17:49:09.120019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/zukr
@@ -51852,7 +51852,7 @@ SUMMARY:Āśvayujaḥ-07-14  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \
  ,  Kanyā-Citrā-06-26🌞🌌  \,  Ūrjaḥ-08-20🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191012T060223
 DTEND;TZID=Asia/Calcutta:20191013T060223
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191012_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-20\, Islamic: 1441-02-12 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -51907,7 +51907,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191012
 DTEND;VALUE=DATE:20191013
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-12T06:02:23.999997+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -51947,7 +51947,7 @@ BEGIN:VEVENT
 SUMMARY:Naṭarājar Mahābhiṣēkam
 DTSTART;VALUE=DATE:20191012
 DTEND;VALUE=DATE:20191013
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:NaṭarājarMahābhiṣēkam_2019-10-12T06:02:23.999997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/Tamil/sidereal_solar_month/tithi/06/14/na
@@ -51968,7 +51968,7 @@ BEGIN:VEVENT
 SUMMARY:Puraṭṭāchi Chanikkiḻamai
 DTSTART;VALUE=DATE:20191012
 DTEND;VALUE=DATE:20191013
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:PuraṭṭāchiChanikkiḻamai_2019-10-12T06:02:23.999997+05:30
 DESCRIPTION:Perform special puja and naivedyam (e.g. tilānnam) to Shri Ve
  nkateshwara.<br/><br/>## Details<br/>- [Edit config file](https://github.c
@@ -51988,7 +51988,7 @@ SUMMARY:Āśvayujaḥ-07-15  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \
  ,  Kanyā-Citrā-06-27🌞🌌  \,  Ūrjaḥ-08-21🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191013T060223
 DTEND;TZID=Asia/Calcutta:20191014T060232
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191013_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-21\, Islamic: 1441-02-13 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -52044,7 +52044,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -52079,7 +52079,7 @@ BEGIN:VEVENT
 SUMMARY:apatya-nīrājanam
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:apatya-nīrājanam_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Niśīthaḥ/puurvaviddha). <br/><br/>Eldest children are given gifts o
@@ -52101,7 +52101,7 @@ SUMMARY:kāñcī 36 jagadguru-śrī-citsukhānandēndra-sarasvatī-ārādh
  anā #1262
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī36jagadguru-śrī-citsukhānandēndra-sarasvatī-ārādhanā#1
  262_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -52126,7 +52126,7 @@ BEGIN:VEVENT
 SUMMARY:kō-jāgarti-vratam
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kō-jāgarti-vratam_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Niśīthaḥ/paraviddha). <br/><br/>Have to play Aksha kreeda only on t
@@ -52151,7 +52151,7 @@ BEGIN:VEVENT
 SUMMARY:kaumudī-utsavaḥ
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kaumudī-utsavaḥ_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>This is celebrated either on Sh
@@ -52172,7 +52172,7 @@ BEGIN:VEVENT
 SUMMARY:kumāra-pūrṇimā/mahā-aśvinī
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kumāra-pūrṇimā/mahā-aśvinī_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -52192,7 +52192,7 @@ BEGIN:VEVENT
 SUMMARY:kuntī-(pārvatī)-vratam
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kuntī-(pārvatī)-vratam_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>Kunti-vratam done today will re
@@ -52215,7 +52215,7 @@ BEGIN:VEVENT
 SUMMARY:lakṣmī-indra-kubēra-pūjā
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:lakṣmī-indra-kubēra-pūjā_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refe
@@ -52235,7 +52235,7 @@ BEGIN:VEVENT
 SUMMARY:mīrābāī-jayantī #522
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mīrābāī-jayantī#522_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). The event occurred in 4599 (Kali era).  <
@@ -52256,7 +52256,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -52277,7 +52277,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -52301,7 +52301,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -52321,7 +52321,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -52340,7 +52340,7 @@ BEGIN:VEVENT
 SUMMARY:vālmīki-maharṣi-jayantī
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vālmīki-maharṣi-jayantī_2019-10-13T06:02:23.999997+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -52360,7 +52360,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-10-13T06:02:23.9999
  97+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -52383,7 +52383,7 @@ BEGIN:VEVENT
 SUMMARY:śarat-pūrṇimā/navānna-pūrṇimā
 DTSTART;VALUE=DATE:20191013
 DTEND;VALUE=DATE:20191014
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śarat-pūrṇimā/navānna-pūrṇimā_2019-10-13T06:02:23.999997+05:
  30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Āśvayujaḥ (lunar) mont
@@ -52405,7 +52405,7 @@ SUMMARY:Āśvayujaḥ-07-16  \,Mīnaḥ-Rēvatī🌛🌌  \,  Kanyā-Citr
  ā-06-28🌞🌌  \,  Ūrjaḥ-08-22🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191014T060232
 DTEND;TZID=Asia/Calcutta:20191015T060241
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191014_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-22\, Islamic: 1441-02-14 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -52461,7 +52461,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191014
 DTEND;VALUE=DATE:20191015
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-14T06:02:32.639982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -52507,7 +52507,7 @@ BEGIN:VEVENT
 SUMMARY:appayya-dīkṣita-jayantī #501
 DTSTART;VALUE=DATE:20191014
 DTEND;VALUE=DATE:20191015
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:appayya-dīkṣita-jayantī#501_2019-10-14T06:02:32.639982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/smArta-misc/sidereal_solar_month/tith
@@ -52529,7 +52529,7 @@ BEGIN:VEVENT
 SUMMARY:jayāvāpti-vratam
 DTSTART;VALUE=DATE:20191014
 DTEND;VALUE=DATE:20191015
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:jayāvāpti-vratam_2019-10-14T06:02:32.639982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of Āśvayujaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -52549,7 +52549,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20191014
 DTEND;VALUE=DATE:20191015
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-10-14T06:02:
  32.639982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -52576,7 +52576,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20191014
 DTEND;VALUE=DATE:20191015
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-10-14T06:02:32.639982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -52595,7 +52595,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20191014
 DTEND;VALUE=DATE:20191015
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-10-14T06:02:32.639982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -52617,7 +52617,7 @@ SUMMARY:Āśvayujaḥ-07-17  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Kanyā-Cit
  rā-06-29🌞🌌  \,  Ūrjaḥ-08-23🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191015T060241
 DTEND;TZID=Asia/Calcutta:20191016T060249
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191015_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-23\, Islamic: 1441-02-15 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -52673,7 +52673,7 @@ BEGIN:VEVENT
 SUMMARY:aśūnyaśayana-vratam
 DTSTART;VALUE=DATE:20191015
 DTEND;VALUE=DATE:20191016
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aśūnyaśayana-vratam_2019-10-15T06:02:41.280008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/07/17/azUnyaza
@@ -52694,7 +52694,7 @@ BEGIN:VEVENT
 SUMMARY:bhaumāśvinī-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191014T235957
 DTEND;TZID=Asia/Calcutta:20191015T122736
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhaumāśvinī-yōgaḥ_2019-10-14T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/bhaumAz
@@ -52713,7 +52713,7 @@ BEGIN:VEVENT
 SUMMARY:Rudra Paśupati Nāyanmār (17) Gurupūjai
 DTSTART;VALUE=DATE:20191015
 DTEND;VALUE=DATE:20191016
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:RudraPaśupatiNāyanmār(17)Gurupūjai_2019-10-15T06:02:41.280008+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -52738,7 +52738,7 @@ SUMMARY:Āśvayujaḥ-07-18  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Kany
  ā-Citrā-06-30🌞🌌  \,  Ūrjaḥ-08-24🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191016T060249
 DTEND;TZID=Asia/Calcutta:20191017T060258
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191016_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-24\, Islamic: 1441-02-16 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -52794,7 +52794,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191016T174607
 DTEND;TZID=Asia/Calcutta:20191017T060258
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-16T17:46:07.680006+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -52815,7 +52815,7 @@ BEGIN:VEVENT
 SUMMARY:candrōdaya-gaurī-vratam
 DTSTART;VALUE=DATE:20191016
 DTEND;VALUE=DATE:20191017
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:candrōdaya-gaurī-vratam_2019-10-16T06:02:49.919993+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Āśvayujaḥ (lun
  ar) month (Chandrōdayaḥ/puurvaviddha). <br/><br/>Attla-Taddi (Telugu). 
@@ -52836,7 +52836,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20191016
 DTEND;VALUE=DATE:20191017
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-10-16T06:02:49.919993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -52857,7 +52857,7 @@ BEGIN:VEVENT
 SUMMARY:kanaka-gaṇēśa-vratam
 DTSTART;VALUE=DATE:20191016
 DTEND;VALUE=DATE:20191017
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kanaka-gaṇēśa-vratam_2019-10-16T06:02:49.919993+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Āśvayujaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -52877,7 +52877,7 @@ BEGIN:VEVENT
 SUMMARY:lalitā-gaurī-vratam
 DTSTART;VALUE=DATE:20191016
 DTEND;VALUE=DATE:20191017
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:lalitā-gaurī-vratam_2019-10-16T06:02:49.919993+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Āśvayujaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -52898,7 +52898,7 @@ SUMMARY:Āśvayujaḥ-07-18  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Kany
  ā-Citrā-06-31🌞🌌  \,  Ūrjaḥ-08-25🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191017T060258
 DTEND;TZID=Asia/Calcutta:20191018T060307
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191017_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-25\, Islamic: 1441-02-17 Ṣafar\
  , 🌌🌞: सं- Kanyā\, तं- Puraṭṭāsi\, म- Kanni\, प- As
@@ -52954,7 +52954,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191018
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-17T06:02:58.560019+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -52979,7 +52979,7 @@ BEGIN:VEVENT
 SUMMARY:karaka-caturthī
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191018
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:karaka-caturthī_2019-10-17T06:02:58.560019+05:30
 DESCRIPTION:Karaka chaturthi vratam --- the famous Karwa Chauth festival i
  s celebrated on this day. Only women have the right to perform this vratam
@@ -53001,7 +53001,7 @@ BEGIN:VEVENT
 SUMMARY:vakratuṇḍa-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191018
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vakratuṇḍa-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-1
  0-17T06:02:58.560019+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -53029,7 +53029,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191018
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-10-17T06:02:58.560019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -53052,7 +53052,7 @@ SUMMARY:Āśvayujaḥ-07-19  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Tul
  ā-Citrā-07-01🌞🌌  \,  Ūrjaḥ-08-26🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191018T060307
 DTEND;TZID=Asia/Calcutta:20191019T060315
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191018_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-26\, Islamic: 1441-02-18 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53108,7 +53108,7 @@ BEGIN:VEVENT
 SUMMARY:ākāśadīpa-ārambhaḥ
 DTSTART;VALUE=DATE:20191018
 DTEND;VALUE=DATE:20191019
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ākāśadīpa-ārambhaḥ_2019-10-18T06:03:07.200004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/sidereal_solar_month/day/07/01/AkAzadIpa-
@@ -53129,7 +53129,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191018T060307
 DTEND;TZID=Asia/Calcutta:20191018T174507
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-18T06:03:07.200004+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -53151,7 +53151,7 @@ BEGIN:VEVENT
 SUMMARY:bhr̥guvāra-subrahmaṇya-vratam
 DTSTART;VALUE=DATE:20191018
 DTEND;VALUE=DATE:20191019
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhr̥guvāra-subrahmaṇya-vratam_2019-10-18T06:03:07.200004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/bhRguvAra-subrahm
@@ -53172,7 +53172,7 @@ BEGIN:VEVENT
 SUMMARY:ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191018T060307
 DTEND;TZID=Asia/Calcutta:20191018T065514
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ravi-saṅkramaṇa-puṇyakālaḥ_2019-10-18T06:03:07.200004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/ravi-saGkra
@@ -53190,7 +53190,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191018T060307
 DTEND;TZID=Asia/Calcutta:20191018T115402
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-10-18T06:03:07.2
  00004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -53210,7 +53210,7 @@ BEGIN:VEVENT
 SUMMARY:tulā-kāvērī-snāna-ārambhaḥ
 DTSTART;VALUE=DATE:20191018
 DTEND;VALUE=DATE:20191019
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:tulā-kāvērī-snāna-ārambhaḥ_2019-10-18T06:03:07.200004+05:30
 DESCRIPTION:Perform snānam in Kaveri during this month.<br/><br/>ṣaṭ
  ṣaṣṭikōṭitīrthāni dvisaptabhuvanēṣu ca।  <br/>kēśavasyā
@@ -53231,7 +53231,7 @@ BEGIN:VEVENT
 SUMMARY:tulā-saṅkramaṇa-puṇyakālaḥ
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191018
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:tulā-saṅkramaṇa-puṇyakālaḥ_2019-10-17T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/tulA-saGkra
@@ -53254,7 +53254,7 @@ SUMMARY:Āśvayujaḥ-07-20  \,Mithunam-Mr̥gaśīrṣam🌛🌌  \,  Tul
  ā-Citrā-07-02🌞🌌  \,  Ūrjaḥ-08-27🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191019T060315
 DTEND;TZID=Asia/Calcutta:20191020T060324
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191019_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-27\, Islamic: 1441-02-19 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53310,7 +53310,7 @@ BEGIN:VEVENT
 SUMMARY:ghōṭaka-pañcamī
 DTSTART;VALUE=DATE:20191019
 DTEND;VALUE=DATE:20191020
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ghōṭaka-pañcamī_2019-10-19T06:03:15.839989+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Pañcamī tithi of Āśvayujaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -53330,7 +53330,7 @@ BEGIN:VEVENT
 SUMMARY:sēṅgālipuram anantarāma-dīkṣita-ārādhanā #50
 DTSTART;VALUE=DATE:20191019
 DTEND;VALUE=DATE:20191020
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sēṅgālipuramanantarāma-dīkṣita-ārādhanā#50_2019-10-19T06:03
  :15.839989+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ṣaṣṭhī tithi of Tulā (sidereal
@@ -53355,7 +53355,7 @@ SUMMARY:Āśvayujaḥ-07-21  \,Mithunam-Ārdrā🌛🌌  \,  Tulā-Citrā-
  07-03🌞🌌  \,  Ūrjaḥ-08-28🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191020T060324
 DTEND;TZID=Asia/Calcutta:20191021T060333
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191020_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-28\, Islamic: 1441-02-20 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53411,7 +53411,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191020T174358
 DTEND;TZID=Asia/Calcutta:20191021T060333
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-20T17:43:58.079984+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -53432,7 +53432,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191020T174952
 DTEND;TZID=Asia/Calcutta:20191021T060333
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-10-20T17:49:52.319986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -53452,7 +53452,7 @@ SUMMARY:Āśvayujaḥ-07-22  \,Mithunam-Punarvasuḥ🌛🌌  \,  Tulā-Ci
  trā-07-04🌞🌌  \,  Ūrjaḥ-08-29🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191021T060333
 DTEND;TZID=Asia/Calcutta:20191022T060341
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191021_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-29\, Islamic: 1441-02-21 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53509,7 +53509,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgārakaḥ–udayaḥ (prāk)
 DTSTART;VALUE=DATE:20191020
 DTEND;VALUE=DATE:20191022
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:aṅgārakaḥ–udayaḥ(prāk)_2019-10-20T23:59:57.120005+05:30
 DESCRIPTION:aṅgārakaḥ rises out of combustion (udayaH)\, heading prā
  k (east)\, on 2019-Oct-22 03:08. At this moment aṅgārakaḥ is at hasta
@@ -53531,7 +53531,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191021
 DTEND;VALUE=DATE:20191022
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-21T06:03:33.120000+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -53566,7 +53566,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20191021
 DTEND;VALUE=DATE:20191022
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-10-21T06:03:33.120000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -53587,7 +53587,7 @@ BEGIN:VEVENT
 SUMMARY:maṅgala-vratam
 DTSTART;VALUE=DATE:20191021
 DTEND;VALUE=DATE:20191022
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:maṅgala-vratam_2019-10-21T06:03:33.120000+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Āśvayujaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -53607,7 +53607,7 @@ BEGIN:VEVENT
 SUMMARY:mahālakṣmī-vratam
 DTSTART;VALUE=DATE:20191021
 DTEND;VALUE=DATE:20191022
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:mahālakṣmī-vratam_2019-10-21T06:03:33.120000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/lakShmI/lunar_month/tithi/07/23/mahAlakSmI
@@ -53628,7 +53628,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20191021
 DTEND;VALUE=DATE:20191022
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-10-21T06:03:33.120000+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -53648,7 +53648,7 @@ SUMMARY:Āśvayujaḥ-07-24  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Tulā-
  Citrā-07-05🌞🌌  \,  Ūrjaḥ-08-30🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191022T060341
 DTEND;TZID=Asia/Calcutta:20191023T060359
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191022_day_summary
 DESCRIPTION:- Indian civil date: 1941-07-30\, Islamic: 1441-02-22 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53704,7 +53704,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191022T174257
 DTEND;TZID=Asia/Calcutta:20191023T060359
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-22T17:42:57.600007+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -53725,7 +53725,7 @@ BEGIN:VEVENT
 SUMMARY:bhīmasēna-jayantī
 DTSTART;VALUE=DATE:20191022
 DTEND;VALUE=DATE:20191023
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:bhīmasēna-jayantī_2019-10-22T06:03:41.759985+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Navamī tithi of Āśvayujaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Bhava year<br/><br/>## Det
@@ -53746,7 +53746,7 @@ SUMMARY:Āśvayujaḥ-07-25  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Tul
  ā-Citrā-07-06🌞🌌  \,  Ūrjaḥ-08-31🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191023T060359
 DTEND;TZID=Asia/Calcutta:20191024T060407
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191023_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-01\, Islamic: 1441-02-23 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53802,7 +53802,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191023
 DTEND;VALUE=DATE:20191024
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-23T06:03:59.039996+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -53827,7 +53827,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191023T223215
 DTEND;TZID=Asia/Calcutta:20191023T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-10-23T22:32:15.360011+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -53843,7 +53843,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191023T115311
 DTEND;TZID=Asia/Calcutta:20191023T174231
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-10-23T11:
  53:11.040011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -53864,7 +53864,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191023T162546
 DTEND;TZID=Asia/Calcutta:20191023T174231
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-viṣṇupadī-puṇyakālaḥ_2019-10-23T16:25:46.559988+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -53884,7 +53884,7 @@ BEGIN:VEVENT
 SUMMARY:sahō-māsaḥ/hēmantar̥tuḥ
 DTSTART;TZID=Asia/Calcutta:20191023T224940
 DTEND;TZID=Asia/Calcutta:20191023T235957
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sahō-māsaḥ/hēmantar̥tuḥ_2019-10-23T22:49:40.800006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -53904,7 +53904,7 @@ SUMMARY:Āśvayujaḥ-07-26  \,Siṁhaḥ-Maghā🌛🌌  \,  Tulā-Citrā
  -07-07🌞🌌  \,  Sahaḥ-09-01🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191024T060407
 DTEND;TZID=Asia/Calcutta:20191025T060416
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191024_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-02\, Islamic: 1441-02-24 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -53959,7 +53959,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191024T060407
 DTEND;TZID=Asia/Calcutta:20191024T174205
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-24T06:04:07.679982+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -53981,7 +53981,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-ramā-ēkādaśī
 DTSTART;VALUE=DATE:20191024
 DTEND;VALUE=DATE:20191025
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:sarva-ramā-ēkādaśī_2019-10-24T06:04:07.679982+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of āśvayuja month is known as ra
  mā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatly 
@@ -54076,7 +54076,7 @@ BEGIN:VEVENT
 SUMMARY:tāmraparṇī-antya-puṣkara-ārambhaḥ
 DTSTART;VALUE=DATE:20191024
 DTEND;VALUE=DATE:20191025
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:tāmraparṇī-antya-puṣkara-ārambhaḥ_2019-10-24T06:04:07.679982+
  05:30
 DESCRIPTION:Coming from Brahma's Kamandalu\, Pushkara Raja resides in diff
@@ -54115,7 +54115,7 @@ SUMMARY:śr̥ṅgērī 34 jagadguru-śrī-candraśēkhara bhāratī-3 jaya
  ntī
 DTSTART;VALUE=DATE:20191024
 DTEND;VALUE=DATE:20191025
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:śr̥ṅgērī34jagadguru-śrī-candraśēkharabhāratī-3jayantī_201
  9-10-24T06:04:07.679982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Ēkādaśī tithi of Āśvayujaḥ (lu
@@ -54140,7 +54140,7 @@ SUMMARY:Āśvayujaḥ-07-27  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Tul
  ā-Svātī-07-08🌞🌌  \,  Sahaḥ-09-02🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191025T060416
 DTEND;TZID=Asia/Calcutta:20191026T060433
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191025_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-03\, Islamic: 1441-02-25 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -54196,7 +54196,7 @@ BEGIN:VEVENT
 SUMMARY:(yama)-dīpa-trayōdaśī
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:(yama)-dīpa-trayōdaśī_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/07/28/%28yama%29-dIpa-t
@@ -54217,7 +54217,7 @@ BEGIN:VEVENT
 SUMMARY:Chatti Nāyanmār (45) Gurupūjai
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:ChattiNāyanmār(45)Gurupūjai_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -54240,7 +54240,7 @@ BEGIN:VEVENT
 SUMMARY:dhanvantari-jayantī
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dhanvantari-jayantī_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Trayōdaśī tithi of Āśvayujaḥ (l
  unar) month (Pradōṣaḥ/puurvaviddha). <br/><br/>Dhanvantari Jayanti (b
@@ -54261,7 +54261,7 @@ BEGIN:VEVENT
 SUMMARY:gōvatsa-dvādaśī
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:gōvatsa-dvādaśī_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Āśvayujaḥ (lun
  ar) month (Pradōṣaḥ/puurvaviddha). <br/><br/>Avoid cow's milk\, ghee\
@@ -54287,7 +54287,7 @@ BEGIN:VEVENT
 SUMMARY:kāmākṣī-āvirbhāvaḥ
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:kāmākṣī-āvirbhāvaḥ_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:Observed on Pūrvaphalgunī nakshatra of Tulā (sidereal solar
  ) month (Sāṅgavaḥ/paraviddha). <br/><br/>kāntā kāma-dughā karīnd
@@ -54313,7 +54313,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20191025T174131
 DTEND;TZID=Asia/Calcutta:20191025T191423
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-10-25T17:41:31.199993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -54331,7 +54331,7 @@ BEGIN:VEVENT
 SUMMARY:vasudēva-pūjā
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vasudēva-pūjā_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Āśvayujaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -54351,7 +54351,7 @@ BEGIN:VEVENT
 SUMMARY:vyāghra-dvādaśī
 DTSTART;VALUE=DATE:20191025
 DTEND;VALUE=DATE:20191026
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vyāghra-dvādaśī_2019-10-25T06:04:16.320007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvādaśī tithi of Āśvayujaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>In Gujarat<br/><br/>## 
@@ -54372,7 +54372,7 @@ SUMMARY:Āśvayujaḥ-07-28  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Tulā-S
  vātī-07-09🌞🌌  \,  Sahaḥ-09-03🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191026T060433
 DTEND;TZID=Asia/Calcutta:20191027T060450
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191026_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-04\, Islamic: 1441-02-26 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -54427,7 +54427,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191026T174105
 DTEND;TZID=Asia/Calcutta:20191027T060450
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-26T17:41:05.279996+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -54448,7 +54448,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-7
 DTSTART;VALUE=DATE:20191026
 DTEND;VALUE=DATE:20191027
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-7_2019-10-26T06:04:33.600018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of Āśvayujaḥ (lu
  nar) month (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -54468,7 +54468,7 @@ BEGIN:VEVENT
 SUMMARY:dhana-trayōdaśī
 DTSTART;VALUE=DATE:20191026
 DTEND;VALUE=DATE:20191027
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dhana-trayōdaśī_2019-10-26T06:04:33.600018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Trayōdaśī tithi of Āśvayujaḥ (l
  unar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Dhan-trayodashi in Gu
@@ -54488,7 +54488,7 @@ BEGIN:VEVENT
 SUMMARY:gō-trirātra-vratam
 DTSTART;VALUE=DATE:20191026
 DTEND;VALUE=DATE:20191027
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:gō-trirātra-vratam_2019-10-26T06:04:33.600018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Trayōdaśī tithi of Āśvayujaḥ (l
  unar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<
@@ -54508,7 +54508,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20191026
 DTEND;VALUE=DATE:20191027
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-10-26T06:04:33.600018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -54528,7 +54528,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20191026
 DTEND;VALUE=DATE:20191027
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-10-26T06:04:33.600018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -54547,7 +54547,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20191026
 DTEND;VALUE=DATE:20191027
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-10-26T06:04:33.600018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -54570,7 +54570,7 @@ SUMMARY:Āśvayujaḥ-07-29  \,Kanyā-Citrā🌛🌌  \,  Tulā-Svātī-07
  -10🌞🌌  \,  Sahaḥ-09-04🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191027T060450
 DTEND;TZID=Asia/Calcutta:20191028T060459
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:20191027_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-05\, Islamic: 1441-02-27 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -54625,7 +54625,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -54665,7 +54665,7 @@ BEGIN:VEVENT
 SUMMARY:dīpāvalī/lakṣmī-kubēra-pūjā
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dīpāvalī/lakṣmī-kubēra-pūjā_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āśvayujaḥ (lunar) month (
  Pradōṣaḥ/paraviddha). <br/><br/>Gives light even to Naraka-vasis\; Al
@@ -54686,7 +54686,7 @@ BEGIN:VEVENT
 SUMMARY:dīpōtsava-caturdaśī/yama-tarpaṇam
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115609Z
+DTSTAMP:20200101T000000Z
 UID:dīpōtsava-caturdaśī/yama-tarpaṇam_2019-10-27T06:04:50.879989+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -54708,7 +54708,7 @@ BEGIN:VEVENT
 SUMMARY:naraka-caturdaśī-snānam
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:naraka-caturdaśī-snānam_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/07/29/naraka-caturdazI-
@@ -54729,7 +54729,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -54750,7 +54750,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -54769,7 +54769,7 @@ BEGIN:VEVENT
 SUMMARY:prēta-caturdaśī
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:prēta-caturdaśī_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/07/29/prEta-caturda
@@ -54791,7 +54791,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-āśvayuja-amāvāsyā
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sarva-āśvayuja-amāvāsyā_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:amāvāsyā of āśvayuja month.<br/><br/>## Details<br/>- [Ed
  it config file](https://github.com/jyotisham/adyatithi/blob/master/time_fo
@@ -54811,7 +54811,7 @@ SUMMARY:śr̥ṅgērī 35 jagadguru-śrī-abhinava vidyātīrtha mahāsvā
  mī jayantī
 DTSTART;VALUE=DATE:20191027
 DTEND;VALUE=DATE:20191028
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śr̥ṅgērī35jagadguru-śrī-abhinavavidyātīrthamahāsvāmījayan
  tī_2019-10-27T06:04:50.879989+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of Āśvayujaḥ (lu
@@ -54836,7 +54836,7 @@ SUMMARY:Āśvayujaḥ-07-30  \,Tulā-Svātī🌛🌌  \,  Tulā-Svātī-07
  -11🌞🌌  \,  Sahaḥ-09-05🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191028T060459
 DTEND;TZID=Asia/Calcutta:20191029T060516
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191028_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-06\, Islamic: 1441-02-28 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -54891,7 +54891,7 @@ BEGIN:VEVENT
 SUMMARY:āgrayaṇa-hōmaḥ drāviḍēṣu
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:āgrayaṇa-hōmaḥdrāviḍēṣu_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Tulā (sidereal solar) month 
  (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform hōma with fresh rice fro
@@ -54912,7 +54912,7 @@ BEGIN:VEVENT
 SUMMARY:āśvina-māsaḥ
 DTSTART;VALUE=DATE:20190928
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:āśvina-māsaḥ_2019-09-28T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/Azvina-mAsaH.tom
@@ -54934,7 +54934,7 @@ BEGIN:VEVENT
 SUMMARY:āśvina-māsa-samāpanam
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:āśvina-māsa-samāpanam_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āśvayujaḥ (lunar) month (
  Sūryōdayaḥ/paraviddha). <br/><br/>āśvina-māsaḥ ends today<br/><br
@@ -54954,7 +54954,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -55000,7 +55000,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -55035,7 +55035,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -55054,7 +55054,7 @@ BEGIN:VEVENT
 SUMMARY:gōvardhana-pūjā
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gōvardhana-pūjā_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/vaiShNava/lunar_month/tithi/08/01/gOvardha
@@ -55076,7 +55076,7 @@ BEGIN:VEVENT
 SUMMARY:kēdāra-gaurī-vratam
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kēdāra-gaurī-vratam_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āśvayujaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -55096,7 +55096,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-10-28T06:04:59.520014
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -55122,7 +55122,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -55143,7 +55143,7 @@ BEGIN:VEVENT
 SUMMARY:sōmavatī amāvāsyā
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sōmavatīamāvāsyā_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/amAvAsyA/description_only/sOma
@@ -55164,7 +55164,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -55185,7 +55185,7 @@ BEGIN:VEVENT
 SUMMARY:vikramāditya-paṭṭābhiṣēkaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vikramāditya-paṭṭābhiṣēkaḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āśvayujaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -55205,7 +55205,7 @@ BEGIN:VEVENT
 SUMMARY:śrīrāma-paṭṭābhiṣēkaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191029
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śrīrāma-paṭṭābhiṣēkaḥ_2019-10-28T06:04:59.520014+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Āśvayujaḥ (lunar) month (
  Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -55225,7 +55225,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191028T080640
 DTEND;TZID=Asia/Calcutta:20191028T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-10-28T08:06:40.320004+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -55242,7 +55242,7 @@ SUMMARY:Kārttikaḥ-08-01  \,Tulā-Viśākhā🌛🌌  \,  Tulā-Svātī-
  07-12🌞🌌  \,  Sahaḥ-09-06🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191029T060516
 DTEND;TZID=Asia/Calcutta:20191030T060534
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191029_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-07\, Islamic: 1441-02-29 Ṣafar\
  , 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulāṁ\, प- Kattaka
@@ -55298,7 +55298,7 @@ BEGIN:VEVENT
 SUMMARY:bali-pratipat
 DTSTART;VALUE=DATE:20191029
 DTEND;VALUE=DATE:20191030
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:bali-pratipat_2019-10-29T06:05:16.799985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/08/01/bali_pratipat.tom
@@ -55319,7 +55319,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20191029T173956
 DTEND;TZID=Asia/Calcutta:20191029T185322
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-10-29T17:39:56.159993+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -55338,7 +55338,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20191029
 DTEND;VALUE=DATE:20191030
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-10-29T06:05:16.799985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -55359,7 +55359,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20191029
 DTEND;VALUE=DATE:20191030
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsa-ārambhaḥ_2019-10-29T06:05:16.799985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/08/01/kArttika-
@@ -55381,7 +55381,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191029T061320
 DTEND;TZID=Asia/Calcutta:20191029T230858
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-10-29T06:13:20.640008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -55400,7 +55400,7 @@ BEGIN:VEVENT
 SUMMARY:yama/bhrātr̥-dvitīyā
 DTSTART;VALUE=DATE:20191029
 DTEND;VALUE=DATE:20191030
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:yama/bhrātr̥-dvitīyā_2019-10-29T06:05:16.799985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/08/02/yama_or_bhrAtR-dv
@@ -55423,7 +55423,7 @@ SUMMARY:Kārttikaḥ-08-03  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,  Tulā
  -Svātī-07-13🌞🌌  \,  Sahaḥ-09-07🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191030T060534
 DTEND;TZID=Asia/Calcutta:20191031T060551
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191030_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-08\, Islamic: 1441-03-01 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -55478,7 +55478,7 @@ BEGIN:VEVENT
 SUMMARY:budhānurādhā-yōgaḥ
 DTSTART;VALUE=DATE:20191029
 DTEND;VALUE=DATE:20191030
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budhānurādhā-yōgaḥ_2019-10-29T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/budhAnu
@@ -55500,7 +55500,7 @@ BEGIN:VEVENT
 SUMMARY:Pūchalār Nāyanmār (58) Gurupūjai
 DTSTART;VALUE=DATE:20191030
 DTEND;VALUE=DATE:20191031
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:PūchalārNāyanmār(58)Gurupūjai_2019-10-30T06:05:34.079996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -55524,7 +55524,7 @@ SUMMARY:Kārttikaḥ-08-04  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \,  Tul
  ā-Svātī-07-14🌞🌌  \,  Sahaḥ-09-08🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191031T060551
 DTEND;TZID=Asia/Calcutta:20191101T060608
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191031_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-09\, Islamic: 1441-03-02 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -55580,7 +55580,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20191031
 DTEND;VALUE=DATE:20191101
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-10-31T06:05:51.360007+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -55601,7 +55601,7 @@ SUMMARY:Kārttikaḥ-08-05  \,Dhanuḥ-Mūlā🌛🌌  \,  Tulā-Svātī-0
  7-15🌞🌌  \,  Sahaḥ-09-09🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191101T060608
 DTEND;TZID=Asia/Calcutta:20191102T060625
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191101_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-10\, Islamic: 1441-03-03 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -55656,7 +55656,7 @@ BEGIN:VEVENT
 SUMMARY:Aiyaḍigaḷ Kāḍavarkōn Nāyanmār (46) Gurupūjai
 DTSTART;VALUE=DATE:20191101
 DTEND;VALUE=DATE:20191102
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:AiyaḍigaḷKāḍavarkōnNāyanmār(46)Gurupūjai_2019-11-01T06:06:0
  8.640018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -55682,7 +55682,7 @@ BEGIN:VEVENT
 SUMMARY:dēvasēnā-pañcamī
 DTSTART;VALUE=DATE:20191101
 DTEND;VALUE=DATE:20191102
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dēvasēnā-pañcamī_2019-11-01T06:06:08.640018+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Kārttikaḥ (lunar) mon
  th (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Refe
@@ -55703,7 +55703,7 @@ BEGIN:VEVENT
 SUMMARY:jayā-vratam
 DTSTART;VALUE=DATE:20191101
 DTEND;VALUE=DATE:20191102
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:jayā-vratam_2019-11-01T06:06:08.640018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/08/05/jayA-vratam.toml)
@@ -55724,7 +55724,7 @@ BEGIN:VEVENT
 SUMMARY:pāṇḍava-(lābha)-pañcamī
 DTSTART;VALUE=DATE:20191101
 DTEND;VALUE=DATE:20191102
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pāṇḍava-(lābha)-pañcamī_2019-11-01T06:06:08.640018+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Kārttikaḥ (lunar) mon
  th (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edi
@@ -55744,7 +55744,7 @@ BEGIN:VEVENT
 SUMMARY:sarpa-pūjā
 DTSTART;VALUE=DATE:20191101
 DTEND;VALUE=DATE:20191102
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sarpa-pūjā_2019-11-01T06:06:08.640018+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Kārttikaḥ (lunar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vishnu's boon to AdiSesha that
@@ -55766,7 +55766,7 @@ SUMMARY:Kārttikaḥ-08-06  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Tul
  ā-Svātī-07-16🌞🌌  \,  Sahaḥ-09-10🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191102T060625
 DTEND;TZID=Asia/Calcutta:20191103T060643
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191102_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-11\, Islamic: 1441-03-04 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -55822,7 +55822,7 @@ BEGIN:VEVENT
 SUMMARY:skandaṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20191102
 DTEND;VALUE=DATE:20191103
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:skandaṣaṣṭhī-vratam_2019-11-02T06:06:25.919988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/description_only/skandaSaSThI-vrat
@@ -55843,7 +55843,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191103T013106
 DTEND;TZID=Asia/Calcutta:20191103T060643
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-11-03T01:31:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -55863,7 +55863,7 @@ SUMMARY:Kārttikaḥ-08-07  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  Tu
  lā-Svātī-07-17🌞🌌  \,  Sahaḥ-09-11🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191103T060643
 DTEND;TZID=Asia/Calcutta:20191104T060700
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191103_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-12\, Islamic: 1441-03-05 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -55918,7 +55918,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191103T173803
 DTEND;TZID=Asia/Calcutta:20191104T060700
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-03T17:38:03.839983+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -55939,7 +55939,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;VALUE=DATE:20191103
 DTEND;VALUE=DATE:20191104
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-11-03T06:06:43.199999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -55961,7 +55961,7 @@ BEGIN:VEVENT
 SUMMARY:vijayā-bhānusaptamī
 DTSTART;VALUE=DATE:20191103
 DTEND;VALUE=DATE:20191104
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vijayā-bhānusaptamī_2019-11-03T06:06:43.199999+05:30
 DESCRIPTION:saptamī tithi on a Sunday is as sacred as a solar eclipse. Pa
  rticularly good for worshipping Surya. When śukla saptamī is present at 
@@ -55985,7 +55985,7 @@ SUMMARY:Kārttikaḥ-08-08  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Tulā-S
  vātī-07-18🌞🌌  \,  Sahaḥ-09-12🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191104T060700
 DTEND;TZID=Asia/Calcutta:20191105T060717
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191104_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-13\, Islamic: 1441-03-06 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -56040,7 +56040,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -56075,7 +56075,7 @@ BEGIN:VEVENT
 SUMMARY:gōpāṣṭamī
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gōpāṣṭamī_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Kārttikaḥ (lunar) m
  onth (Madhyāhnaḥ/paraviddha). <br/><br/>Perform pūjā of cow with calf
@@ -56098,7 +56098,7 @@ BEGIN:VEVENT
 SUMMARY:guru-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191105T024113
 DTEND;TZID=Asia/Calcutta:20191104T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:guru-saṅkrāntiḥ_2019-11-05T02:41:13.919982+05:30
 DESCRIPTION:Transition of Jupiter from one Rashi to another. When it is no
  t retrograde\, it also marks the beginning of a new Pushkara.<br/><br/>## 
@@ -56115,7 +56115,7 @@ BEGIN:VEVENT
 SUMMARY:kārtavīryārjuna-jayantī
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārtavīryārjuna-jayantī_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of Kārttikaḥ (lunar) m
  onth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- R
@@ -56136,7 +56136,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-sōmavāsaraḥ
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-sōmavāsaraḥ_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shaiva/description_only/kArttika~sOmavAsar
@@ -56157,7 +56157,7 @@ BEGIN:VEVENT
 SUMMARY:Poygaiyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:PoygaiyāḻvārTirunakṣattiram_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on Śravaṇaḥ nakshatra of Tulā (sidereal solar) 
  month (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -56177,7 +56177,7 @@ BEGIN:VEVENT
 SUMMARY:puṣkara-mēlā-prārambhaḥ
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:puṣkara-mēlā-prārambhaḥ_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/North/relative_event/puShkara-melA-samApt
@@ -56198,7 +56198,7 @@ BEGIN:VEVENT
 SUMMARY:sōmaśravaṇa-yōgaḥ
 DTSTART;VALUE=DATE:20191103
 DTEND;VALUE=DATE:20191104
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sōmaśravaṇa-yōgaḥ_2019-11-03T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/sOmazra
@@ -56220,7 +56220,7 @@ BEGIN:VEVENT
 SUMMARY:tāmraparṇī-antya-puṣkara-samāpanam
 DTSTART;VALUE=DATE:20191023
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tāmraparṇī-antya-puṣkara-samāpanam_2019-10-23T23:59:57.120005+0
  5:30
 DESCRIPTION:Coming from Brahma's Kamandalu\, Pushkara Raja resides in diff
@@ -56258,7 +56258,7 @@ BEGIN:VEVENT
 SUMMARY:tāmraparṇī-antya-puṣkara-samāpanam
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tāmraparṇī-antya-puṣkara-samāpanam_2019-11-04T06:07:00.480010+0
  5:30
 DESCRIPTION:Coming from Brahma's Kamandalu\, Pushkara Raja resides in diff
@@ -56296,7 +56296,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191105
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-11-04T06:07:00.480010+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -56316,7 +56316,7 @@ SUMMARY:Kārttikaḥ-08-09  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Tulā
  -Svātī-07-19🌞🌌  \,  Sahaḥ-09-13🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191105T060717
 DTEND;TZID=Asia/Calcutta:20191106T060735
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191105_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-14\, Islamic: 1441-03-07 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -56371,7 +56371,7 @@ BEGIN:VEVENT
 SUMMARY:akṣayā/kūṣmāṇḍa-navamī
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:akṣayā/kūṣmāṇḍa-navamī_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/08/09/akSayA~navamI.tom
@@ -56392,7 +56392,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:Anadhyayana on account of yugādi. On the days of Ayana (solst
  ices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (Sh
@@ -56415,7 +56415,7 @@ BEGIN:VEVENT
 SUMMARY:Bhūtattāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:BhūtattāḻvārTirunakṣattiram_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:Observed on Śraviṣṭhā nakshatra of Tulā (sidereal solar
  ) month (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -56435,7 +56435,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-8
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-8_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Kārttikaḥ (lunar) month
   (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit conf
@@ -56454,7 +56454,7 @@ BEGIN:VEVENT
 SUMMARY:jagaddhātrī-pūjā
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:jagaddhātrī-pūjā_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Kārttikaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit
@@ -56474,7 +56474,7 @@ SUMMARY:kāñcī 22 jagadguru-śrī-paripūrṇabōdhēndra-sarasvatī-ār
  ādhanā #1539
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī22jagadguru-śrī-paripūrṇabōdhēndra-sarasvatī-ārādhan
  ā#1539_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -56499,7 +56499,7 @@ BEGIN:VEVENT
 SUMMARY:sindhu/brahmaputra-ādya-puṣkara-ārambhaḥ
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sindhu/brahmaputra-ādya-puṣkara-ārambhaḥ_2019-11-05T06:07:17.759
  981+05:30
 DESCRIPTION:Coming from Brahma's Kamandalu\, Pushkara Raja resides in diff
@@ -56537,7 +56537,7 @@ BEGIN:VEVENT
 SUMMARY:trētāyugādiḥ
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:trētāyugādiḥ_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/yugAdiH/lunar_month/tithi/08/09/trEtAy
@@ -56559,7 +56559,7 @@ BEGIN:VEVENT
 SUMMARY:tulasī-vivāhōtsava-ārambhaḥ
 DTSTART;VALUE=DATE:20191105
 DTEND;VALUE=DATE:20191106
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tulasī-vivāhōtsava-ārambhaḥ_2019-11-05T06:07:17.759981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-flora/lunar_month/tithi/08/09/tulasI-
@@ -56582,7 +56582,7 @@ SUMMARY:Kārttikaḥ-08-09  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,  Tulā
  -Svātī-07-20🌞🌌  \,  Sahaḥ-09-14🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191106T060735
 DTEND;TZID=Asia/Calcutta:20191107T060800
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191106_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-15\, Islamic: 1441-03-08 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -56638,7 +56638,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20191106T191659
 DTEND;TZID=Asia/Calcutta:20191106T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-11-06T19:16:59.519998+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Nov-06 19:17. At this moment budhaḥ is at viśākhā-4 vr̥
@@ -56658,7 +56658,7 @@ SUMMARY:Kārttikaḥ-08-10  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Tulā-V
  iśākhā-07-21🌞🌌  \,  Sahaḥ-09-15🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191107T060800
 DTEND;TZID=Asia/Calcutta:20191108T060818
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191107_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-16\, Islamic: 1441-03-09 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -56715,7 +56715,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191107T173703
 DTEND;TZID=Asia/Calcutta:20191108T060818
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-07T17:37:03.360005+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -56736,7 +56736,7 @@ BEGIN:VEVENT
 SUMMARY:bhīṣma-pañcaka-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20191107
 DTEND;VALUE=DATE:20191108
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:bhīṣma-pañcaka-vrata-ārambhaḥ_2019-11-07T06:08:00.959988+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/xatra/lunar_month/tithi/08/11/bhISma-
@@ -56758,7 +56758,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191107T162520
 DTEND;TZID=Asia/Calcutta:20191107T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-11-07T16:25:20.639992+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -56774,7 +56774,7 @@ BEGIN:VEVENT
 SUMMARY:kaṁsa-vadhaḥ
 DTSTART;VALUE=DATE:20191107
 DTEND;VALUE=DATE:20191108
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kaṁsa-vadhaḥ_2019-11-07T06:08:00.959988+05:30
 DESCRIPTION:Observed on Śukla-Daśamī tithi of Kārttikaḥ (lunar) mont
  h (Sūryōdayaḥ/puurvaviddha). <br/><br/>Bhagavan Krishna killed Kamsa o
@@ -56795,7 +56795,7 @@ BEGIN:VEVENT
 SUMMARY:Pēyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20191107
 DTEND;VALUE=DATE:20191108
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:PēyāḻvārTirunakṣattiram_2019-11-07T06:08:00.959988+05:30
 DESCRIPTION:Observed on Śatabhiṣak nakshatra of Tulā (sidereal solar) 
  month (Prātaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit c
@@ -56815,7 +56815,7 @@ BEGIN:VEVENT
 SUMMARY:rājarāja-cōḻa-dānōtsavaḥ #1034
 DTSTART;VALUE=DATE:20191107
 DTEND;VALUE=DATE:20191108
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:rājarāja-cōḻa-dānōtsavaḥ#1034_2019-11-07T06:08:00.959988+05:3
  0
 DESCRIPTION:Observed on Śatabhiṣak nakshatra of Tulā (sidereal solar) 
@@ -56840,7 +56840,7 @@ SUMMARY:Kārttikaḥ-08-11  \,Mīnaḥ-Pūrvaprōṣṭhapadā🌛🌌  \,
    Tulā-Viśākhā-07-22🌞🌌  \,  Sahaḥ-09-16🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191108T060818
 DTEND;TZID=Asia/Calcutta:20191109T060844
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191108_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-17\, Islamic: 1441-03-10 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -56896,7 +56896,7 @@ BEGIN:VEVENT
 SUMMARY:ādi-śaṅkara mānasika-sannyāsa-dinam
 DTSTART;VALUE=DATE:20191108
 DTEND;VALUE=DATE:20191109
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:ādi-śaṅkaramānasika-sannyāsa-dinam_2019-11-08T06:08:18.239999+05
  :30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Kārttikaḥ (lunar) m
@@ -56918,7 +56918,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191108
 DTEND;VALUE=DATE:20191109
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-08T06:08:18.239999+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -56941,7 +56941,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(svārōciṣaḥ-[2])
 DTSTART;VALUE=DATE:20191108
 DTEND;VALUE=DATE:20191109
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(svārōciṣaḥ-[2])_2019-11-08T06:08:18.239999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/manvAdiH/lunar_month/tithi/08/12/manvA
@@ -56963,7 +56963,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-utthāna-ēkādaśī
 DTSTART;VALUE=DATE:20191108
 DTEND;VALUE=DATE:20191109
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sarva-utthāna-ēkādaśī_2019-11-08T06:08:18.239999+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of kārttika month is known as utth
  āna-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are greatly
@@ -57077,7 +57077,7 @@ BEGIN:VEVENT
 SUMMARY:tulasī-vivāhōtsavaḥ
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191109
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tulasī-vivāhōtsavaḥ_2019-11-04T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-flora/description_only/tulasI-vivAhOt
@@ -57098,7 +57098,7 @@ BEGIN:VEVENT
 SUMMARY:tulasī-vivāhaḥ
 DTSTART;VALUE=DATE:20191108
 DTEND;VALUE=DATE:20191109
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tulasī-vivāhaḥ_2019-11-08T06:08:18.239999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/misc-flora/lunar_month/tithi/08/12/tulasI-
@@ -57121,7 +57121,7 @@ SUMMARY:Kārttikaḥ-08-12  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛🌌  \,
    Tulā-Viśākhā-07-23🌞🌌  \,  Sahaḥ-09-17🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191109T060844
 DTEND;TZID=Asia/Calcutta:20191110T060901
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191109_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-18\, Islamic: 1441-03-11 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -57177,7 +57177,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Anadhyayana on account of viṣṇu-prabōdhōtsava. On the da
  ys of Ayana (solstices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu
@@ -57201,7 +57201,7 @@ BEGIN:VEVENT
 SUMMARY:br̥ndāvana-dvādaśī
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:br̥ndāvana-dvādaśī_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Kārttikaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -57221,7 +57221,7 @@ BEGIN:VEVENT
 SUMMARY:cāturmāsyavratam
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:cāturmāsyavratam_2019-07-11T23:59:57.120005+05:30
 DESCRIPTION:Chaaturmasya begins\; 4 months\; Pradakshina to Pippala\; Deep
  aradhana in temple\; Saraswati Pooja\; 1st month no vegetables\; 2nd month
@@ -57242,7 +57242,7 @@ BEGIN:VEVENT
 SUMMARY:cāturmāsyavrata-samāpanam
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:cāturmāsyavrata-samāpanam_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Kārttikaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -57262,7 +57262,7 @@ BEGIN:VEVENT
 SUMMARY:dvidala-vratam
 DTSTART;VALUE=DATE:20191009
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dvidala-vratam_2019-10-09T23:59:57.120005+05:30
 DESCRIPTION:aniruddha surairvandya dvidalavratamuttamam।  <br/>karōmyah
  amiṣēmāsē nirvighnaṁ kuru mē prabhō॥<br/><br/><br/><br/>## Deta
@@ -57282,7 +57282,7 @@ BEGIN:VEVENT
 SUMMARY:dvidala-vrata-samāpanam
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dvidala-vrata-samāpanam_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Kārttikaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>aniruddha namastubhyaṁ dvid
@@ -57306,7 +57306,7 @@ BEGIN:VEVENT
 SUMMARY:gōpadma-vratam
 DTSTART;VALUE=DATE:20190711
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gōpadma-vratam_2019-07-11T23:59:57.120005+05:30
 DESCRIPTION:Perform puja of Mahalakshmi-Mahavishnu<br/><br/>gōpadmamiti v
  ikhyātaṁ sarvapāpaharaṁ param।  <br/>sarvaduḥkhōpaśamanaṁ sa
@@ -57328,7 +57328,7 @@ BEGIN:VEVENT
 SUMMARY:gōpadma-vrata-samāpanam
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gōpadma-vrata-samāpanam_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Kārttikaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- Re
@@ -57348,7 +57348,7 @@ BEGIN:VEVENT
 SUMMARY:prabōdhōtsavaḥ
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:prabōdhōtsavaḥ_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Kārttikaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -57367,7 +57367,7 @@ BEGIN:VEVENT
 SUMMARY:yājñavalkya-jayantī
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191110
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:yājñavalkya-jayantī_2019-11-09T06:08:44.159995+05:30
 DESCRIPTION:Observed on Śukla-Dvādaśī tithi of Kārttikaḥ (lunar) mo
  nth (Sūryōdayaḥ/puurvaviddha). <br/><br/>Avataram of yājñavalkya mah
@@ -57393,7 +57393,7 @@ BEGIN:VEVENT
 SUMMARY:śanivāra-śukla-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20191109T173628
 DTEND;TZID=Asia/Calcutta:20191109T191039
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śanivāra-śukla-pradōṣa-vratam_2019-11-09T17:36:28.799983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/zani
@@ -57413,7 +57413,7 @@ SUMMARY:Kārttikaḥ-08-13  \,Mīnaḥ-Rēvatī🌛🌌  \,  Tulā-Viśāk
  hā-07-24🌞🌌  \,  Sahaḥ-09-18🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191110T060901
 DTEND;TZID=Asia/Calcutta:20191111T060927
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191110_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-19\, Islamic: 1441-03-12 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -57469,7 +57469,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191110T133709
 DTEND;TZID=Asia/Calcutta:20191110T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-11-10T13:37:09.119995+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -57485,7 +57485,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191110T173620
 DTEND;TZID=Asia/Calcutta:20191111T060927
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-10T17:36:20.159998+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -57506,7 +57506,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsa-antimatrayatithi-vrata-ārambhaḥ
 DTSTART;VALUE=DATE:20191110
 DTEND;VALUE=DATE:20191111
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsa-antimatrayatithi-vrata-ārambhaḥ_2019-11-10T06:09:01
  .440006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -57530,7 +57530,7 @@ SUMMARY:Kārttikaḥ-08-14  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Tulā-Viś
  ākhā-07-25🌞🌌  \,  Sahaḥ-09-19🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191111T060927
 DTEND;TZID=Asia/Calcutta:20191112T060953
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191111_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-20\, Islamic: 1441-03-13 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -57585,7 +57585,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -57625,7 +57625,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsa-antimatrayatithi-vratam
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsa-antimatrayatithi-vratam_2019-11-11T06:09:27.360002+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -57648,7 +57648,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-sōmavāsaraḥ
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-sōmavāsaraḥ_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shaiva/description_only/kArttika~sOmavAsar
@@ -57669,7 +57669,7 @@ BEGIN:VEVENT
 SUMMARY:maṇikarṇikā-snānam/vaikuṇṭha-caturdaśī
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:maṇikarṇikā-snānam/vaikuṇṭha-caturdaśī_2019-11-11T06:09:27
  .360002+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of Kārttikaḥ (lunar) m
@@ -57693,7 +57693,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -57717,7 +57717,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -57736,7 +57736,7 @@ BEGIN:VEVENT
 SUMMARY:Tirumūla Nāyanmār (30) Gurupūjai
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:TirumūlaNāyanmār(30)Gurupūjai_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -57759,7 +57759,7 @@ BEGIN:VEVENT
 SUMMARY:tripurōtsavaḥ
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tripurōtsavaḥ_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Kārttikaḥ (lunar) month
   (Pradōṣaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit 
@@ -57778,7 +57778,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-11-11T06:09:27.360002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -57801,7 +57801,7 @@ SUMMARY:Kārttikaḥ-08-15  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,  Tulā-
  Viśākhā-07-26🌞🌌  \,  Sahaḥ-09-20🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191112T060953
 DTEND;TZID=Asia/Calcutta:20191113T061010
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191112_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-21\, Islamic: 1441-03-14 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -57857,7 +57857,7 @@ BEGIN:VEVENT
 SUMMARY:āgrayaṇa-hōmaḥ drāviḍēṣu
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:āgrayaṇa-hōmaḥdrāviḍēṣu_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Tulā (sidereal solar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform hōma with fresh rice 
@@ -57878,7 +57878,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -57913,7 +57913,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:Anadhyayana on account of manvādi. On the days of Ayana (sols
  tices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sleep (S
@@ -57936,7 +57936,7 @@ BEGIN:VEVENT
 SUMMARY:bhīṣma-pañcaka-vratam
 DTSTART;VALUE=DATE:20191106
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:bhīṣma-pañcaka-vratam_2019-11-06T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/description_only/bhISma-paJcaka-vratam.to
@@ -57957,7 +57957,7 @@ BEGIN:VEVENT
 SUMMARY:bhīṣma-pañcaka-vrata-samāpanam
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:bhīṣma-pañcaka-vrata-samāpanam_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/xatra/lunar_month/tithi/08/15/bhISma-
@@ -57979,7 +57979,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsaḥantimatrayatithi-vratam
 DTSTART;VALUE=DATE:20191109
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsaḥantimatrayatithi-vratam_2019-11-09T23:59:57.120005+0
  5:30
 DESCRIPTION:
@@ -57996,7 +57996,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsa-antimatrayatithi-vrata-samāpanam
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsa-antimatrayatithi-vrata-samāpanam_2019-11-12T06:09:53.
  279998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58019,7 +58019,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-pūrṇimā-snānam
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-pūrṇimā-snānam_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/08/15/kArttika-pUrNimA-
@@ -58040,7 +58040,7 @@ BEGIN:VEVENT
 SUMMARY:mahā-annābhiṣēkaḥ
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:mahā-annābhiṣēkaḥ_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Tulā (sidereal solar) mon
  th (Sūryāstamayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- 
@@ -58060,7 +58060,7 @@ BEGIN:VEVENT
 SUMMARY:manvādiḥ-(dharma-sāvarṇiḥ-[11])
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:manvādiḥ-(dharma-sāvarṇiḥ-[11])_2019-11-12T06:09:53.279998+05:
  30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58084,7 +58084,7 @@ BEGIN:VEVENT
 SUMMARY:Ninṟachīr Neḍumāṟa Nāyanmār (49) Gurupūjai
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:NinṟachīrNeḍumāṟaNāyanmār(49)Gurupūjai_2019-11-12T06:09:53.
  279998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58110,7 +58110,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -58131,7 +58131,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -58151,7 +58151,7 @@ BEGIN:VEVENT
 SUMMARY:padmaka-yōgaḥ
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:padmaka-yōgaḥ_2019-11-12T20:48:43.199983+05:30
 DESCRIPTION:When the Sun is transiting through viśākhā\, and the moon\,
   through kr̥ttikā\, a very special  padmaka yōga occurs\, that is more 
@@ -58174,7 +58174,7 @@ BEGIN:VEVENT
 SUMMARY:puṣkara-mēlā-samāptiḥ
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:puṣkara-mēlā-samāptiḥ_2019-11-12T06:09:53.279998+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Kārttikaḥ (lunar) month
   (Sūryōdayaḥ/puurvaviddha). <br/><br/>Pushkar’s Kartik Purnima festi
@@ -58197,7 +58197,7 @@ BEGIN:VEVENT
 SUMMARY:tiruvanantapura-dēvāyatana-pravēśa-ghōṣaṇā #84
 DTSTART;VALUE=DATE:20191111
 DTEND;VALUE=DATE:20191112
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tiruvanantapura-dēvāyatana-pravēśa-ghōṣaṇā#84_2019-11-11T23:
  59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58220,7 +58220,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-11-12T06:09:53.2799
  98+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -58243,7 +58243,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-gōvinda bhagavatpāda-ārādhanā
 DTSTART;VALUE=DATE:20191112
 DTEND;VALUE=DATE:20191113
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śrī-gōvindabhagavatpāda-ārādhanā_2019-11-12T06:09:53.279998+05:
  30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Kārttikaḥ (lunar) month
@@ -58265,7 +58265,7 @@ SUMMARY:Kārttikaḥ-08-16  \,Vr̥ṣabhaḥ-Kr̥ttikā🌛🌌  \,  Tulā
  -Viśākhā-07-27🌞🌌  \,  Sahaḥ-09-21🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191113T061010
 DTEND;TZID=Asia/Calcutta:20191114T061036
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191113_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-22\, Islamic: 1441-03-15 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -58321,7 +58321,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-13T06:10:10.560009+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -58367,7 +58367,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-13T06:10:10.560009+05:30
 DESCRIPTION:One should not perform adhyayana for three days\, commencing f
  rom the pūrṇimā of the three months\, āṣāḍha\, kārtika and phā
@@ -58390,7 +58390,7 @@ BEGIN:VEVENT
 SUMMARY:Iḍaṅkaḻi Nāyanmār (55) Gurupūjai
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:IḍaṅkaḻiNāyanmār(55)Gurupūjai_2019-11-13T06:10:10.560009+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58415,7 +58415,7 @@ SUMMARY:kāñcī 64 jagadguru-śrī-candraśēkharēndra-sarasvatī-5-ār
  ādhanā #169
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī64jagadguru-śrī-candraśēkharēndra-sarasvatī-5-ārādhan
  ā#169_2019-11-13T06:10:10.560009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58440,7 +58440,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-11-13T06:10:10.560009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -58461,7 +58461,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-11-13T06:10:
  10.560009+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -58488,7 +58488,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-11-13T06:10:10.560009+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -58507,7 +58507,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20191113
 DTEND;VALUE=DATE:20191114
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-11-13T06:10:10.560009+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -58529,7 +58529,7 @@ SUMMARY:Kārttikaḥ-08-17  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,  Tulā
  -Viśākhā-07-28🌞🌌  \,  Sahaḥ-09-22🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191114T061036
 DTEND;TZID=Asia/Calcutta:20191115T061102
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191114_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-23\, Islamic: 1441-03-16 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -58585,7 +58585,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191114
 DTEND;VALUE=DATE:20191115
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-14T06:10:36.480005+05:30
 DESCRIPTION:On the kr̥ṣṇa-pakṣa-dvitīyā days in the months of ā
  ṣāḍha\, kārtika and phālguna\, one must not perform adhyayana.<br/>
@@ -58614,7 +58614,7 @@ BEGIN:VEVENT
 SUMMARY:cāturmāsya-dvitīyā
 DTSTART;VALUE=DATE:20191114
 DTEND;VALUE=DATE:20191115
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:cāturmāsya-dvitīyā_2019-11-14T06:10:36.480005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/08/17/cAturmAsya-dv
@@ -58636,7 +58636,7 @@ SUMMARY:Kārttikaḥ-08-18  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛🌌  \,
   Tulā-Viśākhā-07-29🌞🌌  \,  Sahaḥ-09-23🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191115T061102
 DTEND;TZID=Asia/Calcutta:20191116T061128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191115_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-24\, Islamic: 1441-03-17 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -58692,7 +58692,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191115
 DTEND;VALUE=DATE:20191116
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-15T06:11:02.400001+05:30
 DESCRIPTION:On the kr̥ṣṇa-pakṣa-tr̥tīyā days in the months of ā
  ṣāḍha\, kārtika and phālguna\, one must not perform adhyayana\, as 
@@ -58717,7 +58717,7 @@ BEGIN:VEVENT
 SUMMARY:gaṇādhipa-mahāgaṇapati-saṅkaṭahara-caturthī-vratam
 DTSTART;VALUE=DATE:20191115
 DTEND;VALUE=DATE:20191116
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gaṇādhipa-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_2019-11-
  15T06:11:02.400001+05:30
 DESCRIPTION:Special vrata day for Ganesha. In this month\, Ganesha is wors
@@ -58746,7 +58746,7 @@ SUMMARY:kāñcī 9 jagadguru-śrī-kr̥pāśaṅkarēndra-sarasvatī-ārā
  dhanā #1951
 DTSTART;VALUE=DATE:20191115
 DTEND;VALUE=DATE:20191116
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī9jagadguru-śrī-kr̥pāśaṅkarēndra-sarasvatī-ārādhanā
  #1951_2019-11-15T06:11:02.400001+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -58771,7 +58771,7 @@ BEGIN:VEVENT
 SUMMARY:saubhāgya-sundarī-vratam
 DTSTART;VALUE=DATE:20191115
 DTEND;VALUE=DATE:20191116
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:saubhāgya-sundarī-vratam_2019-11-15T06:11:02.400001+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Tr̥tīyā tithi of Kārttikaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -58792,7 +58792,7 @@ SUMMARY:Kārttikaḥ-08-19  \,Mithunam-Ārdrā🌛🌌  \,  Tulā-Viśākh
  ā-07-30🌞🌌  \,  Sahaḥ-09-24🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191116T061128
 DTEND;TZID=Asia/Calcutta:20191117T061154
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191116_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-25\, Islamic: 1441-03-18 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Tulā\, तं- Aippasi\, म- Tulā
@@ -58848,7 +58848,7 @@ BEGIN:VEVENT
 SUMMARY:ākāśadīpaḥ
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:ākāśadīpaḥ_2019-10-17T23:59:57.120005+05:30
 DESCRIPTION:Offer Akasha Dipam for this entire month\, in the evening\, on
   a high place (pillar?). Light lamps using gingelly oil with eight wicks.<
@@ -58873,7 +58873,7 @@ BEGIN:VEVENT
 SUMMARY:ākāśadīpa-samāpanam
 DTSTART;VALUE=DATE:20191116
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:ākāśadīpa-samāpanam_2019-11-16T06:11:28.319997+05:30
 DESCRIPTION:End of a month long offering of Akasha Dipam.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -58892,7 +58892,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191116
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-16T06:11:28.319997+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -58917,7 +58917,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–udayaḥ (prāk)
 DTSTART;VALUE=DATE:20191115
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–udayaḥ(prāk)_2019-11-15T23:59:57.120005+05:30
 DESCRIPTION:budhaḥ rises out of combustion (udayaH)\, heading prāk (eas
  t)\, on 2019-Nov-17 04:01. At this moment budhaḥ is at svātī-4 tulā (
@@ -58938,7 +58938,7 @@ BEGIN:VEVENT
 SUMMARY:sindhu/brahmaputra-ādya-puṣkara-samāpanam
 DTSTART;VALUE=DATE:20191104
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sindhu/brahmaputra-ādya-puṣkara-samāpanam_2019-11-04T23:59:57.1200
  05+05:30
 DESCRIPTION:Coming from Brahma's Kamandalu\, Pushkara Raja resides in diff
@@ -58976,7 +58976,7 @@ BEGIN:VEVENT
 SUMMARY:sindhu/brahmaputra-ādya-puṣkara-samāpanam
 DTSTART;VALUE=DATE:20191116
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sindhu/brahmaputra-ādya-puṣkara-samāpanam_2019-11-16T06:11:28.3199
  97+05:30
 DESCRIPTION:Coming from Brahma's Kamandalu\, Pushkara Raja resides in diff
@@ -59014,7 +59014,7 @@ BEGIN:VEVENT
 SUMMARY:tulā-kāvērī-snānam
 DTSTART;VALUE=DATE:20191017
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tulā-kāvērī-snānam_2019-10-17T23:59:57.120005+05:30
 DESCRIPTION:Perform snānam in Kaveri during this month.<br/><br/>ṣaṭ
  ṣaṣṭikōṭitīrthāni dvisaptabhuvanēṣu ca।  <br/>kēśavasyā
@@ -59035,7 +59035,7 @@ BEGIN:VEVENT
 SUMMARY:tulā-kāvērī-snāna-samāpanam
 DTSTART;VALUE=DATE:20191116
 DTEND;VALUE=DATE:20191117
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tulā-kāvērī-snāna-samāpanam_2019-11-16T06:11:28.319997+05:30
 DESCRIPTION:End of Tula Kaveri Snanam. Also known as kaḍaimugam.<br/><br
  />## Details<br/>- [Edit config file](https://github.com/jyotisham/adyatit
@@ -59055,7 +59055,7 @@ SUMMARY:Kārttikaḥ-08-20  \,Mithunam-Punarvasuḥ🌛🌌  \,  Vr̥ścik
  aḥ-Viśākhā-08-01🌞🌌  \,  Sahaḥ-09-25🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191117T061154
 DTEND;TZID=Asia/Calcutta:20191118T061220
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191117_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-26\, Islamic: 1441-03-19 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -59112,7 +59112,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191117T061154
 DTEND;TZID=Asia/Calcutta:20191117T173528
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-17T06:11:54.239994+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -59134,7 +59134,7 @@ BEGIN:VEVENT
 SUMMARY:Kārttigai Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20191117
 DTEND;VALUE=DATE:20191118
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:KārttigaiÑāyiṟṟukkiḻamai_2019-11-17T06:11:54.239994+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -59153,7 +59153,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-maṇḍala-pārāyaṇa-ārambhaḥ
 DTSTART;VALUE=DATE:20191117
 DTEND;VALUE=DATE:20191118
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-maṇḍala-pārāyaṇa-ārambhaḥ_2019-11-17T06:11:54.23
  9994+05:30
 DESCRIPTION:Observed on day 1 of Vr̥ścikaḥ (sidereal solar) month (Sū
@@ -59175,7 +59175,7 @@ BEGIN:VEVENT
 SUMMARY:Muḍavan Muḻukku
 DTSTART;VALUE=DATE:20191117
 DTEND;VALUE=DATE:20191118
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:MuḍavanMuḻukku_2019-11-17T06:11:54.239994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/tamil/description_only/muDavan2_muzhukku.toml)<br
@@ -59195,7 +59195,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191117T061154
 DTEND;TZID=Asia/Calcutta:20191117T115345
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-11-17T06:11:54.2
  39994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59215,7 +59215,7 @@ BEGIN:VEVENT
 SUMMARY:tiruviśalūr gaṅgākarṣaṇa-mahōtsava-ārambhaḥ
 DTSTART;VALUE=DATE:20191117
 DTEND;VALUE=DATE:20191118
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tiruviśalūrgaṅgākarṣaṇa-mahōtsava-ārambhaḥ_2019-11-17T06:
  11:54.239994+05:30
 DESCRIPTION:Beginning of Gangakarshana Mahotsava in Thiruvisanallur. See a
@@ -59242,7 +59242,7 @@ BEGIN:VEVENT
 SUMMARY:trētāyugāntaḥ
 DTSTART;VALUE=DATE:20191117
 DTEND;VALUE=DATE:20191118
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:trētāyugāntaḥ_2019-11-17T06:11:54.239994+05:30
 DESCRIPTION:The day on which Vrishchika sankranti happens is also the Tret
  ayuganta day. Shraadhams offered on this day beget endless fruit.<br/><br/
@@ -59268,7 +59268,7 @@ BEGIN:VEVENT
 SUMMARY:vr̥ścika-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191117T061154
 DTEND;TZID=Asia/Calcutta:20191117T064518
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vr̥ścika-ravi-saṅkramaṇa-viṣṇupadī-puṇyakālaḥ_2019-11-
  17T06:11:54.239994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59291,7 +59291,7 @@ SUMMARY:Kārttikaḥ-08-21  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  Vr̥śc
  ikaḥ-Viśākhā-08-02🌞🌌  \,  Sahaḥ-09-26🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191118T061220
 DTEND;TZID=Asia/Calcutta:20191119T061254
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191118_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-27\, Islamic: 1441-03-20 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -59346,7 +59346,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-sōmavāsaraḥ
 DTSTART;VALUE=DATE:20191118
 DTEND;VALUE=DATE:20191119
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-sōmavāsaraḥ_2019-11-18T06:12:20.159990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shaiva/description_only/kArttika~sOmavAsar
@@ -59369,7 +59369,7 @@ SUMMARY:Kārttikaḥ-08-22  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,  Vr̥
  aḥ
 DTSTART;TZID=Asia/Calcutta:20191119T061254
 DTEND;TZID=Asia/Calcutta:20191120T061320
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191119_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-28\, Islamic: 1441-03-21 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -59425,7 +59425,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191119T173519
 DTEND;TZID=Asia/Calcutta:20191120T061320
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-19T17:35:19.679980+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -59446,7 +59446,7 @@ BEGIN:VEVENT
 SUMMARY:kālabhairavāṣṭamī
 DTSTART;VALUE=DATE:20191119
 DTEND;VALUE=DATE:20191120
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kālabhairavāṣṭamī_2019-11-19T06:12:54.720012+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Kārttikaḥ (lun
  ar) month (Pradōṣaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -59466,7 +59466,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20191119
 DTEND;VALUE=DATE:20191120
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-11-19T06:12:54.720012+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -59485,7 +59485,7 @@ BEGIN:VEVENT
 SUMMARY:sāvitrī-kalpādiḥ
 DTSTART;VALUE=DATE:20191119
 DTEND;VALUE=DATE:20191120
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sāvitrī-kalpādiḥ_2019-11-19T06:12:54.720012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/08/22/sAvit
@@ -59507,7 +59507,7 @@ SUMMARY:Kārttikaḥ-08-23  \,Siṁhaḥ-Maghā🌛🌌  \,  Vr̥ścikaḥ
  -Viśākhā-08-04🌞🌌  \,  Sahaḥ-09-28🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191120T061320
 DTEND;TZID=Asia/Calcutta:20191121T061346
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191120_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-29\, Islamic: 1441-03-22 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -59563,7 +59563,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191120
 DTEND;VALUE=DATE:20191121
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-20T06:13:20.640008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -59599,7 +59599,7 @@ SUMMARY:kāñcī 42 jagadguru-śrī-brahmānandaghanēndra-sarasvatī-2-ā
  rādhanā #1042
 DTSTART;VALUE=DATE:20191120
 DTEND;VALUE=DATE:20191121
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī42jagadguru-śrī-brahmānandaghanēndra-sarasvatī-2-ārādha
  nā#1042_2019-11-20T06:13:20.640008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59625,7 +59625,7 @@ SUMMARY:kāñcī 49 jagadguru-śrī-mahādēvēndra-sarasvatī-3-ārādhan
  ā #773
 DTSTART;VALUE=DATE:20191120
 DTEND;VALUE=DATE:20191121
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī49jagadguru-śrī-mahādēvēndra-sarasvatī-3-ārādhanā#773
  _2019-11-20T06:13:20.640008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59651,7 +59651,7 @@ SUMMARY:kāñcī 58 jagadguru-śrī-ātmabōdhēndra-sarasvatī-ārādhan
  ā #382
 DTSTART;VALUE=DATE:20191120
 DTEND;VALUE=DATE:20191121
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī58jagadguru-śrī-ātmabōdhēndra-sarasvatī-ārādhanā#382_
  2019-11-20T06:13:20.640008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59676,7 +59676,7 @@ BEGIN:VEVENT
 SUMMARY:kālāṣṭamī
 DTSTART;VALUE=DATE:20191120
 DTEND;VALUE=DATE:20191121
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kālāṣṭamī_2019-11-20T06:13:20.640008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Kārttikaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br
@@ -59696,7 +59696,7 @@ BEGIN:VEVENT
 SUMMARY:mahādēvāṣṭamī
 DTSTART;VALUE=DATE:20191120
 DTEND;VALUE=DATE:20191121
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:mahādēvāṣṭamī_2019-11-20T06:13:20.640008+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of Kārttikaḥ (lun
  ar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Very famously celebrate
@@ -59717,7 +59717,7 @@ SUMMARY:Kārttikaḥ-08-24  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,  Vr̥
  ścikaḥ-Anūrādhā-08-05🌞🌌  \,  Sahaḥ-09-29🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191121T061346
 DTEND;TZID=Asia/Calcutta:20191122T061412
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191121_day_summary
 DESCRIPTION:- Indian civil date: 1941-08-30\, Islamic: 1441-03-23 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -59773,7 +59773,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191121T173519
 DTEND;TZID=Asia/Calcutta:20191122T061412
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-21T17:35:19.679980+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -59795,7 +59795,7 @@ SUMMARY:kāñcī 28 jagadguru-śrī-mahādēvēndra-sarasvatī-1-ārādhan
  ā #1419
 DTSTART;VALUE=DATE:20191121
 DTEND;VALUE=DATE:20191122
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī28jagadguru-śrī-mahādēvēndra-sarasvatī-1-ārādhanā#141
  9_2019-11-21T06:13:46.560004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59820,7 +59820,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20191121
 DTEND;VALUE=DATE:20191122
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-11-21T06:13:46.560004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -59842,7 +59842,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191121T115848
 DTEND;TZID=Asia/Calcutta:20191121T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-11-21T11:58:48.000002+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -59859,7 +59859,7 @@ SUMMARY:Kārttikaḥ-08-25  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Vr̥ści
  kaḥ-Anūrādhā-08-06🌞🌌  \,  Sahaḥ-09-30🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191122T061412
 DTEND;TZID=Asia/Calcutta:20191123T061447
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191122_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-01\, Islamic: 1441-03-24 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -59915,7 +59915,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191122
 DTEND;VALUE=DATE:20191123
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-22T06:14:12.480000+05:30
 DESCRIPTION:Anadhyayana during the day/night\, as it precedes saṅkrama
  ṇa tonight. When saṅkramaṇa happens in the night\, the previous and 
@@ -59940,7 +59940,7 @@ BEGIN:VEVENT
 SUMMARY:Meypporuḷ Nāyanmār (5) Gurupūjai
 DTSTART;VALUE=DATE:20191122
 DTEND;VALUE=DATE:20191123
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:MeypporuḷNāyanmār(5)Gurupūjai_2019-11-22T06:14:12.480000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -59963,7 +59963,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191121T235957
 DTEND;TZID=Asia/Calcutta:20191122T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ṣaḍaśīti-puṇyakālaḥ_2019-11-21T23:59:57.120005+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -59983,7 +59983,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191122T140456
 DTEND;TZID=Asia/Calcutta:20191122T173519
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-11-22T14:04:56.640019
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -60002,7 +60002,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191122T115446
 DTEND;TZID=Asia/Calcutta:20191122T173519
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-11-22T11:
  54:46.080010+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -60023,7 +60023,7 @@ BEGIN:VEVENT
 SUMMARY:sahasya-māsaḥ
 DTSTART;TZID=Asia/Calcutta:20191122T202850
 DTEND;TZID=Asia/Calcutta:20191122T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sahasya-māsaḥ_2019-11-22T20:28:50.879997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/Rtu/tropical-ayanAdi/description_only/
@@ -60042,7 +60042,7 @@ BEGIN:VEVENT
 SUMMARY:smārta-utpannā-ēkādaśī (gr̥hastha)
 DTSTART;VALUE=DATE:20191122
 DTEND;VALUE=DATE:20191123
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:smārta-utpannā-ēkādaśī(gr̥hastha)_2019-11-22T06:14:12.480000+05
  :30
 DESCRIPTION:The Krishna-paksha Ekadashi of kārttika month is known as utp
@@ -60247,7 +60247,7 @@ SUMMARY:Kārttikaḥ-08-26  \,Kanyā-Hastaḥ🌛🌌  \,  Vr̥ścikaḥ-A
  nūrādhā-08-07🌞🌌  \,  Sahasyaḥ-10-01🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191123T061447
 DTEND;TZID=Asia/Calcutta:20191124T061512
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191123_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-02\, Islamic: 1441-03-25 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -60304,7 +60304,7 @@ BEGIN:VEVENT
 SUMMARY:Ānāya Nāyanmār (14) Gurupūjai
 DTSTART;VALUE=DATE:20191123
 DTEND;VALUE=DATE:20191124
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:ĀnāyaNāyanmār(14)Gurupūjai_2019-11-23T06:14:47.039982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -60327,7 +60327,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191123T061447
 DTEND;TZID=Asia/Calcutta:20191123T173528
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-23T06:14:47.039982+05:30
 DESCRIPTION:Anadhyayana during the day\, since saṅkramaṇa happened dur
  ing night time yesterday. When saṅkramaṇa happens in the night\, the p
@@ -60349,7 +60349,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20191123
 DTEND;VALUE=DATE:20191124
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-11-23T06:14:47.039982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -60370,7 +60370,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191123T144231
 DTEND;TZID=Asia/Calcutta:20191124T034317
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-11-23T14:42:31.680011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -60389,7 +60389,7 @@ BEGIN:VEVENT
 SUMMARY:harivāsaraḥ
 DTSTART;TZID=Asia/Calcutta:20191122T235957
 DTEND;TZID=Asia/Calcutta:20191123T114358
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:harivāsaraḥ_2019-11-22T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/hari
@@ -60407,7 +60407,7 @@ BEGIN:VEVENT
 SUMMARY:sahōmāsa-uṣaḥkāla-pūjārambhaḥ
 DTSTART;VALUE=DATE:20191123
 DTEND;VALUE=DATE:20191124
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sahōmāsa-uṣaḥkāla-pūjārambhaḥ_2019-11-23T06:14:47.039982+05
  :30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -60430,7 +60430,7 @@ BEGIN:VEVENT
 SUMMARY:smārta-utpannā-ēkādaśī (sannyasta)
 DTSTART;VALUE=DATE:20191123
 DTEND;VALUE=DATE:20191124
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:smārta-utpannā-ēkādaśī(sannyasta)_2019-11-23T06:14:47.039982+05:
  30
 DESCRIPTION:The Krishna-paksha Ekadashi of kārttika month is known as utp
@@ -60634,7 +60634,7 @@ BEGIN:VEVENT
 SUMMARY:trispr̥śā-mahādvādaśī
 DTSTART;VALUE=DATE:20191123
 DTEND;VALUE=DATE:20191124
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:trispr̥śā-mahādvādaśī_2019-11-23T06:14:47.039982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/dvAdashI/description_only/tris
@@ -60655,7 +60655,7 @@ BEGIN:VEVENT
 SUMMARY:vaiṣṇava-utpannā-ēkādaśī
 DTSTART;VALUE=DATE:20191123
 DTEND;VALUE=DATE:20191124
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vaiṣṇava-utpannā-ēkādaśī_2019-11-23T06:14:47.039982+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of kārttika month is known as utp
  annā-ēkādaśī. Yudhiṣṭhira inquires about the origin of the auspic
@@ -60859,7 +60859,7 @@ SUMMARY:Kārttikaḥ-08-28  \,Tulā-Citrā🌛🌌  \,  Vr̥ścikaḥ-Anū
  rādhā-08-08🌞🌌  \,  Sahasyaḥ-10-02🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191124T061512
 DTEND;TZID=Asia/Calcutta:20191125T061547
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191124_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-03\, Islamic: 1441-03-26 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -60915,7 +60915,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191124T173528
 DTEND;TZID=Asia/Calcutta:20191125T061547
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-24T17:35:28.320006+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -60936,7 +60936,7 @@ BEGIN:VEVENT
 SUMMARY:Kārttigai Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20191124
 DTEND;VALUE=DATE:20191125
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:KārttigaiÑāyiṟṟukkiḻamai_2019-11-24T06:15:12.960018+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -60955,7 +60955,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20191124
 DTEND;VALUE=DATE:20191125
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-11-24T06:15:12.960018+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -60975,7 +60975,7 @@ BEGIN:VEVENT
 SUMMARY:pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20191124T173528
 DTEND;TZID=Asia/Calcutta:20191124T191030
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pradōṣa-vratam_2019-11-24T17:35:28.320006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/prad
@@ -60994,7 +60994,7 @@ SUMMARY:Kārttikaḥ-08-29  \,Tulā-Svātī🌛🌌  \,  Vr̥ścikaḥ-An
  ūrādhā-08-09🌞🌌  \,  Sahasyaḥ-10-03🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191125T061547
 DTEND;TZID=Asia/Calcutta:20191126T061613
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191125_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-04\, Islamic: 1441-03-27 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -61050,7 +61050,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191125
 DTEND;VALUE=DATE:20191126
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-25T06:15:47.520000+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -61090,7 +61090,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-kārttika-amāvāsyā
 DTSTART;VALUE=DATE:20191125
 DTEND;VALUE=DATE:20191126
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-kārttika-amāvāsyā_2019-11-25T06:15:47.5200
  00+05:30
 DESCRIPTION:
@@ -61107,7 +61107,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-sōmavāsaraḥ
 DTSTART;VALUE=DATE:20191125
 DTEND;VALUE=DATE:20191126
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-sōmavāsaraḥ_2019-11-25T06:15:47.520000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/shaiva/description_only/kArttika~sOmavAsar
@@ -61128,7 +61128,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20191125
 DTEND;VALUE=DATE:20191126
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-11-25T06:15:47.520000+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -61147,7 +61147,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20191125
 DTEND;VALUE=DATE:20191126
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-11-25T06:15:47.520000+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -61168,7 +61168,7 @@ SUMMARY:Kārttikaḥ-08-30  \,Vr̥ścikaḥ-Viśākhā🌛🌌  \,  Vr̥ś
  alaḥ
 DTSTART;TZID=Asia/Calcutta:20191126T061613
 DTEND;TZID=Asia/Calcutta:20191127T061648
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191126_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-05\, Islamic: 1441-03-28 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -61224,7 +61224,7 @@ BEGIN:VEVENT
 SUMMARY:āgrayaṇa-hōmaḥ drāviḍēṣu
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:āgrayaṇa-hōmaḥdrāviḍēṣu_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Vr̥ścikaḥ (sidereal solar
  ) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform hōma with fresh 
@@ -61245,7 +61245,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -61280,7 +61280,7 @@ BEGIN:VEVENT
 SUMMARY:bōdhāyana-kātyāyana-iṣṭiḥ
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:bōdhāyana-kātyāyana-iṣṭiḥ_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:iṣṭiḥ is performed on this day by those following the b
  ōdhāyana/kātyāyana sūtras. This difference happens because chandradar
@@ -61302,7 +61302,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-amāvāsyā (alabhyam–anūrādhā\, puṣkalā)
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-amāvāsyā(alabhyam–anūrādhā\,puṣkalā)_2019-11-26T0
  6:16:13.439996+05:30
 DESCRIPTION:amāvāsyā of kārttika month.<br/><br/>## Details<br/>- [Edi
@@ -61337,7 +61337,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsaḥ
 DTSTART;VALUE=DATE:20191028
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsaḥ_2019-10-28T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/kArttika-mAsaH.t
@@ -61359,7 +61359,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-māsa-samāpanam
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-māsa-samāpanam_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Kārttikaḥ (lunar) month (S
  ūryōdayaḥ/paraviddha). <br/><br/>kārttika-māsaḥ ends today<br/><br
@@ -61379,7 +61379,7 @@ BEGIN:VEVENT
 SUMMARY:kārttika-snānapūrtiḥ
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kārttika-snānapūrtiḥ_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Kārttikaḥ (lunar) month (S
  ūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -61398,7 +61398,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -61419,7 +61419,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-11-26T06:16:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -61440,7 +61440,7 @@ BEGIN:VEVENT
 SUMMARY:tiruviśalūr gaṅgākarṣaṇa-mahōtsavaḥ
 DTSTART;VALUE=DATE:20191116
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tiruviśalūrgaṅgākarṣaṇa-mahōtsavaḥ_2019-11-16T23:59:57.120
  005+05:30
 DESCRIPTION:Beginning of Gangakarshana Mahotsava in Thiruvisanallur. See a
@@ -61465,7 +61465,7 @@ BEGIN:VEVENT
 SUMMARY:tiruviśalūr gaṅgākarṣaṇa-mahōtsava-samāpanam
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191127
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tiruviśalūrgaṅgākarṣaṇa-mahōtsava-samāpanam_2019-11-26T06:1
  6:13.439996+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -61491,7 +61491,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-01  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,
   Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191127T061648
 DTEND;TZID=Asia/Calcutta:20191128T061722
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191127_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-06\, Islamic: 1441-03-29 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -61547,7 +61547,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -61593,7 +61593,7 @@ BEGIN:VEVENT
 SUMMARY:budhānurādhā-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191126T235957
 DTEND;TZID=Asia/Calcutta:20191127T080959
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budhānurādhā-yōgaḥ_2019-11-26T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/amrita-siddhi/description_only/budhAnu
@@ -61612,7 +61612,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20191127T173545
 DTEND;TZID=Asia/Calcutta:20191127T182233
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-11-27T17:35:45.600016+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -61631,7 +61631,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -61650,7 +61650,7 @@ BEGIN:VEVENT
 SUMMARY:dhana-vratam
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dhana-vratam_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Mārgaśīrṣaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>atha mārgasitādyāyā
@@ -61676,7 +61676,7 @@ SUMMARY:kāñcī 18 jagadguru-śrī-yōgatilaka-surēndra-sarasvatī-ārā
  dhanā #1635
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī18jagadguru-śrī-yōgatilaka-surēndra-sarasvatī-ārādhanā
  #1635_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -61701,7 +61701,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-māsa-ārambhaḥ_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/09/01/mArgazIrS
@@ -61723,7 +61723,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-11-27T06:16:48.000018
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -61749,7 +61749,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -61770,7 +61770,7 @@ BEGIN:VEVENT
 SUMMARY:vanadurgānavarātra-ārambhaḥ
 DTSTART;VALUE=DATE:20191127
 DTEND;VALUE=DATE:20191128
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vanadurgānavarātra-ārambhaḥ_2019-11-27T06:16:48.000018+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of Mārgaśīrṣaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vanadurga Navaratri. Spe
@@ -61793,7 +61793,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-02  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \
  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191128T061722
 DTEND;TZID=Asia/Calcutta:20191129T061748
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191128_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-07\, Islamic: 1441-03-30 Rabīʿ 
  alʾ Awwal/Ūlā\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārttigai\, 
@@ -61849,7 +61849,7 @@ BEGIN:VEVENT
 SUMMARY:Mūrkkha Nāyanmār (32) Gurupūjai
 DTSTART;VALUE=DATE:20191128
 DTEND;VALUE=DATE:20191129
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:MūrkkhaNāyanmār(32)Gurupūjai_2019-11-28T06:17:22.559999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -61872,7 +61872,7 @@ BEGIN:VEVENT
 SUMMARY:tintriṇī-gaurī-vratam
 DTSTART;VALUE=DATE:20191128
 DTEND;VALUE=DATE:20191129
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:tintriṇī-gaurī-vratam_2019-11-28T06:17:22.559999+05:30
 DESCRIPTION:Observed on Śukla-Dvitīyā tithi of Mārgaśīrṣaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -61893,7 +61893,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-03  \,Dhanuḥ-Mūlā🌛🌌  \,  Vr̥ścik
  aḥ-Anūrādhā-08-13🌞🌌  \,  Sahasyaḥ-10-07🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191129T061748
 DTEND;TZID=Asia/Calcutta:20191130T061823
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191129_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-08\, Islamic: 1441-04-01 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -61949,7 +61949,7 @@ BEGIN:VEVENT
 SUMMARY:Chiṟappuli Nāyanmār (35) Gurupūjai
 DTSTART;VALUE=DATE:20191129
 DTEND;VALUE=DATE:20191130
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:ChiṟappuliNāyanmār(35)Gurupūjai_2019-11-29T06:17:48.479995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -61972,7 +61972,7 @@ BEGIN:VEVENT
 SUMMARY:gurōḥ vārdhakya-prārambhaḥ
 DTSTART;TZID=Asia/Calcutta:20191130T045727
 DTEND;TZID=Asia/Calcutta:20191129T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gurōḥvārdhakya-prārambhaḥ_2019-11-30T04:57:27.360018+05:30
 DESCRIPTION:guruḥ enters vArdhakya (old age) on 2019-Nov-30 04:57\, 15 d
  ays before it sets into combustion (mAudhyam). At this moment guruḥ is a
@@ -61992,7 +61992,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-04  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \
  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191130T061823
 DTEND;TZID=Asia/Calcutta:20191201T061857
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191130_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-09\, Islamic: 1441-04-02 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62048,7 +62048,7 @@ BEGIN:VEVENT
 SUMMARY:badarī-gaurī-vratam
 DTSTART;VALUE=DATE:20191130
 DTEND;VALUE=DATE:20191201
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:badarī-gaurī-vratam_2019-11-30T06:18:23.040017+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of Mārgaśīrṣaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -62068,7 +62068,7 @@ BEGIN:VEVENT
 SUMMARY:dēvī-parva-9
 DTSTART;VALUE=DATE:20191130
 DTEND;VALUE=DATE:20191201
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dēvī-parva-9_2019-11-30T06:18:23.040017+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Mārgaśīrṣaḥ (luna
  r) month (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [E
@@ -62088,7 +62088,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20191130
 DTEND;VALUE=DATE:20191201
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-11-30T06:18:23.040017+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -62110,7 +62110,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-05  \,Makaraḥ-Uttarāṣāḍhā🌛🌌
   \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191201T061857
 DTEND;TZID=Asia/Calcutta:20191202T061923
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191201_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-10\, Islamic: 1441-04-03 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62166,7 +62166,7 @@ BEGIN:VEVENT
 SUMMARY:Kārttigai Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20191201
 DTEND;VALUE=DATE:20191202
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:KārttigaiÑāyiṟṟukkiḻamai_2019-12-01T06:18:57.599999+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -62185,7 +62185,7 @@ BEGIN:VEVENT
 SUMMARY:vivāha-pañcamī
 DTSTART;VALUE=DATE:20191201
 DTEND;VALUE=DATE:20191202
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vivāha-pañcamī_2019-12-01T06:18:57.599999+05:30
 DESCRIPTION:Observed on Śukla-Pañcamī tithi of Mārgaśīrṣaḥ (luna
  r) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Widely celebrated in Nor
@@ -62208,7 +62208,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-06  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  V
  ōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191202T061923
 DTEND;TZID=Asia/Calcutta:20191203T061958
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191202_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-11\, Islamic: 1441-04-04 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62265,7 +62265,7 @@ SUMMARY:kāñcī 32 jagadguru-śrī-cidānandaghanēndra-sarasvatī-ārād
  hanā #1348
 DTSTART;VALUE=DATE:20191202
 DTEND;VALUE=DATE:20191203
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī32jagadguru-śrī-cidānandaghanēndra-sarasvatī-ārādhanā#
  1348_2019-12-02T06:19:23.519995+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -62290,7 +62290,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-śivaliṅga-ṣaṣṭhī
 DTSTART;VALUE=DATE:20191202
 DTEND;VALUE=DATE:20191203
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-śivaliṅga-ṣaṣṭhī_2019-12-02T06:19:23.519995+
  05:30
 DESCRIPTION:Observed on Śukla-Ṣaṣṭhī tithi of Mārgaśīrṣaḥ (
@@ -62314,7 +62314,7 @@ BEGIN:VEVENT
 SUMMARY:subrahmaṇya-ṣaṣṭhī-vratam
 DTSTART;VALUE=DATE:20191202
 DTEND;VALUE=DATE:20191203
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:subrahmaṇya-ṣaṣṭhī-vratam_2019-12-02T06:19:23.519995+05:30
 DESCRIPTION:Also known as champā/champaka ṣaṣṭhī<br/><br/>sēnāvi
  dāraka skanda mahāsēna mahābala।  <br/>rudrōmāgnija ṣaḍvaktra 
@@ -62335,7 +62335,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20191202
 DTEND;VALUE=DATE:20191203
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-12-02T06:19:23.519995+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -62356,7 +62356,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-07  \,Kumbhaḥ-Śraviṣṭhā🌛🌌  \,
   Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191203T061958
 DTEND;TZID=Asia/Calcutta:20191204T062032
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191203_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-12\, Islamic: 1441-04-05 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62412,7 +62412,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191203T173654
 DTEND;TZID=Asia/Calcutta:20191204T062032
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-03T17:36:54.720020+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -62433,7 +62433,7 @@ BEGIN:VEVENT
 SUMMARY:dvipuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191203T061958
 DTEND;TZID=Asia/Calcutta:20191203T141400
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-12-03T06:19:58.080017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
@@ -62453,7 +62453,7 @@ SUMMARY:kāñcī 5 jagadguru-śrī-jñānānandēndra-sarasvatī-ārādhan
  ā #2224
 DTSTART;VALUE=DATE:20191203
 DTEND;VALUE=DATE:20191204
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī5jagadguru-śrī-jñānānandēndra-sarasvatī-ārādhanā#222
  4_2019-12-03T06:19:58.080017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -62478,7 +62478,7 @@ BEGIN:VEVENT
 SUMMARY:mitra-saptamī
 DTSTART;VALUE=DATE:20191203
 DTEND;VALUE=DATE:20191204
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:mitra-saptamī_2019-12-03T06:19:58.080017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/general/lunar_month/tithi/09/07/mitra-saptamI.tom
@@ -62500,7 +62500,7 @@ BEGIN:VEVENT
 SUMMARY:nandā-saptamī
 DTSTART;VALUE=DATE:20191203
 DTEND;VALUE=DATE:20191204
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:nandā-saptamī_2019-12-03T06:19:58.080017+05:30
 DESCRIPTION:Observed on Śukla-Saptamī tithi of Mārgaśīrṣaḥ (lunar
  ) month (Madhyāhnaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -62523,7 +62523,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-08  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  V
   Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191204T062032
 DTEND;TZID=Asia/Calcutta:20191205T062107
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191204_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-13\, Islamic: 1441-04-06 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62579,7 +62579,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191204
 DTEND;VALUE=DATE:20191205
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-04T06:20:32.639998+05:30
 DESCRIPTION:Observed on Śukla-Aṣṭamī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭamī.
@@ -62614,7 +62614,7 @@ BEGIN:VEVENT
 SUMMARY:budhāṣṭamī
 DTSTART;VALUE=DATE:20191204
 DTEND;VALUE=DATE:20191205
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budhāṣṭamī_2019-12-04T06:20:32.639998+05:30
 DESCRIPTION:aṣṭamī tithi on a Wednesday is as sacred as a solar eclip
  se.<br/><br/>amāvāsyā tu sōmēna saptamī bhānunā saha।  <br/>catu
@@ -62638,7 +62638,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-09  \,Kumbhaḥ-Pūrvaprōṣṭhapadā🌛
  🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191205T062107
 DTEND;TZID=Asia/Calcutta:20191206T062141
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191205_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-14\, Islamic: 1441-04-07 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62695,7 +62695,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191205T101314
 DTEND;TZID=Asia/Calcutta:20191205T235957
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-12-05T10:13:14.880018+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -62711,7 +62711,7 @@ BEGIN:VEVENT
 SUMMARY:pralaya-kalpādiḥ
 DTSTART;VALUE=DATE:20191205
 DTEND;VALUE=DATE:20191206
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:pralaya-kalpādiḥ_2019-12-05T06:21:07.200020+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/kalpAdiH/lunar_month/tithi/09/09/prala
@@ -62732,7 +62732,7 @@ BEGIN:VEVENT
 SUMMARY:vanadurgānavarātraḥ
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191206
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vanadurgānavarātraḥ_2019-11-26T23:59:57.120005+05:30
 DESCRIPTION:Vanadurga Navaratri. Specially celebrated in Kathiramangalam.<
  br/><br/>## Details<br/>- [Edit config file](https://github.com/jyotisham/
@@ -62751,7 +62751,7 @@ BEGIN:VEVENT
 SUMMARY:vanadurgānavarātra-samāpanam
 DTSTART;VALUE=DATE:20191205
 DTEND;VALUE=DATE:20191206
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vanadurgānavarātra-samāpanam_2019-12-05T06:21:07.200020+05:30
 DESCRIPTION:Observed on Śukla-Navamī tithi of Mārgaśīrṣaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Vanadurga Navaratri. Speci
@@ -62774,7 +62774,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-10  \,Mīnaḥ-Uttaraprōṣṭhapadā🌛
  🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191206T062141
 DTEND;TZID=Asia/Calcutta:20191207T062216
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191206_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-15\, Islamic: 1441-04-08 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62831,7 +62831,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-10  \,Mīnaḥ-Rēvatī🌛🌌  \,  Vr̥śc
  ḥ
 DTSTART;TZID=Asia/Calcutta:20191207T062216
 DTEND;TZID=Asia/Calcutta:20191208T062242
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191207_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-16\, Islamic: 1441-04-09 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62887,7 +62887,7 @@ BEGIN:VEVENT
 SUMMARY:vyatīpāta-śrāddham
 DTSTART;VALUE=DATE:20191207
 DTEND;VALUE=DATE:20191208
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:vyatīpāta-śrāddham_2019-12-07T06:22:16.319983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/17/vyatI
@@ -62911,7 +62911,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-11  \,Mēṣaḥ-Aśvinī🌛🌌  \,  Vr̥
  ānuḥ
 DTSTART;TZID=Asia/Calcutta:20191208T062242
 DTEND;TZID=Asia/Calcutta:20191209T062316
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191208_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-17\, Islamic: 1441-04-10 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -62967,7 +62967,7 @@ BEGIN:VEVENT
 SUMMARY:gītā-jayantī
 DTSTART;VALUE=DATE:20191208
 DTEND;VALUE=DATE:20191209
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:gītā-jayantī_2019-12-08T06:22:42.240019+05:30
 DESCRIPTION:Observed on Śukla-Ēkādaśī tithi of Mārgaśīrṣaḥ (lu
  nar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<b
@@ -62987,7 +62987,7 @@ BEGIN:VEVENT
 SUMMARY:guruvāyupura-ēkādaśī
 DTSTART;VALUE=DATE:20191208
 DTEND;VALUE=DATE:20191209
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:guruvāyupura-ēkādaśī_2019-12-08T06:22:42.240019+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of vr̥śchikamāsa is known as gur
  uvāyupura-ēkādaśī.<br/><br/>## Details<br/>- [Edit config file](https
@@ -63007,7 +63007,7 @@ BEGIN:VEVENT
 SUMMARY:Kārttigai Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20191208
 DTEND;VALUE=DATE:20191209
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:KārttigaiÑāyiṟṟukkiḻamai_2019-12-08T06:22:42.240019+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -63026,7 +63026,7 @@ BEGIN:VEVENT
 SUMMARY:kaiśika-ēkādaśī
 DTSTART;VALUE=DATE:20191208
 DTEND;VALUE=DATE:20191209
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kaiśika-ēkādaśī_2019-12-08T06:22:42.240019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/ekAdashI/description_only/kaiz
@@ -63047,7 +63047,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-mōkṣadā-ēkādaśī
 DTSTART;VALUE=DATE:20191208
 DTEND;VALUE=DATE:20191209
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sarva-mōkṣadā-ēkādaśī_2019-12-08T06:22:42.240019+05:30
 DESCRIPTION:The Shukla-paksha Ekadashi of mārgaśīrṣa month is known a
  s mōkṣadā-ēkādaśī. During the bright half of Mārgaśīrṣa\, the
@@ -63193,7 +63193,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-12  \,Mēṣaḥ-Apabharaṇī🌛🌌  \,
  , Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191209T062316
 DTEND;TZID=Asia/Calcutta:20191210T062351
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191209_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-18\, Islamic: 1441-04-11 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -63249,7 +63249,7 @@ BEGIN:VEVENT
 SUMMARY:Bharaṇī Dīpam
 DTSTART;VALUE=DATE:20191209
 DTEND;VALUE=DATE:20191210
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:BharaṇīDīpam_2019-12-09T06:23:16.800001+05:30
 DESCRIPTION:Observed on Apabharaṇī nakshatra of Vr̥ścikaḥ (sidereal
   solar) month (Sūryōdayaḥ/paraviddha). <br/><br/><br/><br/>## Details<
@@ -63269,7 +63269,7 @@ BEGIN:VEVENT
 SUMMARY:Kārttigai
 DTSTART;VALUE=DATE:20191209
 DTEND;VALUE=DATE:20191210
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:Kārttigai_2019-12-09T06:23:16.800001+05:30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Vr̥ścikaḥ (sidereal so
  lar) month (Rātrimānam/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -63289,7 +63289,7 @@ BEGIN:VEVENT
 SUMMARY:kaiśika-dvādaśī
 DTSTART;VALUE=DATE:20191209
 DTEND;VALUE=DATE:20191210
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kaiśika-dvādaśī_2019-12-09T06:23:16.800001+05:30
 DESCRIPTION:Read kaiśika purāṇam on this day. Special celebrations in 
  Thirukurungudi Divya Desham Temple.<br/><br/>## Details<br/>- [Edit config
@@ -63309,7 +63309,7 @@ BEGIN:VEVENT
 SUMMARY:sōma-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20191209T173838
 DTEND;TZID=Asia/Calcutta:20191209T191415
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:sōma-pradōṣa-vratam_2019-12-09T17:38:38.400005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/sOma
@@ -63327,7 +63327,7 @@ BEGIN:VEVENT
 SUMMARY:Tiruvaṇṇāmalai Dīpam
 DTSTART;VALUE=DATE:20191209
 DTEND;VALUE=DATE:20191210
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:TiruvaṇṇāmalaiDīpam_2019-12-09T06:23:16.800001+05:30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Vr̥ścikaḥ (sidereal so
  lar) month (Rātrimānam/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -63349,7 +63349,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-13  \,Mēṣaḥ-Kr̥ttikā🌛🌌  \,  Vr
  Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191210T062351
 DTEND;TZID=Asia/Calcutta:20191211T062425
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:20191210_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-19\, Islamic: 1441-04-12 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -63405,7 +63405,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191210T173855
 DTEND;TZID=Asia/Calcutta:20191211T062425
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-10T17:38:55.680015+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -63426,7 +63426,7 @@ BEGIN:VEVENT
 SUMMARY:kr̥ttikā-vratam
 DTSTART;VALUE=DATE:20191210
 DTEND;VALUE=DATE:20191211
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:kr̥ttikā-vratam_2019-12-10T06:23:51.359982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/kaumAra/sidereal_solar_month/nakshatra/00/
@@ -63447,7 +63447,7 @@ BEGIN:VEVENT
 SUMMARY:Kaṇampulla Nāyanmār (47) Gurupūjai
 DTSTART;VALUE=DATE:20191210
 DTEND;VALUE=DATE:20191211
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:KaṇampullaNāyanmār(47)Gurupūjai_2019-12-10T06:23:51.359982+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -63470,7 +63470,7 @@ BEGIN:VEVENT
 SUMMARY:Tirumaṅgaiyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20191210
 DTEND;VALUE=DATE:20191211
-DTSTAMP:20260822T115610Z
+DTSTAMP:20200101T000000Z
 UID:TirumaṅgaiyāḻvārTirunakṣattiram_2019-12-10T06:23:51.359982+05:
  30
 DESCRIPTION:Observed on Kr̥ttikā nakshatra of Vr̥ścikaḥ (sidereal so
@@ -63493,7 +63493,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-14  \,Vr̥ṣabhaḥ-Rōhiṇī🌛🌌  \,
  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191211T062425
 DTEND;TZID=Asia/Calcutta:20191212T062500
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191211_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-20\, Islamic: 1441-04-13 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -63549,7 +63549,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Śukla-Caturdaśī tithi of every (lunar) month (S
  āṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturdaśī
@@ -63589,7 +63589,7 @@ BEGIN:VEVENT
 SUMMARY:dattātrēya-jayantī
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:dattātrēya-jayantī_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mārgaśīrṣaḥ (lunar)
   month (Pradōṣaḥ/paraviddha). <br/><br/>ādau brahmā madhyē viṣ
@@ -63611,7 +63611,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-pūrṇimā
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-pūrṇimā_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mārgaśīrṣaḥ (lunar)
   month (Chandrōdayaḥ/puurvaviddha). <br/><br/>Do dānam of salt\, sunda
@@ -63641,7 +63641,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam pūrṇimāyām
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratampūrṇimāyām_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_16/offse
@@ -63662,7 +63662,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-pūjā
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-pūjā_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Pūrv
  arātriḥ##~##(Trēdhā)/puurvaviddha). <br/><br/>pūrṇimā pūjā is p
@@ -63686,7 +63686,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (pūrṇimā)
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(pūrṇimā)_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Āśv
  inaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file
@@ -63705,7 +63705,7 @@ BEGIN:VEVENT
 SUMMARY:piśācamōcanayātrā
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:piśācamōcanayātrā_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/temples/North/lunar_month/tithi/09/14/pizAcamOcan
@@ -63726,7 +63726,7 @@ BEGIN:VEVENT
 SUMMARY:Sarvālaya Dīpam
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:SarvālayaDīpam_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vr̥ścikaḥ (sidereal so
  lar) month (Rātrimānam/puurvaviddha). <br/><br/><br/><br/>## Details<br/
@@ -63746,7 +63746,7 @@ BEGIN:VEVENT
 SUMMARY:tripura-bhairavī-jayantī
 DTSTART;VALUE=DATE:20191211
 DTEND;VALUE=DATE:20191212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:tripura-bhairavī-jayantī_2019-12-11T06:24:25.920004+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mārgaśīrṣaḥ (lunar)
   month (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Tripura Bhairavi is 
@@ -63769,7 +63769,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-15  \,Vr̥ṣabhaḥ-Mr̥gaśīrṣam🌛
  🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191212T062500
 DTEND;TZID=Asia/Calcutta:20191213T062526
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191212_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-21\, Islamic: 1441-04-14 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -63825,7 +63825,7 @@ BEGIN:VEVENT
 SUMMARY:āgrayaṇa-hōmaḥ drāviḍēṣu
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:āgrayaṇa-hōmaḥdrāviḍēṣu_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Vr̥ścikaḥ (sidereal so
  lar) month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Perform hōma with fre
@@ -63846,7 +63846,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of pūrṇimā. S
@@ -63881,7 +63881,7 @@ BEGIN:VEVENT
 SUMMARY:annapūrṇā-jayantī
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:annapūrṇā-jayantī_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mārgaśīrṣaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/><br/><br/>## Details<br/>-
@@ -63902,7 +63902,7 @@ SUMMARY:kāñcī 13 jagadguru-śrī-saccidghanēndra-sarasvatī-ārādhan
  ā #1748
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī13jagadguru-śrī-saccidghanēndra-sarasvatī-ārādhanā#1748
  _2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -63927,7 +63927,7 @@ BEGIN:VEVENT
 SUMMARY:mahāmārgaśīrṣī-yōgaḥ
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mahāmārgaśīrṣī-yōgaḥ_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/mahA-m
@@ -63949,7 +63949,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ paurṇamāsyām
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥpaurṇamāsyām_2019-12-12T06:25:
  00.479986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
@@ -63976,7 +63976,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇamāsēṣṭiḥ
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇamāsēṣṭiḥ_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config fi
@@ -63995,7 +63995,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇimā-vratam
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇimā-vratam_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
  ōdayaḥ/puurvaviddha). <br/><br/>pūrṇimā vratam is commonly observed
@@ -64015,7 +64015,7 @@ BEGIN:VEVENT
 SUMMARY:sarpa-balyutsarjanam
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sarpa-balyutsarjanam_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of Mārgaśīrṣaḥ (lunar)
   month (Sūryōdayaḥ/puurvaviddha). <br/><br/>Offer final bali to serpen
@@ -64038,7 +64038,7 @@ BEGIN:VEVENT
 SUMMARY:pūrṇa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pūrṇa-sthālīpākaḥ_2019-12-12T06:25:00.479986+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Pūrvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnight
@@ -64059,7 +64059,7 @@ BEGIN:VEVENT
 SUMMARY:vēṅkaṭācalē pūrṇimā-garuḍa-sēvā
 DTSTART;VALUE=DATE:20191212
 DTEND;VALUE=DATE:20191213
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:vēṅkaṭācalēpūrṇimā-garuḍa-sēvā_2019-12-12T06:25:00.4799
  86+05:30
 DESCRIPTION:Observed on Paurṇamāsī tithi of every (lunar) month (Sūry
@@ -64084,7 +64084,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-16  \,Mithunam-Ārdrā🌛🌌  \,  Vr̥ści
  ḥ
 DTSTART;TZID=Asia/Calcutta:20191213T062526
 DTEND;TZID=Asia/Calcutta:20191214T062600
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191213_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-22\, Islamic: 1441-04-15 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -64141,7 +64141,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191213
 DTEND;VALUE=DATE:20191214
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-13T06:25:26.399982+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Prathamā tithi of every (lunar) month
   (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā
@@ -64189,7 +64189,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-17  \,Mithunam-Punarvasuḥ🌛🌌  \,  Vr
  Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191214T062600
 DTEND;TZID=Asia/Calcutta:20191215T062635
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191214_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-23\, Islamic: 1441-04-16 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -64246,7 +64246,7 @@ BEGIN:VEVENT
 SUMMARY:gurōḥ vārdhakya-samāpanam
 DTSTART;TZID=Asia/Calcutta:20191215T045727
 DTEND;TZID=Asia/Calcutta:20191214T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:gurōḥvārdhakya-samāpanam_2019-12-15T04:57:27.360018+05:30
 DESCRIPTION:guruḥ's vArdhakya ends on 2019-Dec-15 04:57\, as it sets int
  o combustion (mAudhyam). At this moment guruḥ is at mūlā-3 dhanuḥ (l
@@ -64262,7 +64262,7 @@ BEGIN:VEVENT
 SUMMARY:guruḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20191215T045727
 DTEND;TZID=Asia/Calcutta:20191214T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:guruḥ–astamayaḥ(prāk)_2019-12-15T04:57:27.360018+05:30
 DESCRIPTION:guruḥ sets into combustion (astamayaH)\, heading prāk (east
  )\, on 2019-Dec-15 04:57. At this moment guruḥ is at mūlā-3 dhanuḥ (
@@ -64281,7 +64281,7 @@ BEGIN:VEVENT
 SUMMARY:nārāyaṇīyaṁ-jayantī #434
 DTSTART;VALUE=DATE:20191214
 DTEND;VALUE=DATE:20191215
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:nārāyaṇīyaṁ-jayantī#434_2019-12-14T06:26:00.960004+05:30
 DESCRIPTION:Observed on day 28 of Vr̥ścikaḥ (sidereal solar) month (S
  ūryōdayaḥ/puurvaviddha). The event occurred in 4687 (Kali era).  <br/>
@@ -64303,7 +64303,7 @@ BEGIN:VEVENT
 SUMMARY:paraśurāma-jayantī (draviḍa-sampradāyaḥ)
 DTSTART;VALUE=DATE:20191214
 DTEND;VALUE=DATE:20191215
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:paraśurāma-jayantī(draviḍa-sampradāyaḥ)_2019-12-14T06:26:00.96
  0004+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Dvitīyā tithi of Mārgaśīrṣaḥ 
@@ -64330,7 +64330,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191214T062600
 DTEND;TZID=Asia/Calcutta:20191214T084716
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-12-14T06:26:00.960004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -64351,7 +64351,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-18  \,Karkaṭaḥ-Puṣyaḥ🌛🌌  \,  V
   Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191215T062635
 DTEND;TZID=Asia/Calcutta:20191216T062710
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191215_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-24\, Islamic: 1441-04-17 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Vr̥ścikaḥ\, तं- Kārt
@@ -64409,7 +64409,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191215T174056
 DTEND;TZID=Asia/Calcutta:20191216T062710
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-15T17:40:56.640011+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -64431,7 +64431,7 @@ BEGIN:VEVENT
 SUMMARY:dinakṣayaḥ
 DTSTART;VALUE=DATE:20191215
 DTEND;VALUE=DATE:20191216
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:dinakṣayaḥ_2019-12-15T06:26:35.519985+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/special-tithis/description_only/dinakS
@@ -64452,7 +64452,7 @@ BEGIN:VEVENT
 SUMMARY:Kārttigai Ñāyiṟṟukkiḻamai
 DTSTART;VALUE=DATE:20191215
 DTEND;VALUE=DATE:20191216
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:KārttigaiÑāyiṟṟukkiḻamai_2019-12-15T06:26:35.519985+05:30
 DESCRIPTION:Do puja to Surya/Suryanamaskaram.<br/><br/>## Details<br/>- [E
  dit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/
@@ -64471,7 +64471,7 @@ BEGIN:VEVENT
 SUMMARY:ravipuṣya-yōgaḥ
 DTSTART;VALUE=DATE:20191214
 DTEND;VALUE=DATE:20191215
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:ravipuṣya-yōgaḥ_2019-12-14T23:59:57.120005+05:30
 DESCRIPTION:When Pushya nakshatra falls on a Sunday\, it is a special yōg
  aḥ\, on which it is important to propitiate Surya Bhagavan.<br/><br/>ād
@@ -64495,7 +64495,7 @@ SUMMARY:ravivāra-ākhuratha-mahāgaṇapati-saṅkaṭahara-caturthī-vra
  tam
 DTSTART;VALUE=DATE:20191215
 DTEND;VALUE=DATE:20191216
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:ravivāra-ākhuratha-mahāgaṇapati-saṅkaṭahara-caturthī-vratam_
  2019-12-15T06:26:35.519985+05:30
 DESCRIPTION:
@@ -64513,7 +64513,7 @@ BEGIN:VEVENT
 SUMMARY:śukra-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191215T173628
 DTEND;TZID=Asia/Calcutta:20191215T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:śukra-saṅkrāntiḥ_2019-12-15T17:36:28.799983+05:30
 DESCRIPTION:Transition of Venus from one Rashi to another.<br/><br/>## Det
  ails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/
@@ -64531,7 +64531,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-20  \,Karkaṭaḥ-Āśrēṣā🌛🌌  \,
  ōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191216T062710
 DTEND;TZID=Asia/Calcutta:20191217T062736
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191216_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-25\, Islamic: 1441-04-18 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -64588,7 +64588,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191216
 DTEND;VALUE=DATE:20191217
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-16T06:27:10.080007+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -64613,7 +64613,7 @@ BEGIN:VEVENT
 SUMMARY:dhanūravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191216T150106
 DTEND;TZID=Asia/Calcutta:20191216T174122
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:dhanūravi-saṅkramaṇa-ṣaḍaśīti-puṇyakālaḥ_2019-12-16T15
  :01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -64634,7 +64634,7 @@ BEGIN:VEVENT
 SUMMARY:ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191216T083703
 DTEND;TZID=Asia/Calcutta:20191216T174122
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:ravi-saṅkramaṇa-puṇyakālaḥ_2019-12-16T08:37:03.360005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/ravi-saGkra
@@ -64652,7 +64652,7 @@ BEGIN:VEVENT
 SUMMARY:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191216T120416
 DTEND;TZID=Asia/Calcutta:20191216T174122
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:saṅkramaṇa-dina-aparāhṇa-puṇyakālaḥ_2019-12-16T12:04:16.32
  0007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -64672,7 +64672,7 @@ BEGIN:VEVENT
 SUMMARY:vaidhr̥ti-śrāddham
 DTSTART;VALUE=DATE:20191216
 DTEND;VALUE=DATE:20191217
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:vaidhr̥ti-śrāddham_2019-12-16T06:27:10.080007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/sidereal_solar_month/yoga/00/27/vaidh
@@ -64695,7 +64695,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-21  \,Siṁhaḥ-Maghā🌛🌌  \,  Dhanu
  ḥ-Mūlā-09-02🌞🌌  \,  Sahasyaḥ-10-25🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191217T062736
 DTEND;TZID=Asia/Calcutta:20191218T062810
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191217_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-26\, Islamic: 1441-04-19 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -64751,7 +64751,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191217T174148
 DTEND;TZID=Asia/Calcutta:20191218T062810
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-17T17:41:48.480003+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -64772,7 +64772,7 @@ BEGIN:VEVENT
 SUMMARY:dhanurmāsa-uṣaḥkāla-pūjārambhaḥ
 DTSTART;VALUE=DATE:20191217
 DTEND;VALUE=DATE:20191218
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:dhanurmāsa-uṣaḥkāla-pūjārambhaḥ_2019-12-17T06:27:36.000003+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -64796,7 +64796,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-22  \,Siṁhaḥ-Pūrvaphalgunī🌛🌌  \,
    Dhanuḥ-Mūlā-09-03🌞🌌  \,  Sahasyaḥ-10-26🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191218T062810
 DTEND;TZID=Asia/Calcutta:20191219T062845
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191218_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-27\, Islamic: 1441-04-20 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -64853,7 +64853,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191218
 DTEND;VALUE=DATE:20191219
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-18T06:28:10.559985+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -64878,7 +64878,7 @@ BEGIN:VEVENT
 SUMMARY:budhaḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20191218T204415
 DTEND;TZID=Asia/Calcutta:20191218T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:budhaḥ–astamayaḥ(prāk)_2019-12-18T20:44:15.359995+05:30
 DESCRIPTION:budhaḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Dec-18 20:44. At this moment budhaḥ is at jyēṣṭhā-1 v
@@ -64897,7 +64897,7 @@ BEGIN:VEVENT
 SUMMARY:kucēla-dinam
 DTSTART;VALUE=DATE:20191218
 DTEND;VALUE=DATE:20191219
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kucēla-dinam_2019-12-18T06:28:10.559985+05:30
 DESCRIPTION:Celebrated especially in Kerala/Guruvayur. Commemorates the in
  cident of Kuchela visiting Bhagavan Krishna. Offer naivedyam of pr̥thukam
@@ -64917,7 +64917,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-aṣṭakā-pūrvēdyuḥ
 DTSTART;VALUE=DATE:20191218
 DTEND;VALUE=DATE:20191219
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-aṣṭakā-pūrvēdyuḥ_2019-12-18T06:28:10.559985+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -64942,7 +64942,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-23  \,Kanyā-Uttaraphalgunī🌛🌌  \,  Dh
  anuḥ-Mūlā-09-04🌞🌌  \,  Sahasyaḥ-10-27🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191219T062845
 DTEND;TZID=Asia/Calcutta:20191220T062911
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191219_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-28\, Islamic: 1441-04-21 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -64998,7 +64998,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191219
 DTEND;VALUE=DATE:20191220
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-19T06:28:45.120007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of aṣṭ
@@ -65033,7 +65033,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191219
 DTEND;VALUE=DATE:20191220
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-19T06:28:45.120007+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -65058,7 +65058,7 @@ BEGIN:VEVENT
 SUMMARY:Iyaṟpagai Nāyanmār (3) Gurupūjai
 DTSTART;VALUE=DATE:20191219
 DTEND;VALUE=DATE:20191220
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:IyaṟpagaiNāyanmār(3)Gurupūjai_2019-12-19T06:28:45.120007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -65082,7 +65082,7 @@ SUMMARY:kāñcī 4 jagadguru-śrī-satyabōdhēndra-sarasvatī-ārādhanā
   #2287
 DTSTART;VALUE=DATE:20191219
 DTEND;VALUE=DATE:20191220
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī4jagadguru-śrī-satyabōdhēndra-sarasvatī-ārādhanā#2287_
  2019-12-19T06:28:45.120007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65107,7 +65107,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-aṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20191219
 DTEND;VALUE=DATE:20191220
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-aṣṭakā-śrāddham_2019-12-19T06:28:45.120007+05:3
  0
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65130,7 +65130,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (aṣṭamī)
 DTSTART;VALUE=DATE:20191219
 DTEND;VALUE=DATE:20191220
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(aṣṭamī)_2019-12-19T06:28:45.120007+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Aṣṭamī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -65150,7 +65150,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-24  \,Kanyā-Hastaḥ🌛🌌  \,  Dhanuḥ-
  Mūlā-09-05🌞🌌  \,  Sahasyaḥ-10-28🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191220T062911
 DTEND;TZID=Asia/Calcutta:20191221T062945
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191220_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-29\, Islamic: 1441-04-22 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -65206,7 +65206,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191220
 DTEND;VALUE=DATE:20191221
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-20T06:29:11.040003+05:30
 DESCRIPTION:The three days around the Ashtaka Shraaddha of  mārgaśīrṣ
  a\, pauṣa and māgha month are anadhyayana days\, where one is not suppo
@@ -65231,7 +65231,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-anvaṣṭakā-śrāddham
 DTSTART;VALUE=DATE:20191220
 DTEND;VALUE=DATE:20191221
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-anvaṣṭakā-śrāddham_2019-12-20T06:29:11.040003+0
  5:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65256,7 +65256,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-25  \,Kanyā-Citrā🌛🌌  \,  Dhanuḥ-M
  ūlā-09-06🌞🌌  \,  Sahasyaḥ-10-29🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191221T062945
 DTEND;TZID=Asia/Calcutta:20191222T063011
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191221_day_summary
 DESCRIPTION:- Indian civil date: 1941-09-30\, Islamic: 1441-04-23 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -65312,7 +65312,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191221T174340
 DTEND;TZID=Asia/Calcutta:20191222T063011
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-21T17:43:40.800014+05:30
 DESCRIPTION:Anadhyayana during the night\, as it precedes saṅkramaṇa d
  uring the day tomorrow. When saṅkramaṇa happens in the night\, the pre
@@ -65335,7 +65335,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-26  \,Tulā-Svātī🌛🌌  \,  Dhanuḥ-M
  ūlā-09-07🌞🌌  \,  Tapaḥ-11-01🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191222T063011
 DTEND;TZID=Asia/Calcutta:20191223T063046
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191222_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-01\, Islamic: 1441-04-24 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -65392,7 +65392,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191222
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-22T06:30:11.519980+05:30
 DESCRIPTION:Anadhyayana during the day and night\, owing to saṅkramaṇa
   during daytime. When saṅkramaṇa happens in the night\, the previous a
@@ -65417,7 +65417,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191222
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-22T06:30:11.519980+05:30
 DESCRIPTION:Anadhyayana on account of uttarāyaṇa. On the days of Ayana 
  (solstices)\, Vishu (equinoxes)\, the day when Bhagavan Vishnu goes to sle
@@ -65441,7 +65441,7 @@ BEGIN:VEVENT
 SUMMARY:gaṇitajña-rāmānuja-janma #132
 DTSTART;VALUE=DATE:20191221
 DTEND;VALUE=DATE:20191222
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:gaṇitajña-rāmānuja-janma#132_2019-12-21T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/general-indic-tropical/gregorian/day/
@@ -65462,7 +65462,7 @@ BEGIN:VEVENT
 SUMMARY:Mānakkañchāṟa Nāyanmār (12) Gurupūjai
 DTSTART;VALUE=DATE:20191222
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:MānakkañchāṟaNāyanmār(12)Gurupūjai_2019-12-22T06:30:11.519980+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65486,7 +65486,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191222T063011
 DTEND;TZID=Asia/Calcutta:20191222T161323
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-ravi-saṅkramaṇa-puṇyakālaḥ_2019-12-22T06:30:11.519980
  +05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65505,7 +65505,7 @@ BEGIN:VEVENT
 SUMMARY:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191222T063011
 DTEND;TZID=Asia/Calcutta:20191222T120709
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sāyana-saṅkramaṇa-dina-pūrvāhṇa-puṇyakālaḥ_2019-12-22T06
  :30:11.519980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65526,7 +65526,7 @@ BEGIN:VEVENT
 SUMMARY:sahōmāsaḥuṣaḥkāla-pūjā-
 DTSTART;VALUE=DATE:20191122
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sahōmāsaḥuṣaḥkāla-pūjā-_2019-11-22T23:59:57.120005+05:30
 DESCRIPTION:
 TRANSP:TRANSPARENT
@@ -65542,7 +65542,7 @@ BEGIN:VEVENT
 SUMMARY:sahōmāsa-uṣaḥkāla-pūjā-samāpanam
 DTSTART;VALUE=DATE:20191222
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sahōmāsa-uṣaḥkāla-pūjā-samāpanam_2019-12-22T06:30:11.519980+
  05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65565,7 +65565,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-saphalā-ēkādaśī
 DTSTART;VALUE=DATE:20191222
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sarva-saphalā-ēkādaśī_2019-12-22T06:30:11.519980+05:30
 DESCRIPTION:The Krishna-paksha Ekadashi of mārgaśīrṣa month is known 
  as saphalā-ēkādaśī.<br/><br/>The fruits of fasting on Ekādaśī are 
@@ -65660,7 +65660,7 @@ BEGIN:VEVENT
 SUMMARY:tapō-māsaḥ/śiśirar̥tuḥ/uttarāyaṇam
 DTSTART;TZID=Asia/Calcutta:20191222T094920
 DTEND;TZID=Asia/Calcutta:20191222T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:tapō-māsaḥ/śiśirar̥tuḥ/uttarāyaṇam_2019-12-22T09:49:20.640
  000+05:30
 DESCRIPTION:
@@ -65674,7 +65674,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191222T183548
 DTEND;TZID=Asia/Calcutta:20191223T063046
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-12-22T18:35:48.480012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -65693,7 +65693,7 @@ BEGIN:VEVENT
 SUMMARY:uttarāyaṇārambhaḥ
 DTSTART;VALUE=DATE:20191222
 DTEND;VALUE=DATE:20191223
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:uttarāyaṇārambhaḥ_2019-12-22T06:30:11.519980+05:30
 DESCRIPTION:Observed on day 1 of Tapaḥ (tropical) month (Sūryōdayaḥ/
  puurvaviddha). <br/><br/>Winter solstice.<br/><br/>## Details<br/>- [Edit 
@@ -65713,7 +65713,7 @@ BEGIN:VEVENT
 SUMMARY:uttarāyaṇa-puṇyakālaḥ
 DTSTART;TZID=Asia/Calcutta:20191222T094920
 DTEND;TZID=Asia/Calcutta:20191222T174406
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:uttarāyaṇa-puṇyakālaḥ_2019-12-22T09:49:20.640000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/sankrAnti/description_only/uttarAyaNa-
@@ -65733,7 +65733,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-27  \,Tulā-Viśākhā🌛🌌  \,  Dhanuḥ
  -Mūlā-09-08🌞🌌  \,  Tapaḥ-11-02🌞🪐  \, Sōmaḥ
 DTSTART;TZID=Asia/Calcutta:20191223T063046
 DTEND;TZID=Asia/Calcutta:20191224T063111
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191223_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-02\, Islamic: 1441-04-25 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -65791,7 +65791,7 @@ SUMMARY:kāñcī 68 jagadguru-śrī-candraśēkharēndra-sarasvatī-7-ār
  ādhanā #26
 DTSTART;VALUE=DATE:20191223
 DTEND;VALUE=DATE:20191224
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī68jagadguru-śrī-candraśēkharēndra-sarasvatī-7-ārādhan
  ā#26_2019-12-23T06:30:46.080002+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -65816,7 +65816,7 @@ BEGIN:VEVENT
 SUMMARY:sōma-pradōṣa-vratam
 DTSTART;TZID=Asia/Calcutta:20191223T174441
 DTEND;TZID=Asia/Calcutta:20191223T192026
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sōma-pradōṣa-vratam_2019-12-23T17:44:41.279992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/monthly/pradoSha/description_only/sOma
@@ -65835,7 +65835,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-28  \,Vr̥ścikaḥ-Anūrādhā🌛🌌  \,
   Dhanuḥ-Mūlā-09-09🌞🌌  \,  Tapaḥ-11-03🌞🪐  \, Maṅgalaḥ
 DTSTART;TZID=Asia/Calcutta:20191224T063111
 DTEND;TZID=Asia/Calcutta:20191225T063146
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191224_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-03\, Islamic: 1441-04-26 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -65892,7 +65892,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;TZID=Asia/Calcutta:20191224T174515
 DTEND;TZID=Asia/Calcutta:20191225T063146
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-24T17:45:15.840013+05:30
 DESCRIPTION:When the next day is anadhyayana\, for whatever reason\, one m
  ust not perform adhyayana in the previous night.<br/><br/>hārītaḥ—  
@@ -65913,7 +65913,7 @@ BEGIN:VEVENT
 SUMMARY:māsaśivarātriḥ
 DTSTART;VALUE=DATE:20191224
 DTEND;VALUE=DATE:20191225
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:māsaśivarātriḥ_2019-12-24T06:31:11.999998+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Niśīthaḥ/paraviddha). <br/><br/>Monthly Shivaratri day.<br/><br/>#
@@ -65933,7 +65933,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (caturdaśī)
 DTSTART;VALUE=DATE:20191224
 DTEND;VALUE=DATE:20191225
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(caturdaśī)_2019-12-24T06:31:11.999998+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Āśvinaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit co
@@ -65953,7 +65953,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-29  \,Vr̥ścikaḥ-Jyēṣṭhā🌛🌌  \
  ,  Dhanuḥ-Mūlā-09-10🌞🌌  \,  Tapaḥ-11-04🌞🪐  \, Budhaḥ
 DTSTART;TZID=Asia/Calcutta:20191225T063146
 DTEND;TZID=Asia/Calcutta:20191226T063212
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191225_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-04\, Islamic: 1441-04-27 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -66010,7 +66010,7 @@ BEGIN:VEVENT
 SUMMARY:aṅgāraka-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191225T205009
 DTEND;TZID=Asia/Calcutta:20191225T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:aṅgāraka-saṅkrāntiḥ_2019-12-25T20:50:09.599997+05:30
 DESCRIPTION:Transition of Mars from one Rashi to another.<br/><br/>## Deta
  ils<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/m
@@ -66026,7 +66026,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:Observed on Kr̥ṣṇa-Caturdaśī tithi of every (lunar) mon
  th (Sāṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of chaturd
@@ -66066,7 +66066,7 @@ BEGIN:VEVENT
 SUMMARY:budha-saṅkrāntiḥ
 DTSTART;TZID=Asia/Calcutta:20191225T152853
 DTEND;TZID=Asia/Calcutta:20191225T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:budha-saṅkrāntiḥ_2019-12-25T15:28:53.759992+05:30
 DESCRIPTION:Transition of Mercury from one Rashi to another.<br/><br/>## D
  etails<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blo
@@ -66083,7 +66083,7 @@ SUMMARY:kāñcī 14 jagadguru-śrī-vidyāghanēndra-sarasvatī-ārādhan
  ā #1703
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī14jagadguru-śrī-vidyāghanēndra-sarasvatī-ārādhanā#1703
  _2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -66109,7 +66109,7 @@ SUMMARY:kāñcī 34 jagadguru-śrī-candraśēkharēndra-sarasvatī-2-ār
  ādhanā #1310
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kāñcī34jagadguru-śrī-candraśēkharēndra-sarasvatī-2-ārādhan
  ā#1310_2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -66134,7 +66134,7 @@ BEGIN:VEVENT
 SUMMARY:kamalā-jayantī
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:kamalā-jayantī_2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Mārgaśīrṣaḥ (lunar) mo
  nth (Madhyarātriḥ/puurvaviddha). <br/><br/>Devi Kamala is 10th of the D
@@ -66154,7 +66154,7 @@ BEGIN:VEVENT
 SUMMARY:khyēcimāvasa pōṣta/khicaḍī-amāvāsyā
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:khyēcimāvasapōṣta/khicaḍī-amāvāsyā_2019-12-25T06:31:46.5599
  80+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
@@ -66177,7 +66177,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇavratam amāvāsyāyām
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇavratamamāvāsyāyām_2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/gRhya/general/relative_event/sthAlIpAkaH_1/offset
@@ -66198,7 +66198,7 @@ BEGIN:VEVENT
 SUMMARY:pañca-parva-pūjā (amāvāsyā)
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pañca-parva-pūjā(amāvāsyā)_2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Āśvina
  ḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config file](h
@@ -66217,7 +66217,7 @@ BEGIN:VEVENT
 SUMMARY:sarva-mārgaśīrṣa-amāvāsyā
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sarva-mārgaśīrṣa-amāvāsyā_2019-12-25T06:31:46.559980+05:30
 DESCRIPTION:amāvāsyā of mārgaśīrṣa lunar month.<br/><br/>## Detail
  s<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/blob/mas
@@ -66236,7 +66236,7 @@ BEGIN:VEVENT
 SUMMARY:Toṇḍaraḍippoḍiyāḻvār Tirunakṣattiram
 DTSTART;VALUE=DATE:20191225
 DTEND;VALUE=DATE:20191226
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:ToṇḍaraḍippoḍiyāḻvārTirunakṣattiram_2019-12-25T06:31:46.
  559980+05:30
 DESCRIPTION:Observed on Jyēṣṭhā nakshatra of Dhanuḥ (sidereal sola
@@ -66258,7 +66258,7 @@ SUMMARY:Mārgaśīrṣaḥ-09-30  \,Dhanuḥ-Mūlā🌛🌌  \,  Dhanuḥ-
  Mūlā-09-11🌞🌌  \,  Tapaḥ-11-05🌞🪐  \, Guruḥ
 DTSTART;TZID=Asia/Calcutta:20191226T063212
 DTEND;TZID=Asia/Calcutta:20191227T063238
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191226_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-05\, Islamic: 1441-04-28 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -66314,7 +66314,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-26T06:32:12.480016+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of every (lunar) month (Sāṅga
  vaḥ/paraviddha). <br/><br/>Anadhyayana on account of amāvāsyā. Severa
@@ -66349,7 +66349,7 @@ BEGIN:VEVENT
 SUMMARY:darśēṣṭiḥ
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:darśēṣṭiḥ_2019-12-26T06:32:12.480016+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha).<br/><br/>## Details<br/>- [Edit config file](h
@@ -66368,7 +66368,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-māsaḥ
 DTSTART;VALUE=DATE:20191126
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-māsaḥ_2019-11-26T23:59:57.120005+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/description_only/mArgazIrSa-mAsaH
@@ -66390,7 +66390,7 @@ BEGIN:VEVENT
 SUMMARY:mārgaśīrṣa-māsa-samāpanam
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:mārgaśīrṣa-māsa-samāpanam_2019-12-26T06:32:12.480016+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Mārgaśīrṣaḥ (lunar) mo
  nth (Sūryōdayaḥ/paraviddha). <br/><br/>mārgaśīrṣa-māsaḥ ends t
@@ -66410,7 +66410,7 @@ BEGIN:VEVENT
 SUMMARY:pārvaṇa-prāyaścittāvakāśaḥ darśē
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pārvaṇa-prāyaścittāvakāśaḥdarśē_2019-12-26T06:32:12.480016
  +05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
@@ -66436,7 +66436,7 @@ BEGIN:VEVENT
 SUMMARY:piṇḍa-pitr̥-yajñaḥ
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:piṇḍa-pitr̥-yajñaḥ_2019-12-26T06:32:12.480016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/devatA/pitR/lunar_month/tithi/00/30/piNDa-pitR-ya
@@ -66457,7 +66457,7 @@ BEGIN:VEVENT
 SUMMARY:sūrya-grahaṇam (rāhupucchagrasta)
 DTSTART;TZID=Asia/Calcutta:20191226T080849
 DTEND;TZID=Asia/Calcutta:20191226T111929
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:sūrya-grahaṇam(rāhupucchagrasta)_2019-12-26T08:08:49.919985+05:30
 DESCRIPTION:Partial solar eclipse (parimāṇa ≈10.7 of 12 aṅgulas)\, 
  Sun at the Rahu node (puccha/descending). <br/><br/>Magnitude: 89% of the 
@@ -66488,7 +66488,7 @@ BEGIN:VEVENT
 SUMMARY:darśa-sthālīpākaḥ
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:darśa-sthālīpākaḥ_2019-12-26T06:32:12.480016+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Pū
  rvāhṇaḥ/puurvaviddha). sthālīpakaḥ is an important fortnightly ri
@@ -66509,7 +66509,7 @@ BEGIN:VEVENT
 SUMMARY:śrī-hanūmat-jayantī
 DTSTART;VALUE=DATE:20191226
 DTEND;VALUE=DATE:20191227
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:śrī-hanūmat-jayantī_2019-12-26T06:32:12.480016+05:30
 DESCRIPTION:Observed on Amāvāsyā tithi of Dhanuḥ (sidereal solar) mon
  th (Sūryōdayaḥ/puurvaviddha). <br/><br/>āśvinasyāsitē pakṣē bh
@@ -66532,7 +66532,7 @@ SUMMARY:Pauṣaḥ-10-01  \,Dhanuḥ-Pūrvāṣāḍhā🌛🌌  \,  Dhanu
  ḥ-Mūlā-09-12🌞🌌  \,  Tapaḥ-11-06🌞🪐  \, Śukraḥ
 DTSTART;TZID=Asia/Calcutta:20191227T063238
 DTEND;TZID=Asia/Calcutta:20191228T063304
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191227_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-06\, Islamic: 1441-04-29 Rabīʿ 
  ath-Thānī/ al-ʾĀkhir\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi
@@ -66589,7 +66589,7 @@ BEGIN:VEVENT
 SUMMARY:anadhyāyaḥ
 DTSTART;VALUE=DATE:20191227
 DTEND;VALUE=DATE:20191228
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:anadhyāyaḥ_2019-12-27T06:32:38.400013+05:30
 DESCRIPTION:Observed on Śukla-Prathamā tithi of every (lunar) month (Sā
  ṅgavaḥ/paraviddha). <br/><br/>Anadhyayana on account of prathamā. Sev
@@ -66635,7 +66635,7 @@ BEGIN:VEVENT
 SUMMARY:Chākkiya Nāyanmār (34) Gurupūjai
 DTSTART;VALUE=DATE:20191227
 DTEND;VALUE=DATE:20191228
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:ChākkiyaNāyanmār(34)Gurupūjai_2019-12-27T06:32:38.400013+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/mahApuruSha/nAyanmAr/sidereal_solar_month/nakshat
@@ -66658,7 +66658,7 @@ BEGIN:VEVENT
 SUMMARY:candra-darśanam
 DTSTART;TZID=Asia/Calcutta:20191227T174650
 DTEND;TZID=Asia/Calcutta:20191227T185305
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:candra-darśanam_2019-12-27T17:46:50.880013+05:30
 DESCRIPTION:Have darshan of Moon today\, chanting the following shloka<br/
  ><br/>śvētāmbaraḥ śvētavibhūṣaṇaśca  <br/>śvētadyutirdaṇ
@@ -66677,7 +66677,7 @@ BEGIN:VEVENT
 SUMMARY:pauṣa-māsa-ārambhaḥ
 DTSTART;VALUE=DATE:20191227
 DTEND;VALUE=DATE:20191228
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:pauṣa-māsa-ārambhaḥ_2019-12-27T06:32:38.400013+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc/lunar_month/tithi/10/01/pauSa-mAs
@@ -66700,7 +66700,7 @@ SUMMARY:Pauṣaḥ-10-02  \,Makaraḥ-Uttarāṣāḍhā🌛🌌  \,  Dhan
  uḥ-Mūlā-09-13🌞🌌  \,  Tapaḥ-11-07🌞🪐  \, Śaniḥ
 DTSTART;TZID=Asia/Calcutta:20191228T063304
 DTEND;TZID=Asia/Calcutta:20191229T063330
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191228_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-07\, Islamic: 1441-05-01 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -66756,7 +66756,7 @@ BEGIN:VEVENT
 SUMMARY:tripuṣkara-yōgaḥ
 DTSTART;TZID=Asia/Calcutta:20191228T063304
 DTEND;TZID=Asia/Calcutta:20191228T111007
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-12-28T06:33:04.320009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
  am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
@@ -66775,7 +66775,7 @@ BEGIN:VEVENT
 SUMMARY:śaniḥ–astamayaḥ (prāk)
 DTSTART;TZID=Asia/Calcutta:20191228T233135
 DTEND;TZID=Asia/Calcutta:20191228T235957
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:śaniḥ–astamayaḥ(prāk)_2019-12-28T23:31:35.039999+05:30
 DESCRIPTION:śaniḥ sets into combustion (astamayaH)\, heading prāk (eas
  t)\, on 2019-Dec-28 23:31. At this moment śaniḥ is at uttarāṣāḍh
@@ -66795,7 +66795,7 @@ SUMMARY:Pauṣaḥ-10-03  \,Makaraḥ-Śravaṇaḥ🌛🌌  \,  Dhanuḥ-
  Mūlā-09-14🌞🌌  \,  Tapaḥ-11-08🌞🪐  \, Bhānuḥ
 DTSTART;TZID=Asia/Calcutta:20191229T063330
 DTEND;TZID=Asia/Calcutta:20191230T063356
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191229_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-08\, Islamic: 1441-05-02 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -66852,7 +66852,7 @@ BEGIN:VEVENT
 SUMMARY:śravaṇa-vratam
 DTSTART;VALUE=DATE:20191229
 DTEND;VALUE=DATE:20191230
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:śravaṇa-vratam_2019-12-29T06:33:30.240005+05:30
 DESCRIPTION:Observed on every occurrence of Śravaṇaḥ nakshatra (Sā
  ṅgavaḥ/paraviddha). <br/><br/><br/><br/>## Details<br/>- [Edit config 
@@ -66871,7 +66871,7 @@ BEGIN:VEVENT
 SUMMARY:śukla-caturthī-vratam
 DTSTART;VALUE=DATE:20191229
 DTEND;VALUE=DATE:20191230
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:śukla-caturthī-vratam_2019-12-29T06:33:30.240005+05:30
 DESCRIPTION:Observed on Śukla-Caturthī tithi of every (lunar) month (Mad
  hyāhnaḥ/puurvaviddha). <br/><br/>Shukla Chaturthi Vratam for Bhagavan G
@@ -66893,7 +66893,7 @@ SUMMARY:Pauṣaḥ-10-04  \,Makaraḥ-Śraviṣṭhā🌛🌌  \,  Dhanu
  ḥ
 DTSTART;TZID=Asia/Calcutta:20191230T063356
 DTEND;TZID=Asia/Calcutta:20191231T063422
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191230_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-09\, Islamic: 1441-05-03 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 
@@ -66951,7 +66951,7 @@ SUMMARY:Pauṣaḥ-10-05  \,Kumbhaḥ-Śatabhiṣak🌛🌌  \,  Dhanuḥ-
  ḥ
 DTSTART;TZID=Asia/Calcutta:20191231T063422
 DTEND;TZID=Asia/Calcutta:20200101T063447
-DTSTAMP:20260822T115611Z
+DTSTAMP:20200101T000000Z
 UID:20191231_day_summary
 DESCRIPTION:- Indian civil date: 1941-10-10\, Islamic: 1441-05-04 Jumādā
   al-ʾAwwal/ʾŪlā\, 🌌🌞: सं- Dhanuḥ\, तं- Mārgaḻi\, 

--- a/jyotisha_tests/spatio_temporal/writer/test_ics.py
+++ b/jyotisha_tests/spatio_temporal/writer/test_ics.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime, timezone
 
 from indic_transliteration import sanscript
 from jyotisha.panchaanga.writer.ics import compute_calendar, write_to_file
@@ -12,28 +13,27 @@ logging.basicConfig(
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
 
+# Fixed so the golden .ics fixture (and this comparison) is stable across regenerations --
+# DTSTAMP is otherwise stamped with datetime.now() at generation time (correct for real
+# calendar output, per RFC 5545), which used to make every regeneration touch every single
+# event and forced this test to skip DTSTAMP lines during comparison instead of just comparing
+# file content directly.
+FIXED_DTSTAMP = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
 
 def test_panchanga_chennai_2019():
   panchaanga_2019 = Panchaanga.read_from_file(filename=os.path.join(TEST_DATA_PATH, 'Chennai-2019.json'))
   orig_ics_file = os.path.join(TEST_DATA_PATH, 'Chennai-2019-devanagari.ics')
   current_ics_output = os.path.join(TEST_DATA_PATH, 'Chennai-2019-devanagari.ics.local')
-  ics_calendar = compute_calendar(panchaanga_2019, scripts=[sanscript.ISO], set_sequence=False)
+  ics_calendar = compute_calendar(panchaanga_2019, scripts=[sanscript.ISO], set_sequence=False, dtstamp=FIXED_DTSTAMP)
   write_to_file(ics_calendar, current_ics_output)
   if not os.path.exists(orig_ics_file):
     logging.warning("%s not present. Assuming that it was deliberately deleted to update test files.", orig_ics_file)
     write_to_file(ics_calendar, orig_ics_file)
 
-  ics_file_match = True
   with open(orig_ics_file) as orig_ics:
     with open(current_ics_output) as current_ics:
-      for line1, line2 in zip(current_ics, orig_ics):
-        if line1.startswith("DTSTAMP") and line2.startswith("DTSTAMP"):
-          continue
-        if line1 != line2:
-          ics_file_match = False
-          break
-  
-  assert ics_file_match == True
+      assert current_ics.read() == orig_ics.read()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- `compute_calendar`/`get_day_summary_event`/`add_festival_events`/`festival_instance_to_event` now take an optional `dtstamp` parameter, defaulting to `datetime.now()` when omitted -- no behavior change for real calendar generation (e.g. the `ics` `__main__` CLI).
- `test_ics.py` now passes a fixed reference `dtstamp` and compares the generated file against the golden fixture with a plain `read() == read()`, instead of a manual line-by-line walk that specifically skipped `DTSTAMP` lines.
- That old walk also used `zip(current_ics, orig_ics)`, which silently truncates to the shorter file -- a real gap, since an actual difference in line count (an event added or dropped) wouldn't have been caught at all.
- Golden `.ics` fixture regenerated with the fixed `dtstamp` baked in; it's now stable across regenerations and will only show a diff when content genuinely changes, not on every run.

## Why
`DTSTAMP` was always `datetime.now()` at generation time (correct per RFC 5545 -- "the instant the calendar information was created" -- for real output), which meant every regeneration of the golden fixture touched every single event's `DTSTAMP` line, producing thousands of lines of diff noise unrelated to any real change, and forcing the comparison test into a fragile workaround.

## Test plan
- [x] Full test suite (72 tests) green.
- [x] Verified the ICS test's output is now byte-identical across repeated runs (confirms determinism).
- [x] Verified the fixed `DTSTAMP:20200101T000000Z` appears on all 2275 events in the regenerated fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qpqp8TRMy7b3F93RvYvi9m)_