### PR TITLE
VARA as a first-class anga: generic intersection engine + vaara-conditioned engine

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/__init__.py
@@ -2,11 +2,15 @@ import copy
 import logging
 import os
 import sys
+from math import floor
+from numbers import Number
 
-from jyotisha.panchaanga.temporal import PeriodicPanchaangaApplier, era
+from jyotisha.panchaanga.temporal import PeriodicPanchaangaApplier, era, zodiac
 from jyotisha.panchaanga.temporal import festival
-from jyotisha.panchaanga.temporal.festival import rules
+from jyotisha.panchaanga.temporal.festival import rules, FestivalInstance
 from jyotisha.panchaanga.temporal.festival.rules import RulesRepo
+from jyotisha.panchaanga.temporal.interval import Interval, AngaSpan
+from jyotisha.panchaanga.temporal.zodiac.angas import AngaType, Anga
 from sanskrit_data.schema import common
 from timebudget import timebudget
 
@@ -20,6 +24,100 @@ class FestivalAssigner(PeriodicPanchaangaApplier):
     self.festival_options = panchaanga.computation_system.festival_options
     self.rules_collection = rules.RulesCollection.get_cached(
       repos_tuple=tuple(panchaanga.computation_system.festival_options.repos), julian_handling=self.festival_options.julian_handling)
+
+  def _find_vara_span(self, jd1, jd2, target_anga_id):
+    """ Resolves an AngaType.VARA span the same way every other per-day anga span is bounded elsewhere in this
+    codebase (sunrise to next sunrise), rather than via AngaSpanFinder's brentq-based ecliptic longitude search
+    (wrong tool for a step function like weekday, and liable to drift from the timezone-correct
+    daily_panchaanga.date.get_weekday() used everywhere else). Scans self.daily_panchaangas (already computed for
+    this run) for the day whose weekday matches target_anga_id, so results are byte-identical to date.get_weekday().
+    """
+    if isinstance(target_anga_id, Number):
+      target_anga = Anga.get_cached(index=target_anga_id, anga_type_id=AngaType.VARA.name)
+    else:
+      target_anga = target_anga_id
+    for daily_panchaanga in self.daily_panchaangas:
+      if daily_panchaanga.jd_next_sunrise is None or daily_panchaanga.jd_next_sunrise <= jd1:
+        continue
+      if daily_panchaanga.jd_sunrise is None or daily_panchaanga.jd_sunrise >= jd2:
+        break
+      if daily_panchaanga.date.get_weekday() + 1 == target_anga.index:
+        return AngaSpan(jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, anga=target_anga)
+    return None
+
+  def _assign_anga_intersection(self, yoga_name, intersect_list, jd_start=None, jd_end=None, show_debug_info=True):
+    """ Assign a festival wherever every (anga_type, target_anga_id) pair in intersect_list simultaneously holds
+    within [jd_start, jd_end]. target_anga_id may be a single index or a list of indices (any-of / OR semantics
+    for that anga -- eg. karana in {2, 9, 16, ...}); list-valued entries are expanded by trying each candidate
+    value independently (so multiple list-valued angas in the same call are tried combinatorially).
+
+    anga_type may be AngaType.VARA (weekday), resolved via _find_vara_span rather than ecliptic search.
+    """
+    if jd_start is None:
+      jd_start = self.panchaanga.jd_start
+    if jd_end is None:
+      jd_end = self.panchaanga.jd_end
+
+    for i, (anga_type, target_anga_id) in enumerate(intersect_list):
+      if isinstance(target_anga_id, (list, tuple)):
+        any_happened = False
+        for candidate in target_anga_id:
+          expanded = list(intersect_list)
+          expanded[i] = (anga_type, candidate)
+          any_happened = self._assign_anga_intersection(
+            yoga_name, expanded, jd_start=jd_start, jd_end=jd_end, show_debug_info=show_debug_info) or any_happened
+        return any_happened
+
+    jd_start_in = jd_start
+    jd_end_in = jd_end
+    anga_list = []
+    yoga_happens = True
+    for anga_type, target_anga_id in intersect_list:
+      if anga_type == AngaType.VARA:
+        anga = self._find_vara_span(jd1=jd_start, jd2=jd_end, target_anga_id=target_anga_id)
+      else:
+        finder = zodiac.AngaSpanFinder.get_cached(ayanaamsha_id=self.ayanaamsha_id, anga_type=anga_type)
+        anga = finder.find(jd1=jd_start, jd2=jd_end, target_anga_id=target_anga_id)
+      if anga is None:
+        if show_debug_info:
+          msg = ' + '.join(['%s %s' % (intersect_list[i][0], intersect_list[i][1]) for i in range(len(intersect_list))])
+          logging.debug('No %s involving %s in span %s!' % (yoga_name, msg, Interval(jd_start=jd_start_in, jd_end=jd_end_in)))
+        yoga_happens = False
+        break
+      else:
+        if anga.jd_start is None:
+          anga.jd_start = jd_start
+        if anga.jd_end is None:
+          anga.jd_end = jd_end
+
+      if anga.jd_start is not None:
+        jd_start = anga.jd_start
+      if anga.jd_end is not None:
+        jd_end = anga.jd_end
+      anga_list.append(anga)
+
+    if yoga_happens:
+      jd_start, jd_end = max([x.jd_start for x in anga_list]), min([x.jd_end for x in anga_list])
+      if jd_start > jd_end or jd_start > self.panchaanga.jd_end:
+        if show_debug_info:
+          msg = ' + '.join(['%s %s' % (intersect_list[i][0], intersect_list[i][1]) for i in range(len(intersect_list))])
+          logging.debug('No %s involving %s in span %s!' % (msg, yoga_name, Interval(jd_start=jd_start_in, jd_end=jd_end_in)))
+      elif (jd_end - jd_start) < 1/1800:  # Less than 1 Kalā
+        if show_debug_info:
+          msg = ' + '.join(['%s %s' % (intersect_list[i][0], intersect_list[i][1]) for i in range(len(intersect_list))])
+          logging.debug('Not assigning %s involving %s in span %s due to extremely short duration (%s seconds)!' % (msg, yoga_name, Interval(jd_start=jd_start_in, jd_end=jd_end_in), (jd_end - jd_start) * 24 * 60 * 60))
+      else:
+        fday = int(floor(jd_start) - floor(self.daily_panchaangas[0].julian_day_start))
+        if jd_start < self.daily_panchaangas[fday].jd_sunrise:
+          fday -= 1
+        jd_midnight_local = self.daily_panchaangas[fday + 1].julian_day_start
+        if jd_start > jd_midnight_local and jd_end > self.daily_panchaangas[fday + 1].jd_sunrise:
+          fday += 1
+        if show_debug_info:
+          logging.debug(f'Adding {yoga_name} from {Interval(jd_start=jd_start, jd_end=jd_end)} on {self.daily_panchaangas[fday].date}')
+        self.panchaanga.add_festival_instance(festival_instance=FestivalInstance(name=yoga_name, interval=Interval(jd_start=jd_start, jd_end=jd_end)), date=self.daily_panchaangas[fday].date)
+
+    return yoga_happens
 
   @timebudget
   def assign_festival_numbers(self):

--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -6,6 +6,7 @@ from jyotisha.panchaanga.temporal import Anga, AngaType, get_2_day_interval_boun
 from jyotisha.panchaanga.temporal.festival import priority_decision
 from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
 from jyotisha.panchaanga.temporal.festival.rules import RulesRepo, resolve_vaara_index
+from jyotisha.panchaanga.temporal.interval import Interval
 
 
 # TOML-facing anga_type names for `intersection_groups`, mapped to the AngaType singletons. Kept distinct from
@@ -172,8 +173,15 @@ class RuleLookupAssigner(FestivalAssigner):
           continue
         if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
           continue
-        if target_anga is not None and daily_panchaanga.sunrise_day_angas.find_anga_span(target_anga) is None:
-          continue
+        if target_anga is not None:
+          # Bounded to daytime (sunrise..sunset), not the full sunrise..next_sunrise night-inclusive span:
+          # every hand-written festival of this shape checks "anga at sunrise OR anga at sunset" (a vrata
+          # observed during daylight), so an anga that only appears after sunset (during the night) shouldn't
+          # count -- matching find_anga_span's whole-day span would count it and diverge from the original.
+          daytime_spans = daily_panchaanga.sunrise_day_angas.get_anga_spans_in_interval(
+            anga_type=target_anga.get_type(), interval=Interval(jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_sunset))
+          if not any(span.anga == target_anga for span in daytime_spans):
+            continue
         self.panchaanga.add_festival(fest_id=fest_id, date=daily_panchaanga.date)
 
   @timebudget

--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -6,7 +6,6 @@ from jyotisha.panchaanga.temporal import Anga, AngaType, get_2_day_interval_boun
 from jyotisha.panchaanga.temporal.festival import priority_decision
 from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
 from jyotisha.panchaanga.temporal.festival.rules import RulesRepo, resolve_vaara_index
-from jyotisha.panchaanga.temporal.interval import Interval
 
 
 # TOML-facing anga_type names for `intersection_groups`, mapped to the AngaType singletons. Kept distinct from
@@ -174,12 +173,12 @@ class RuleLookupAssigner(FestivalAssigner):
         if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
           continue
         if target_anga is not None:
-          # Bounded to daytime (sunrise..sunset), not the full sunrise..next_sunrise night-inclusive span:
+          # Bounded to dinamaana (sunrise..sunset), not the full sunrise..next_sunrise night-inclusive span:
           # every hand-written festival of this shape checks "anga at sunrise OR anga at sunset" (a vrata
           # observed during daylight), so an anga that only appears after sunset (during the night) shouldn't
           # count -- matching find_anga_span's whole-day span would count it and diverge from the original.
           daytime_spans = daily_panchaanga.sunrise_day_angas.get_anga_spans_in_interval(
-            anga_type=target_anga.get_type(), interval=Interval(jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_sunset))
+            anga_type=target_anga.get_type(), interval=daily_panchaanga.day_length_based_periods.dinamaana)
           if not any(span.anga == target_anga for span in daytime_spans):
             continue
         self.panchaanga.add_festival(fest_id=fest_id, date=daily_panchaanga.date)

--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -8,6 +8,35 @@ from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
 from jyotisha.panchaanga.temporal.festival.rules import RulesRepo
 
 
+# TOML-facing anga_type names for `intersection_groups`, mapped to the AngaType singletons. Kept distinct from
+# AngaType.from_name()'s (upper-cased AngaType.name) lookup since a couple of internal names are abbreviated
+# (eg. AngaType.SOLAR_NAKSH) in ways that would be needlessly cryptic to require rule authors to know.
+_INTERSECTION_ANGA_TYPES = {
+  "tithi": AngaType.TITHI,
+  "tithi_pada": AngaType.TITHI_PADA,
+  "nakshatra": AngaType.NAKSHATRA,
+  "nakshatra_pada": AngaType.NAKSHATRA_PADA,
+  "rashi": AngaType.RASHI,
+  "yoga": AngaType.YOGA,
+  "yoga_pada": AngaType.YOGA_PADA,
+  "karana": AngaType.KARANA,
+  "vara": AngaType.VARA,
+  "solar_nakshatra": AngaType.SOLAR_NAKSH,
+  "solar_nakshatra_pada": AngaType.SOLAR_NAKSH_PADA,
+}
+
+
+def _month_matches(daily_panchaanga, month_type, month_number):
+  """month_number may be None (no filter), a single month, or a list of months (any-of)."""
+  if month_number is None:
+    return True
+  months = month_number if isinstance(month_number, (list, tuple)) else [month_number]
+  if 0 in months:
+    return True
+  day_month = daily_panchaanga.get_date(month_type=month_type).month
+  return day_month in months
+
+
 class RuleLookupAssigner(FestivalAssigner):
   def assign_varalakshmi_vratam(self):
     """ varalakSmI-vratam is set directly off zrAvaNa-pUrNimA (tithi 15 of nija zrAvaNa mAsa, decided at
@@ -108,6 +137,41 @@ class RuleLookupAssigner(FestivalAssigner):
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.TITHI)
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.NAKSHATRA)
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.YOGA)
+    self.apply_anga_intersection_events()
+
+  @timebudget
+  def apply_anga_intersection_events(self):
+    """ Apply festivals declared via `[timing] intersection_groups = [[...]]` -- multi-anga conjunctions (tithi
+    AND nakshatra AND vara ..., possibly VARA among them), the TOML-driven counterpart of the hand-written
+    intersect_list calls to FestivalAssigner._assign_anga_intersection still used in solar.py/vaara.py. See
+    apply_month_anga_events()/apply_month_day_events() above for the single-anga counterparts of this method.
+    """
+    for fest_id, fest_rule in self.rules_collection.name_to_rule.items():
+      if fest_rule.timing is None or fest_rule.timing.intersection_groups is None:
+        continue
+      groups = [
+        [(_INTERSECTION_ANGA_TYPES[item['anga_type']], item['anga_number']) for item in group['angas']]
+        for group in fest_rule.timing.intersection_groups
+      ]
+      window = fest_rule.timing.get_window()
+      if window == "full_period":
+        for group in groups:
+          self._assign_anga_intersection(fest_id, group, jd_start=self.panchaanga.jd_start, jd_end=self.panchaanga.jd_end, show_debug_info=False)
+      else:
+        for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
+          daily_panchaanga = self.daily_panchaangas[d]
+          if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
+            continue
+          if window == "sunrise_to_sunset":
+            jd_start, jd_end = daily_panchaanga.jd_sunrise, daily_panchaanga.jd_sunset
+          elif window == "sunrise_to_next_sunrise":
+            jd_start, jd_end = daily_panchaanga.jd_sunrise, daily_panchaanga.jd_next_sunrise
+          elif window == "padded_1_day":
+            jd_start, jd_end = daily_panchaanga.jd_sunrise - 1, daily_panchaanga.jd_sunset + 2
+          else:
+            raise ValueError("Unknown window %s for %s" % (window, fest_id))
+          for group in groups:
+            self._assign_anga_intersection(fest_id, group, jd_start=jd_start, jd_end=jd_end, show_debug_info=False)
 
   def apply_month_day_events(self, day_panchaanga, month_type):
     """Apply events set to take place on a given (ordinal) day of a given month. Eg. Jan 1 as per Julian calendar, Aug 15 as per Gregorian calendar, 1st day of sidereal solar month 6. See calls from apply_festival_from_rules_repos().

--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -138,6 +138,31 @@ class RuleLookupAssigner(FestivalAssigner):
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.NAKSHATRA)
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.YOGA)
     self.apply_anga_intersection_events()
+    self.apply_vara_conditioned_events()
+
+  @timebudget
+  def apply_vara_conditioned_events(self):
+    """ Apply festivals declared via `[timing] vara = N` -- a plain weekday filter, for festivals that recur on
+    every day matching (month, weekday, and optionally a single anga touching that day), with no disambiguation
+    and no anga-span search: the trivial "month/anga + weekday" shape (eg. kArttika~sOmavAsaraH: lunar month 8,
+    every Monday), as opposed to the genuine multi-anga conjunctions apply_anga_intersection_events() searches
+    for. See that method and apply_month_anga_events() above for the other two (heavier) mechanisms.
+    """
+    for fest_id, fest_rule in self.rules_collection.name_to_rule.items():
+      if fest_rule.timing is None or fest_rule.timing.vara is None:
+        continue
+      target_anga = None
+      if fest_rule.timing.anga_type is not None:
+        target_anga = Anga.get_cached(index=fest_rule.timing.anga_number, anga_type_id=_INTERSECTION_ANGA_TYPES[fest_rule.timing.anga_type].name)
+      for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
+        daily_panchaanga = self.daily_panchaangas[d]
+        if daily_panchaanga.date.get_weekday() + 1 != fest_rule.timing.vara:
+          continue
+        if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
+          continue
+        if target_anga is not None and daily_panchaanga.sunrise_day_angas.find_anga_span(target_anga) is None:
+          continue
+        self.panchaanga.add_festival(fest_id=fest_id, date=daily_panchaanga.date)
 
   @timebudget
   def apply_anga_intersection_events(self):

--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -166,6 +166,9 @@ class RuleLookupAssigner(FestivalAssigner):
       target_anga = None
       if fest_rule.timing.anga_type is not None:
         target_anga = Anga.get_cached(index=fest_rule.timing.anga_number, anga_type_id=_INTERSECTION_ANGA_TYPES[fest_rule.timing.anga_type].name)
+      touch_window = fest_rule.timing.window
+      if touch_window is not None and touch_window not in ("sunrise_to_sunset", "sunrise_to_purvaahna"):
+        raise ValueError("Unsupported window %r for vaara-conditioned rule %s (expected sunrise_to_sunset or sunrise_to_purvaahna)" % (touch_window, fest_id))
       for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
         daily_panchaanga = self.daily_panchaangas[d]
         if daily_panchaanga.date.get_weekday() + 1 != vaara_index:
@@ -173,12 +176,13 @@ class RuleLookupAssigner(FestivalAssigner):
         if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
           continue
         if target_anga is not None:
-          # Bounded to dinamaana (sunrise..sunset), not the full sunrise..next_sunrise night-inclusive span:
-          # every hand-written festival of this shape checks "anga at sunrise OR anga at sunset" (a vrata
-          # observed during daylight), so an anga that only appears after sunset (during the night) shouldn't
-          # count -- matching find_anga_span's whole-day span would count it and diverge from the original.
-          daytime_spans = daily_panchaanga.sunrise_day_angas.get_anga_spans_in_interval(
-            anga_type=target_anga.get_type(), interval=daily_panchaanga.day_length_based_periods.dinamaana)
+          # Bounded to daytime (dinamaana, sunrise..sunset, or the narrower purvaahna half of it), never the
+          # full sunrise..next_sunrise night-inclusive span: every hand-written festival of this shape checks
+          # "anga at sunrise OR anga at {sunset,purvaahna_end}" (a vrata observed during daylight, sometimes
+          # only its first half), so an anga that only appears later shouldn't count -- matching
+          # find_anga_span's whole-day span would count it and diverge from the original.
+          touch_interval = daily_panchaanga.day_length_based_periods.puurvaahna if touch_window == "sunrise_to_purvaahna" else daily_panchaanga.day_length_based_periods.dinamaana
+          daytime_spans = daily_panchaanga.sunrise_day_angas.get_anga_spans_in_interval(anga_type=target_anga.get_type(), interval=touch_interval)
           if not any(span.anga == target_anga for span in daytime_spans):
             continue
         self.panchaanga.add_festival(fest_id=fest_id, date=daily_panchaanga.date)
@@ -239,6 +243,9 @@ class RuleLookupAssigner(FestivalAssigner):
           days = [30, 31]
     fest_dict = rule_set.get_possibly_relevant_fests(month=date.month, angas=days, month_type=month_type, anga_type_id=rules.RulesRepo.DAY_DIR)
     for fest_id, fest in fest_dict.items():
+      if fest.timing.vaara is not None:
+        # See the matching guard in apply_month_anga_events: owned by apply_vaara_conditioned_events instead.
+        continue
       if month_type in [RulesRepo.GREGORIAN_MONTH_DIR, RulesRepo.JULIAN_MONTH_DIR]:
         self.panchaanga.add_festival(date=day_panchaanga.date, fest_id=fest_id, interval_id="julian_day")
       else:
@@ -339,6 +346,13 @@ class RuleLookupAssigner(FestivalAssigner):
     ###########################
     # Iterate over relevant festivals
     for fest_id, fest_rule in fest_dict.items():
+      if fest_rule.timing.vaara is not None:
+        # Owned by apply_vaara_conditioned_events instead: a rule can end up indexed into this (month_type,
+        # anga_type, month, anga) tree bucket incidentally (via get_storage_file_name's path routing) even
+        # though it also has `vaara` set and is meant to be weekday-gated -- this engine has no concept of
+        # `vaara` at all, so it must not process such rules (it would otherwise assign them on every matching
+        # day regardless of weekday, double-processing them alongside the correct, weekday-gated assignment).
+        continue
       kaala = fest_rule.timing.get_kaala()
       priority = fest_rule.timing.get_priority()
       adhika_maasa_handling = fest_rule.timing.get_adhika_maasa_handling()

--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -5,7 +5,7 @@ from timebudget import timebudget
 from jyotisha.panchaanga.temporal import Anga, AngaType, get_2_day_interval_boundary_angas
 from jyotisha.panchaanga.temporal.festival import priority_decision
 from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
-from jyotisha.panchaanga.temporal.festival.rules import RulesRepo
+from jyotisha.panchaanga.temporal.festival.rules import RulesRepo, resolve_vaara_index
 
 
 # TOML-facing anga_type names for `intersection_groups`, mapped to the AngaType singletons. Kept distinct from
@@ -20,10 +20,20 @@ _INTERSECTION_ANGA_TYPES = {
   "yoga": AngaType.YOGA,
   "yoga_pada": AngaType.YOGA_PADA,
   "karana": AngaType.KARANA,
-  "vara": AngaType.VARA,
+  "vaara": AngaType.VARA,
   "solar_nakshatra": AngaType.SOLAR_NAKSH,
   "solar_nakshatra_pada": AngaType.SOLAR_NAKSH_PADA,
 }
+
+
+def _resolve_anga_number(anga_type_str, anga_number):
+  """anga_number for anga_type="vaara" may be a name (or list of names) instead of an index; everything else
+  passes through unchanged."""
+  if anga_type_str != "vaara":
+    return anga_number
+  if isinstance(anga_number, (list, tuple)):
+    return [resolve_vaara_index(v) for v in anga_number]
+  return resolve_vaara_index(anga_number)
 
 
 def _month_matches(daily_panchaanga, month_type, month_number):
@@ -138,25 +148,27 @@ class RuleLookupAssigner(FestivalAssigner):
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.NAKSHATRA)
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.YOGA)
     self.apply_anga_intersection_events()
-    self.apply_vara_conditioned_events()
+    self.apply_vaara_conditioned_events()
 
   @timebudget
-  def apply_vara_conditioned_events(self):
-    """ Apply festivals declared via `[timing] vara = N` -- a plain weekday filter, for festivals that recur on
-    every day matching (month, weekday, and optionally a single anga touching that day), with no disambiguation
-    and no anga-span search: the trivial "month/anga + weekday" shape (eg. kArttika~sOmavAsaraH: lunar month 8,
-    every Monday), as opposed to the genuine multi-anga conjunctions apply_anga_intersection_events() searches
-    for. See that method and apply_month_anga_events() above for the other two (heavier) mechanisms.
+  def apply_vaara_conditioned_events(self):
+    """ Apply festivals declared via `[timing] vaara = ...` -- a plain weekday filter, for festivals that recur
+    on every day matching (month, weekday, and optionally a single anga touching that day), with no
+    disambiguation and no anga-span search: the trivial "month/anga + weekday" shape (eg. kArttika~sOmavAsaraH:
+    lunar month 8, every Monday), as opposed to the genuine multi-anga conjunctions
+    apply_anga_intersection_events() searches for. See that method and apply_month_anga_events() above for the
+    other two (heavier) mechanisms.
     """
     for fest_id, fest_rule in self.rules_collection.name_to_rule.items():
-      if fest_rule.timing is None or fest_rule.timing.vara is None:
+      if fest_rule.timing is None or fest_rule.timing.vaara is None:
         continue
+      vaara_index = fest_rule.timing.get_vaara_index()
       target_anga = None
       if fest_rule.timing.anga_type is not None:
         target_anga = Anga.get_cached(index=fest_rule.timing.anga_number, anga_type_id=_INTERSECTION_ANGA_TYPES[fest_rule.timing.anga_type].name)
       for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
         daily_panchaanga = self.daily_panchaangas[d]
-        if daily_panchaanga.date.get_weekday() + 1 != fest_rule.timing.vara:
+        if daily_panchaanga.date.get_weekday() + 1 != vaara_index:
           continue
         if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
           continue
@@ -167,7 +179,7 @@ class RuleLookupAssigner(FestivalAssigner):
   @timebudget
   def apply_anga_intersection_events(self):
     """ Apply festivals declared via `[timing] intersection_groups = [[...]]` -- multi-anga conjunctions (tithi
-    AND nakshatra AND vara ..., possibly VARA among them), the TOML-driven counterpart of the hand-written
+    AND nakshatra AND vaara ..., possibly VARA among them), the TOML-driven counterpart of the hand-written
     intersect_list calls to FestivalAssigner._assign_anga_intersection still used in solar.py/vaara.py. See
     apply_month_anga_events()/apply_month_day_events() above for the single-anga counterparts of this method.
     """
@@ -175,7 +187,7 @@ class RuleLookupAssigner(FestivalAssigner):
       if fest_rule.timing is None or fest_rule.timing.intersection_groups is None:
         continue
       groups = [
-        [(_INTERSECTION_ANGA_TYPES[item['anga_type']], item['anga_number']) for item in group['angas']]
+        [(_INTERSECTION_ANGA_TYPES[item['anga_type']], _resolve_anga_number(item['anga_type'], item['anga_number'])) for item in group['angas']]
         for group in fest_rule.timing.intersection_groups
       ]
       window = fest_rule.timing.get_window()

--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -334,59 +334,6 @@ class SolarFestivalAssigner(FestivalAssigner):
 
           return
 
-  def _assign_yoga(self, yoga_name, intersect_list, jd_start=None, jd_end=None, show_debug_info=True):
-    if jd_start is None:
-      jd_start = self.panchaanga.jd_start
-    if jd_end is None:
-      jd_end = self.panchaanga.jd_end
-    jd_start_in = jd_start
-    jd_end_in = jd_end
-    anga_list = []
-    yoga_happens = True
-    for anga_type, target_anga_id in intersect_list:
-      finder = zodiac.AngaSpanFinder.get_cached(ayanaamsha_id=self.computation_system.ayanaamsha_id, anga_type=anga_type)
-      anga = finder.find(jd1 = jd_start, jd2=jd_end, target_anga_id=target_anga_id)
-      if anga is None:
-        if show_debug_info:
-          msg = ' + '.join(['%s %d' % (intersect_list[i][0], intersect_list[i][1]) for i in range(len(intersect_list))])
-          logging.debug('No %s involving %s in span %s!' % (yoga_name, msg, Interval(jd_start=jd_start_in, jd_end=jd_end_in)))
-        yoga_happens = False
-        break
-      else:
-        if anga.jd_start is None:
-          anga.jd_start = jd_start
-        if anga.jd_end is None:
-          anga.jd_end = jd_end
-
-      if anga.jd_start is not None:
-        jd_start = anga.jd_start
-      if anga.jd_end is not None:
-        jd_end = anga.jd_end
-      anga_list.append(anga)
-
-    if yoga_happens:
-      jd_start, jd_end = max([x.jd_start for x in anga_list]), min([x.jd_end for x in anga_list])
-      if jd_start > jd_end or jd_start > self.panchaanga.jd_end:
-        if show_debug_info:
-          msg = ' + '.join(['%s %d' % (intersect_list[i][0], intersect_list[i][1]) for i in range(len(intersect_list))])
-          logging.debug('No %s involving %s in span %s!' % (msg, yoga_name, Interval(jd_start=jd_start_in, jd_end=jd_end_in)))
-      elif (jd_end - jd_start) < 1/1800:  # Less than 1 Kalā
-        if show_debug_info:
-          msg = ' + '.join(['%s %d' % (intersect_list[i][0], intersect_list[i][1]) for i in range(len(intersect_list))])
-          logging.debug('Not assigning %s involving %s in span %s due to extremely short duration (%s seconds)!' % (msg, yoga_name, Interval(jd_start=jd_start_in, jd_end=jd_end_in), (jd_end - jd_start) * 24 * 60 * 60))
-      else:
-        fday = int(floor(jd_start) - floor(self.daily_panchaangas[0].julian_day_start))
-        if jd_start < self.daily_panchaangas[fday].jd_sunrise:
-          fday -= 1
-        jd_midnight_local = self.daily_panchaangas[fday + 1].julian_day_start
-        if jd_start > jd_midnight_local and jd_end > self.daily_panchaangas[fday + 1].jd_sunrise:
-          fday += 1
-        if show_debug_info:
-          logging.debug(f'Adding {yoga_name} from {Interval(jd_start=jd_start, jd_end=jd_end)} on {self.daily_panchaangas[fday].date}')
-        self.panchaanga.add_festival_instance(festival_instance=FestivalInstance(name=yoga_name, interval=Interval(jd_start=jd_start, jd_end=jd_end)), date=self.daily_panchaangas[fday].date)
-
-    return yoga_happens
-
   def assign_month_day_mesha_sankraanti(self):
     if 'sauramAna-saMvatsarArambhaH' not in self.rules_collection.name_to_rule:
       return 
@@ -450,9 +397,9 @@ class SolarFestivalAssigner(FestivalAssigner):
   def assign_gajachhaya_yoga(self):
     if 'gajacchAyA-yOgaH' not in self.rules_collection.name_to_rule:
       return 
-    self._assign_yoga('gajacchAyA-yOgaH', [(zodiac.AngaType.SOLAR_NAKSH, 13), (zodiac.AngaType.NAKSHATRA, 10), (zodiac.AngaType.TITHI, 28)],
+    self._assign_anga_intersection('gajacchAyA-yOgaH', [(zodiac.AngaType.SOLAR_NAKSH, 13), (zodiac.AngaType.NAKSHATRA, 10), (zodiac.AngaType.TITHI, 28)],
                       jd_start=self.panchaanga.jd_start, jd_end=self.panchaanga.jd_end)
-    self._assign_yoga('gajacchAyA-yOgaH', [(zodiac.AngaType.SOLAR_NAKSH, 13), (zodiac.AngaType.NAKSHATRA, 13), (zodiac.AngaType.TITHI, 30)],
+    self._assign_anga_intersection('gajacchAyA-yOgaH', [(zodiac.AngaType.SOLAR_NAKSH, 13), (zodiac.AngaType.NAKSHATRA, 13), (zodiac.AngaType.TITHI, 30)],
                       jd_start=self.panchaanga.jd_start, jd_end=self.panchaanga.jd_end)
 
   def assign_pushkara_yoga(self):
@@ -480,10 +427,10 @@ class SolarFestivalAssigner(FestivalAssigner):
       wday = daily_panchaanga.date.get_weekday()
       if p_tithi is not None and wday in PUSHKARA_WDAY:
         if tp_nakshatra is not None:
-          self._assign_yoga('tripuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, tp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
+          self._assign_anga_intersection('tripuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, tp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
             jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
         if dp_nakshatra is not None:
-          self._assign_yoga('dvipuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, dp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
+          self._assign_anga_intersection('dvipuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, dp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
             jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
 
   def assign_ayushmad_bava_saumya_yoga(self):
@@ -495,7 +442,7 @@ class SolarFestivalAssigner(FestivalAssigner):
       # AYUSHMAN BAVA SAUMYA
       if self.daily_panchaangas[d].date.get_weekday() == 3:
         for karana_ID in BAVA_KARANA:
-          self._assign_yoga('AyuSmad-bava-saumya-saMyOgaH', [(zodiac.AngaType.YOGA, AYUSHMAD_YOGA), (zodiac.AngaType.KARANA, karana_ID)],
+          self._assign_anga_intersection('AyuSmad-bava-saumya-saMyOgaH', [(zodiac.AngaType.YOGA, AYUSHMAD_YOGA), (zodiac.AngaType.KARANA, karana_ID)],
                             jd_start=self.daily_panchaangas[d].jd_sunrise, jd_end=self.daily_panchaangas[d].jd_sunset, show_debug_info=False)
 
 
@@ -517,7 +464,7 @@ class SolarFestivalAssigner(FestivalAssigner):
           karana_ID = sunrise_zodiac.get_anga(zodiac.AngaType.KARANA).index
         elif sunset_zodiac.get_anga(zodiac.AngaType.KARANA).index in VISHTI:
           karana_ID = sunset_zodiac.get_anga(zodiac.AngaType.KARANA).index
-        self._assign_yoga('padmaka-yOga-puNyakAlaH', [(zodiac.AngaType.KARANA, karana_ID), (zodiac.AngaType.YOGA, 17)],
+        self._assign_anga_intersection('padmaka-yOga-puNyakAlaH', [(zodiac.AngaType.KARANA, karana_ID), (zodiac.AngaType.YOGA, 17)],
                           jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_sunset)
         # self.panchaanga.add_festival_instance(festival_instance=FestivalInstance(name='padmaka-yOga-puNyakAlaH', interval=Interval(jd_start=None, jd_end=None)), date=daily_panchaanga.date)
 
@@ -526,7 +473,7 @@ class SolarFestivalAssigner(FestivalAssigner):
             sunset_zodiac.get_anga(zodiac.AngaType.TITHI).index % 30 == 7):
         self.panchaanga.add_festival_instance(festival_instance=FestivalInstance(name='padmaka-yOgaH-2', interval=Interval(jd_start=None, jd_end=None)), date=daily_panchaanga.date)
 
-    self._assign_yoga('padmaka-yOgaH-3', [(zodiac.AngaType.SOLAR_NAKSH, 16), (zodiac.AngaType.NAKSHATRA, 3)],
+    self._assign_anga_intersection('padmaka-yOgaH-3', [(zodiac.AngaType.SOLAR_NAKSH, 16), (zodiac.AngaType.NAKSHATRA, 3)],
                       jd_start=self.panchaanga.jd_start, jd_end=self.panchaanga.jd_end)
 
   def assign_mahodaya_ardhodaya(self):
@@ -555,7 +502,7 @@ class SolarFestivalAssigner(FestivalAssigner):
       return
     for d, daily_panchaanga in enumerate(self.daily_panchaangas):
       if daily_panchaanga.lunar_date.month.index == 8 and daily_panchaanga.sunrise_day_angas.tithi_at_sunrise.index in (11, 12):
-        self._assign_yoga('cAturmAsya-vrata-pAraNa-niSiddha-yOgaH', [(zodiac.AngaType.NAKSHATRA_PADA, 108), (zodiac.AngaType.TITHI, 12)],
+        self._assign_anga_intersection('cAturmAsya-vrata-pAraNa-niSiddha-yOgaH', [(zodiac.AngaType.NAKSHATRA_PADA, 108), (zodiac.AngaType.TITHI, 12)],
                       jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_sunset)
   
   def assign_anadhyayana_dvadashi_yoga(self):
@@ -565,7 +512,7 @@ class SolarFestivalAssigner(FestivalAssigner):
         if daily_panchaanga.lunar_date.month.index in [4, 6, 8]:
           if daily_panchaanga.sunrise_day_angas.tithi_at_sunrise.index == 12 or self.daily_panchaangas[d + 1].sunrise_day_angas.tithi_at_sunrise.index == 12:
             for _nakshatra in [17, 22, 27]:
-              self._assign_yoga('anadhyAyaH~dvAdazI-yOgaH', [(zodiac.AngaType.NAKSHATRA, _nakshatra), (zodiac.AngaType.TITHI, 12)], jd_start=daily_panchaanga.jd_sunrise - 1, jd_end=daily_panchaanga.jd_sunset + 2, show_debug_info=False)
+              self._assign_anga_intersection('anadhyAyaH~dvAdazI-yOgaH', [(zodiac.AngaType.NAKSHATRA, _nakshatra), (zodiac.AngaType.TITHI, 12)], jd_start=daily_panchaanga.jd_sunrise - 1, jd_end=daily_panchaanga.jd_sunset + 2, show_debug_info=False)
 
   def assign_vaarunii_trayodashi(self):
     if 'vAruNI~trayOdazI' not in self.rules_collection.name_to_rule:
@@ -577,10 +524,10 @@ class SolarFestivalAssigner(FestivalAssigner):
       # VARUNI TRAYODASHI
       if day_panchaanga.lunar_date.month.index == 12 and (tithi_sunrise == 28 or tithi_sunset == 28):
         if day_panchaanga.date.get_weekday() == 6:
-          if not self._assign_yoga('mahAmahAvAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28), (zodiac.AngaType.YOGA, 23)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise):
-            self._assign_yoga('mahAvAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise)
+          if not self._assign_anga_intersection('mahAmahAvAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28), (zodiac.AngaType.YOGA, 23)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise):
+            self._assign_anga_intersection('mahAvAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise)
         else:
-            self._assign_yoga('vAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise)
+            self._assign_anga_intersection('vAruNI~trayOdazI', [(zodiac.AngaType.NAKSHATRA, 24), (zodiac.AngaType.TITHI, 28)], jd_start = day_panchaanga.jd_sunrise, jd_end = day_panchaanga.jd_next_sunrise)
 
   def assign_mahamagha_utsava(self):
     if 'mahAmaghOtsavaH' not in self.rules_collection.name_to_rule:

--- a/jyotisha/panchaanga/temporal/festival/applier/vaara.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/vaara.py
@@ -14,7 +14,6 @@ from sanskrit_data.schema import common
 class VaraFestivalAssigner(FestivalAssigner):
   def assign_all(self):
     self.assign_bhriguvara_subrahmanya_vratam()
-    self.assign_masa_vara_yoga_kaarttika()
     self.assign_masa_vara_yoga_fests_tn()
     self.assign_nakshatra_vara_yoga_vratam()
     self.assign_tithi_vara_yoga_mangala_angaaraka()
@@ -44,16 +43,6 @@ class VaraFestivalAssigner(FestivalAssigner):
           else:
             self.panchaanga.add_festival(fest_id=festival_name, date=day_panchaanga.date)
 
-
-  def assign_masa_vara_yoga_kaarttika(self):
-    festival_name = 'kArttika~sOmavAsaraH'
-    if festival_name not in self.rules_collection.name_to_rule:
-      return
-    for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
-
-      # KRTTIKA SOMAVASARA
-      if self.daily_panchaangas[d].lunar_date.month.index == 8 and self.daily_panchaangas[d].date.get_weekday() == 1:
-        self.panchaanga.add_festival(fest_id='kArttika~sOmavAsaraH', date=self.daily_panchaangas[d].date)
 
   def assign_masa_vara_yoga_fests_tn(self):
     festival_name = 'AvaNi~JAyir2r2ukkizhamai'

--- a/jyotisha/panchaanga/temporal/festival/applier/vaara.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/vaara.py
@@ -15,7 +15,6 @@ class VaraFestivalAssigner(FestivalAssigner):
   def assign_all(self):
     self.assign_bhriguvara_subrahmanya_vratam()
     self.assign_nakshatra_vara_yoga_vratam()
-    self.assign_tithi_vara_yoga_mangala_angaaraka()
     self.assign_tithi_vara_yoga_kRSNAGgAraka()
     self.assign_vara_yoga_yoga_vratam()
     self.assign_tithi_vara_yoga_budhaaShTamii()
@@ -42,18 +41,6 @@ class VaraFestivalAssigner(FestivalAssigner):
           else:
             self.panchaanga.add_festival(fest_id=festival_name, date=day_panchaanga.date)
 
-
-  def assign_tithi_vara_yoga_mangala_angaaraka(self):
-    if 'aGgArakI~caturthI' not in self.rules_collection.name_to_rule:
-      return
-    for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
-      # MANGALA-CHATURTHI
-      tithi_sunset = self.daily_panchaangas[d].sunrise_day_angas.get_anga_at_jd(jd=self.daily_panchaangas[d].jd_sunset, anga_type=AngaType.TITHI) % 15
-      if self.daily_panchaangas[d].date.get_weekday() == 2 and (self.daily_panchaangas[d].sunrise_day_angas.tithi_at_sunrise.index % 15 == 4 or tithi_sunset == 4):
-        festival_name = 'aGgArakI~caturthI'
-        if self.daily_panchaangas[d].sunrise_day_angas.tithi_at_sunrise.index == 4 or tithi_sunset == 4:
-          festival_name = 'sukhA' + '~' + festival_name
-        self.panchaanga.add_festival(fest_id=festival_name, date=self.daily_panchaangas[d].date)
 
   def assign_tithi_vara_yoga_kRSNAGgAraka(self):
     if 'kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam' not in self.rules_collection.name_to_rule:

--- a/jyotisha/panchaanga/temporal/festival/applier/vaara.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/vaara.py
@@ -15,7 +15,6 @@ class VaraFestivalAssigner(FestivalAssigner):
   def assign_all(self):
     self.assign_bhriguvara_subrahmanya_vratam()
     self.assign_nakshatra_vara_yoga_vratam()
-    self.assign_tithi_vara_yoga_kRSNAGgAraka()
     self.assign_vara_yoga_yoga_vratam()
     self.assign_tithi_vara_yoga_budhaaShTamii()
     self.assign_vishesha_mahashivaratri()
@@ -41,19 +40,6 @@ class VaraFestivalAssigner(FestivalAssigner):
           else:
             self.panchaanga.add_festival(fest_id=festival_name, date=day_panchaanga.date)
 
-
-  def assign_tithi_vara_yoga_kRSNAGgAraka(self):
-    if 'kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam' not in self.rules_collection.name_to_rule:
-      return
-    for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
-      # KRISHNA ANGARAKA CHATURDASHI
-      tithi_sunrise = self.daily_panchaangas[d].sunrise_day_angas.tithi_at_sunrise.index
-      tithi_purvaahna_end = self.daily_panchaangas[d].sunrise_day_angas.get_anga_at_jd(jd=self.daily_panchaangas[d].day_length_based_periods.puurvaahna.jd_end, anga_type=AngaType.TITHI).index
-      if self.daily_panchaangas[d].date.get_weekday() == 2 and (tithi_sunrise == 29 or tithi_purvaahna_end == 29):
-        # Double-check rule. When should the vyApti be? Since Smriti Muktaphalam says सदैव वा, we can at least stretch to the end of purvAahna.
-        self.panchaanga.add_festival(fest_id='kRSNAGgAraka-caturdazI-puNyakAlaH or yamatarpaNam', date=self.daily_panchaangas[d].date)
-        if self.daily_panchaangas[d].lunar_date.month.index == 1:
-          self.panchaanga.add_festival(fest_id='pizAcamOcanam', date=self.daily_panchaangas[d].date)
 
   def assign_vishesha_mahashivaratri(self):
     if 'mahAzivarAtriH' not in self.rules_collection.name_to_rule:

--- a/jyotisha/panchaanga/temporal/festival/applier/vaara.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/vaara.py
@@ -14,7 +14,6 @@ from sanskrit_data.schema import common
 class VaraFestivalAssigner(FestivalAssigner):
   def assign_all(self):
     self.assign_bhriguvara_subrahmanya_vratam()
-    self.assign_masa_vara_yoga_fests_tn()
     self.assign_nakshatra_vara_yoga_vratam()
     self.assign_tithi_vara_yoga_mangala_angaaraka()
     self.assign_tithi_vara_yoga_kRSNAGgAraka()
@@ -43,21 +42,6 @@ class VaraFestivalAssigner(FestivalAssigner):
           else:
             self.panchaanga.add_festival(fest_id=festival_name, date=day_panchaanga.date)
 
-
-  def assign_masa_vara_yoga_fests_tn(self):
-    festival_name = 'AvaNi~JAyir2r2ukkizhamai'
-    if festival_name not in self.rules_collection.name_to_rule:
-      return
-    for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
-      # SOLAR MONTH-WEEKDAY FESTIVALS
-      for (mwd_fest_m, mwd_fest_wd, mwd_fest_name) in ((5, 0, 'AvaNi~JAyir2r2ukkizhamai'),
-                                                       (6, 6, 'puraTTAci~can2ikkizhamai'),
-                                                       (8, 0, 'kArttigai~JAyir2r2ukkizhamai'),
-                                                       (4, 5, 'ADi~veLLikkizhamai'),
-                                                       (10, 5, 'tai~veLLikkizhamai'),
-                                                       (11, 2, 'mAci~cevvAy')):
-        if self.daily_panchaangas[d].solar_sidereal_date_sunset.month == mwd_fest_m and self.daily_panchaangas[d].date.get_weekday() == mwd_fest_wd:
-          self.panchaanga.add_festival(fest_id=mwd_fest_name, date=self.daily_panchaangas[d].date)
 
   def assign_tithi_vara_yoga_mangala_angaaraka(self):
     if 'aGgArakI~caturthI' not in self.rules_collection.name_to_rule:

--- a/jyotisha/panchaanga/temporal/festival/rules/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/rules/__init__.py
@@ -94,6 +94,35 @@ class HinduCalendarEventTiming(common.JsonObject):
         "type": "integer",
         "description": "A festival may be 8 days before some other event xyz. The 8 is stored here.",
       },
+      "intersection_groups": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "angas": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "anga_type": {
+                    "type": "string",
+                    "description": "An AngaType name (eg. \"tithi\", \"nakshatra\", \"yoga\", \"karana\", \"vara\", \"solar_nakshatra\", \"nakshatra_pada\"), lower-cased.",
+                  },
+                  "anga_number": {
+                    "description": "Either a single anga index, or a list of indices (any-of / OR semantics).",
+                  },
+                },
+              },
+            },
+          },
+        },
+        "description": "A multi-anga conjunction (traditionally called a yoga): each entry's `angas` list is a group of angas that must ALL simultaneously hold (AND, within `window`); the festival is assigned wherever ANY one group is satisfied (OR across groups) -- most rules only need a single group. Mutually exclusive with anga_type/anga_number above.",
+      },
+      "window": {
+        "type": "string",
+        "enum": ["full_period", "sunrise_to_sunset", "sunrise_to_next_sunrise", "padded_1_day"],
+        "description": "Only used together with `intersection_groups`. Bounds to search for the conjunction within: the whole computed period, a single day's sunrise-to-sunset/sunrise-to-next-sunrise, or a day padded by 1 day on each side (for conjunctions that may straddle a day boundary). Defaults to full_period.",
+      },
     }
   }))
 
@@ -118,6 +147,9 @@ class HinduCalendarEventTiming(common.JsonObject):
 
   def get_priority(self):
     return "puurvaviddha" if self.priority is None else self.priority
+
+  def get_window(self):
+    return "full_period" if self.window is None else self.window
 
   def get_adhika_maasa_handling(self):
     if self.month_type == RulesRepo.LUNAR_MONTH_DIR:
@@ -206,6 +238,10 @@ class HinduCalendarEvent(common.JsonObject):
         offset=self.timing.offset,
         id=self.id
       )
+    elif self.timing.intersection_groups is not None:
+      # Intersection (multi-anga conjunction) rules aren't keyed by a single (month_type, anga_type, month,
+      # anga) slot, so they don't fit the tree-indexed path below; store them flatly by id instead.
+      path = "yoga_intersections/%(id)s.toml" % dict(id=self.id)
     elif self.timing is None or self.timing.month_number is None:
       path = "description_only/%(id)s.toml" % dict(
         id=self.id

--- a/jyotisha/panchaanga/temporal/festival/rules/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/rules/__init__.py
@@ -32,6 +32,42 @@ def transliterate_quoted_text(text, script):
   return transliterated_text
 
 
+# Plain-spelling aliases that HK-Dravidian transliteration (see _build_vaara_name_to_index) doesn't produce
+# directly -- eg. its "maGgalaH"/"zukraH"/"zaniH"/"bhRguH" lower/strip to "maggala"/"zukra"/"zani"/"bhrgu",
+# not the common spellings below -- so these are added on top rather than derived.
+_VAARA_COMMON_SPELLING_ALIASES = {"mangala": 3, "shukra": 6, "shani": 7, "bhrigu": 6}
+
+
+def _build_vaara_name_to_index():
+  """Accepted names for AngaType.VARA's 1=Sunday..7=Saturday index (so a TOML rule can write eg.
+  `vaara = "budha"` instead of a bare number), built from the same VARA_NAMES/VARA_NAMES_ALT data
+  AngaType.VARA's own names_dict is built from (see zodiac/angas.py), so the accepted spellings stay in sync
+  with what the codebase already considers each weekday's name(s) to be -- plus a few common plain-English
+  spellings (_VAARA_COMMON_SPELLING_ALIASES) that the HK-Dravidian-derived forms don't cover."""
+  primary = names.NAMES['VARA_NAMES']['sa']['hk_dravidian']
+  alt = names.NAMES['VARA_NAMES_ALT']['sa']['hk_dravidian']
+  name_to_index = {}
+  for index_0based, (p, a) in enumerate(zip(primary, alt)):
+    for name in (p, a):
+      name_to_index[name.rstrip('H').lower()] = index_0based + 1
+  name_to_index.update(_VAARA_COMMON_SPELLING_ALIASES)
+  return name_to_index
+
+
+VAARA_NAME_TO_INDEX = _build_vaara_name_to_index()
+
+
+def resolve_vaara_index(value):
+  """Resolve a `vaara` (or an intersection_groups `anga_number` for anga_type="vaara") value -- either an int
+  (1=Sunday..7=Saturday) or one of VAARA_NAME_TO_INDEX's names (case-insensitive) -- to that integer index."""
+  if value is None or isinstance(value, int):
+    return value
+  key = value.strip().lower()
+  if key not in VAARA_NAME_TO_INDEX:
+    raise ValueError("Unrecognized vaara name %r (expected an int 1-7, or one of %s)" % (value, sorted(VAARA_NAME_TO_INDEX)))
+  return VAARA_NAME_TO_INDEX[key]
+
+
 def clean_id(id):
   id = id.replace('/','__').strip('{}')
   id = regex.sub(" +", "_", id)
@@ -106,10 +142,10 @@ class HinduCalendarEventTiming(common.JsonObject):
                 "properties": {
                   "anga_type": {
                     "type": "string",
-                    "description": "An AngaType name (eg. \"tithi\", \"nakshatra\", \"yoga\", \"karana\", \"vara\", \"solar_nakshatra\", \"nakshatra_pada\"), lower-cased.",
+                    "description": "An AngaType name (eg. \"tithi\", \"nakshatra\", \"yoga\", \"karana\", \"vaara\", \"solar_nakshatra\", \"nakshatra_pada\"), lower-cased.",
                   },
                   "anga_number": {
-                    "description": "Either a single anga index, or a list of indices (any-of / OR semantics).",
+                    "description": "Either a single anga index, or a list of indices (any-of / OR semantics). For anga_type=\"vaara\", a name (eg. \"budha\") is also accepted instead of an index -- see VAARA_NAME_TO_INDEX.",
                   },
                 },
               },
@@ -123,9 +159,8 @@ class HinduCalendarEventTiming(common.JsonObject):
         "enum": ["full_period", "sunrise_to_sunset", "sunrise_to_next_sunrise", "padded_1_day"],
         "description": "Only used together with `intersection_groups`. Bounds to search for the conjunction within: the whole computed period, a single day's sunrise-to-sunset/sunrise-to-next-sunrise, or a day padded by 1 day on each side (for conjunctions that may straddle a day boundary). Defaults to full_period.",
       },
-      "vara": {
-        "type": "integer",
-        "description": "A weekday filter (1=Sunday...7=Saturday, matching AngaType.VARA's index convention): the festival recurs on every day within `month_type`/`month_number` (and, if `anga_type`/`anga_number` are also set, touching that single anga) whose weekday matches. Unlike `intersection_groups`, this is a plain per-day predicate over already-known daily facts -- no search. Mutually exclusive with `intersection_groups`.",
+      "vaara": {
+        "description": "A weekday filter: either an int (1=Sunday...7=Saturday, matching AngaType.VARA's index convention) or a name (eg. \"budha\", \"saumya\" -- see VAARA_NAME_TO_INDEX for all accepted names/aliases). The festival recurs on every day within `month_type`/`month_number` (and, if `anga_type`/`anga_number` are also set, touching that single anga) whose weekday matches. Unlike `intersection_groups`, this is a plain per-day predicate over already-known daily facts -- no search. Mutually exclusive with `intersection_groups`.",
       },
     }
   }))
@@ -154,6 +189,9 @@ class HinduCalendarEventTiming(common.JsonObject):
 
   def get_window(self):
     return "full_period" if self.window is None else self.window
+
+  def get_vaara_index(self):
+    return resolve_vaara_index(self.vaara)
 
   def get_adhika_maasa_handling(self):
     if self.month_type == RulesRepo.LUNAR_MONTH_DIR:
@@ -246,9 +284,9 @@ class HinduCalendarEvent(common.JsonObject):
       # Intersection (multi-anga conjunction) rules aren't keyed by a single (month_type, anga_type, month,
       # anga) slot, so they don't fit the tree-indexed path below; store them flatly by id instead.
       path = "yoga_intersections/%(id)s.toml" % dict(id=self.id)
-    elif self.timing.vara is not None and self.timing.anga_type is None:
+    elif self.timing.vaara is not None and self.timing.anga_type is None:
       # A plain month+weekday rule (no single anga) likewise doesn't fit the anga_type/anga_number-indexed path.
-      path = "vara_conditioned/%(id)s.toml" % dict(id=self.id)
+      path = "vaara_conditioned/%(id)s.toml" % dict(id=self.id)
     elif self.timing is None or self.timing.month_number is None:
       path = "description_only/%(id)s.toml" % dict(
         id=self.id

--- a/jyotisha/panchaanga/temporal/festival/rules/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/rules/__init__.py
@@ -156,8 +156,8 @@ class HinduCalendarEventTiming(common.JsonObject):
       },
       "window": {
         "type": "string",
-        "enum": ["full_period", "sunrise_to_sunset", "sunrise_to_next_sunrise", "padded_1_day"],
-        "description": "Only used together with `intersection_groups`. Bounds to search for the conjunction within: the whole computed period, a single day's sunrise-to-sunset/sunrise-to-next-sunrise, or a day padded by 1 day on each side (for conjunctions that may straddle a day boundary). Defaults to full_period.",
+        "enum": ["full_period", "sunrise_to_sunset", "sunrise_to_next_sunrise", "sunrise_to_purvaahna", "padded_1_day"],
+        "description": "With `intersection_groups`: bounds to search the conjunction within (full_period/sunrise_to_sunset/sunrise_to_next_sunrise/padded_1_day; defaults to full_period). With `vaara` + `anga_type`/`anga_number`: bounds the \"does the anga touch today\" check (sunrise_to_sunset [dinamaana] or sunrise_to_purvaahna; defaults to sunrise_to_sunset).",
       },
       "vaara": {
         "description": "A weekday filter: either an int (1=Sunday...7=Saturday, matching AngaType.VARA's index convention) or a name (eg. \"budha\", \"saumya\" -- see VAARA_NAME_TO_INDEX for all accepted names/aliases). The festival recurs on every day within `month_type`/`month_number` (and, if `anga_type`/`anga_number` are also set, touching that single anga) whose weekday matches. Unlike `intersection_groups`, this is a plain per-day predicate over already-known daily facts -- no search. Mutually exclusive with `intersection_groups`.",

--- a/jyotisha/panchaanga/temporal/festival/rules/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/rules/__init__.py
@@ -123,6 +123,10 @@ class HinduCalendarEventTiming(common.JsonObject):
         "enum": ["full_period", "sunrise_to_sunset", "sunrise_to_next_sunrise", "padded_1_day"],
         "description": "Only used together with `intersection_groups`. Bounds to search for the conjunction within: the whole computed period, a single day's sunrise-to-sunset/sunrise-to-next-sunrise, or a day padded by 1 day on each side (for conjunctions that may straddle a day boundary). Defaults to full_period.",
       },
+      "vara": {
+        "type": "integer",
+        "description": "A weekday filter (1=Sunday...7=Saturday, matching AngaType.VARA's index convention): the festival recurs on every day within `month_type`/`month_number` (and, if `anga_type`/`anga_number` are also set, touching that single anga) whose weekday matches. Unlike `intersection_groups`, this is a plain per-day predicate over already-known daily facts -- no search. Mutually exclusive with `intersection_groups`.",
+      },
     }
   }))
 
@@ -242,6 +246,9 @@ class HinduCalendarEvent(common.JsonObject):
       # Intersection (multi-anga conjunction) rules aren't keyed by a single (month_type, anga_type, month,
       # anga) slot, so they don't fit the tree-indexed path below; store them flatly by id instead.
       path = "yoga_intersections/%(id)s.toml" % dict(id=self.id)
+    elif self.timing.vara is not None and self.timing.anga_type is None:
+      # A plain month+weekday rule (no single anga) likewise doesn't fit the anga_type/anga_number-indexed path.
+      path = "vara_conditioned/%(id)s.toml" % dict(id=self.id)
     elif self.timing is None or self.timing.month_number is None:
       path = "description_only/%(id)s.toml" % dict(
         id=self.id

--- a/jyotisha/panchaanga/temporal/zodiac/angas.py
+++ b/jyotisha/panchaanga/temporal/zodiac/angas.py
@@ -19,6 +19,7 @@ class AngaType(common.JsonObject):
   RASHI = None
   YOGA = None
   KARANA = None
+  VARA = None
   TROPICAL_MONTH = None
   SOLAR_NAKSH = None
   SOLAR_NAKSH_PADA = None
@@ -87,6 +88,13 @@ AngaType.RASHI = AngaType(name='RASHI', name_hk="rAziH", num_angas=12, body_weig
 AngaType.YOGA = AngaType(name='YOGA', name_hk="yOgaH", num_angas=27, body_weights={Graha.MOON: 1, Graha.SUN: 1}, mean_period_days=29.541)
 AngaType.YOGA_PADA = AngaType(name='YOGA_PADA', name_hk="yOga-pAdaH", num_angas=108, body_weights={Graha.MOON: 1, Graha.SUN: 1}, mean_period_days=29.541)
 AngaType.KARANA = AngaType(name='KARANA', name_hk="karaNam", num_angas=60, body_weights={Graha.MOON: 1, Graha.SUN: -1}, mean_period_days=29.4)
+# VARA (weekday) is not ecliptic-derived (no body_weights): it's a civil-calendar property, resolved from
+# daily_panchaanga.date.get_weekday() rather than by AngaSpanFinder's brentq-based longitude search (see
+# FestivalAssigner._find_vara_span). Index is 1=Sunday...7=Saturday (weekday()+1) rather than the 0-indexed
+# convention VARA_NAMES itself uses, so as to satisfy Anga's "index starts at 1" invariant (its __add__/__sub__
+# modular arithmetic assumes a 1..num_angas range); the names_dict below is shifted accordingly.
+AngaType.VARA = AngaType(name='VARA', name_hk="vAraH", num_angas=7, mean_period_days=7,
+                          names_dict={script: [None] + list(values) for script, values in names.NAMES['VARA_NAMES']['sa'].items()})
 AngaType.TROPICAL_MONTH = AngaType(name='TROPICAL_MONTH', name_hk="Artava-mAsaH", num_angas=12, body_weights={Graha.MOON: 0, Graha.SUN: 1}, mean_period_days=365.242)
 AngaType.SOLAR_NAKSH = AngaType(name='SOLAR_NAKSH', name_hk="saura-nakSatram", num_angas=27, body_weights={Graha.MOON: 0, Graha.SUN: 1}, mean_period_days=365.242)
 AngaType.SOLAR_NAKSH_PADA = AngaType(name='SOLAR_NAKSH_PADA', name_hk="saura-nakSatra-pAdaH", num_angas=108, body_weights={Graha.MOON: 0, Graha.SUN: 1}, mean_period_days=365.242)

--- a/jyotisha_tests/temporal/festival/applier/anga_intersection_test.py
+++ b/jyotisha_tests/temporal/festival/applier/anga_intersection_test.py
@@ -1,0 +1,101 @@
+import pytest
+
+from jyotisha.panchaanga.spatio_temporal import City, periodical
+from jyotisha.panchaanga.temporal import ComputationSystem
+from jyotisha.panchaanga.temporal.festival import rules
+from jyotisha.panchaanga.temporal.festival.applier.solar import SolarFestivalAssigner
+from jyotisha.panchaanga.temporal.festival.rules import HinduCalendarEvent
+from jyotisha.panchaanga.temporal.time import Date
+from jyotisha.panchaanga.temporal.zodiac.angas import AngaType
+
+chennai = City.get_city_from_db('Chennai')
+
+
+def _rules_collection():
+  computation_system = ComputationSystem.DEFAULT
+  return rules.RulesCollection.get_cached(
+    repos_tuple=tuple(computation_system.festival_options.repos),
+    julian_handling=computation_system.festival_options.julian_handling)
+
+
+def test_vara_span_matches_get_weekday():
+  """AngaType.VARA span-finding (day-granularity, sunrise-anchored) must agree exactly with
+  daily_panchaanga.date.get_weekday(), the source of truth used everywhere else in the codebase."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2024, 1, 1), end_date=Date(2024, 1, 14),
+                                      computation_system=computation_system)
+  assigner = SolarFestivalAssigner(panchaanga)
+  for target_index in range(1, 8):
+    span = assigner._find_vara_span(jd1=panchaanga.jd_start, jd2=panchaanga.jd_end, target_anga_id=target_index)
+    assert span is not None, target_index
+    matches = [dp for dp in assigner.daily_panchaangas
+               if dp.jd_sunrise == span.jd_start and dp.jd_next_sunrise == span.jd_end]
+    assert len(matches) == 1
+    assert matches[0].date.get_weekday() + 1 == target_index
+
+
+def test_anga_intersection_or_list_and_vara():
+  """_assign_anga_intersection: a VARA condition, combined with a list-valued (OR) anga, should find a match
+  wherever the true value is among the candidates -- the OR-list mechanism several rules need (eg.
+  assign_ayushmad_bava_saumya_yoga's `for karana_ID in BAVA_KARANA: ...` hand-loop). Uses a real day's actual
+  tithi/weekday (deterministic) rather than searching for a rare astronomical coincidence, plus a decoy
+  alternative in the OR-list to prove it isn't just matching the first candidate."""
+  # Note: end_date is deliberately not near a lunar-month-4/6/8 boundary ~30 days out, to avoid an unrelated
+  # pre-existing off-by-one in assign_anadhyayana_dvadashi_yoga (solar.py:511-513, `daily_panchaangas[d + 1]`
+  # on the very last enumerated day) that this refactor doesn't touch and isn't the concern of this test.
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2018, 4, 1), end_date=Date(2018, 4, 30),
+                                      computation_system=computation_system)
+  assigner = SolarFestivalAssigner(panchaanga)
+  target_day = assigner.daily_panchaangas[panchaanga.duration_prior_padding + 3]
+  actual_tithi = target_day.sunrise_day_angas.tithi_at_sunrise.index
+  actual_vara = target_day.date.get_weekday() + 1
+  decoy_tithi = (actual_tithi % 30) + 1  # guaranteed different from actual_tithi
+
+  assigner._assign_anga_intersection(
+    'test~or-list', [(AngaType.VARA, actual_vara), (AngaType.TITHI, [decoy_tithi, actual_tithi])],
+    jd_start=target_day.jd_sunrise, jd_end=target_day.jd_next_sunrise, show_debug_info=False)
+
+  assert panchaanga.festival_id_to_days.get('test~or-list', set()) == {target_day.date}
+
+  # A VARA value that does NOT match today should not assign anything.
+  wrong_vara = (actual_vara % 7) + 1
+  assigner._assign_anga_intersection(
+    'test~or-list-no-match', [(AngaType.VARA, wrong_vara), (AngaType.TITHI, actual_tithi)],
+    jd_start=target_day.jd_sunrise, jd_end=target_day.jd_next_sunrise, show_debug_info=False)
+  assert panchaanga.festival_id_to_days.get('test~or-list-no-match', set()) == set()
+
+
+def test_apply_anga_intersection_events_from_toml():
+  """End-to-end: a TOML rule using `intersection_groups` (the real gajacchAyA-yOgaH conditions, under a test id)
+  should, via apply_anga_intersection_events, assign the festival on exactly the same days as calling
+  _assign_anga_intersection directly with the same two intersect_lists (what assign_gajachhaya_yoga does)."""
+  collection = _rules_collection()
+  test_id = 'test~gajacchAyA-yOgaH'
+  assert test_id not in collection.name_to_rule
+  event = HinduCalendarEvent(id=test_id)
+  event.timing = rules.HinduCalendarEventTiming()
+  event.timing.window = "full_period"
+  event.timing.intersection_groups = [
+    {"angas": [{"anga_type": "solar_nakshatra", "anga_number": 13}, {"anga_type": "nakshatra", "anga_number": 10}, {"anga_type": "tithi", "anga_number": 28}]},
+    {"angas": [{"anga_type": "solar_nakshatra", "anga_number": 13}, {"anga_type": "nakshatra", "anga_number": 13}, {"anga_type": "tithi", "anga_number": 30}]},
+  ]
+  collection.name_to_rule[test_id] = event
+  try:
+    computation_system = ComputationSystem.DEFAULT
+    panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2018, 1, 1), end_date=Date(2023, 12, 31),
+                                        computation_system=computation_system)
+    assigner = SolarFestivalAssigner(panchaanga)
+    assigner._assign_anga_intersection('test~gajacchAyA-direct', [(AngaType.SOLAR_NAKSH, 13), (AngaType.NAKSHATRA, 10), (AngaType.TITHI, 28)],
+                                        jd_start=panchaanga.jd_start, jd_end=panchaanga.jd_end, show_debug_info=False)
+    assigner._assign_anga_intersection('test~gajacchAyA-direct', [(AngaType.SOLAR_NAKSH, 13), (AngaType.NAKSHATRA, 13), (AngaType.TITHI, 30)],
+                                        jd_start=panchaanga.jd_start, jd_end=panchaanga.jd_end, show_debug_info=False)
+
+    toml_days = panchaanga.festival_id_to_days.get(test_id, set())
+    direct_days = panchaanga.festival_id_to_days.get('test~gajacchAyA-direct', set())
+    assert len(direct_days) > 0
+    assert toml_days == direct_days
+    # And it should agree with the real (unconverted) production festival too.
+    assert toml_days == panchaanga.festival_id_to_days.get('gajacchAyA-yOgaH', set())
+  finally:
+    del collection.name_to_rule[test_id]

--- a/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
+++ b/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
@@ -93,3 +93,38 @@ def test_angaaraki_caturthi():
   plain_days = set(panchaanga.festival_id_to_days.get('aGgArakI~caturthI', set()))
   assert Date(2015, 9, 1) in plain_days  # tithi 18->19 at sunset -- old code mislabeled this sukhA~
   assert Date(2016, 4, 26) in plain_days  # tithi 19 all day -- likewise mislabeled
+
+
+def test_krsnaangaaraka_caturdashi_and_pizaacamocanam():
+  """kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam (tithi 29, vaara=mangala) / pizAcamOcanam (same, but only
+  in lunar month 1). Two things distinguish this from aGgArakI~caturthI:
+
+  1. Its "does the anga touch" window is sunrise..purvaahna_end (first half of daytime), not the full
+     sunrise..sunset dinamaana -- so it exercises the window="sunrise_to_purvaahna" option.
+  2. pizAcamOcanam sets anga_type/anga_number/month_type/month_number *and* vaara together, which surfaced a
+     real bug: apply_month_anga_events (the pre-existing single-anga engine, which knows nothing about `vaara`)
+     was independently picking up and assigning any such rule via its own tree-indexed lookup, double-processing
+     it alongside the correct, weekday-gated assignment from apply_vaara_conditioned_events -- assigning it on
+     every matching-tithi day regardless of weekday. apply_month_anga_events/apply_month_day_events now skip any
+     rule with `vaara` set, since it's owned by apply_vaara_conditioned_events instead."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2015, 1, 1), end_date=Date(2020, 12, 31),
+                                      computation_system=computation_system)
+  daily_panchaangas = panchaanga.daily_panchaangas_sorted()
+
+  expected = {'kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam': set(), 'pizAcamOcanam': set()}
+  for d in range(panchaanga.duration_prior_padding, panchaanga.duration + panchaanga.duration_prior_padding):
+    dp = daily_panchaangas[d]
+    if dp.date.get_weekday() != 2:
+      continue
+    tithi_sunrise = dp.sunrise_day_angas.tithi_at_sunrise.index
+    tithi_purvaahna_end = dp.sunrise_day_angas.get_anga_at_jd(jd=dp.day_length_based_periods.puurvaahna.jd_end, anga_type=AngaType.TITHI).index
+    if tithi_sunrise == 29 or tithi_purvaahna_end == 29:
+      expected['kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam'].add(dp.date)
+      if dp.lunar_date.month.index == 1:
+        expected['pizAcamOcanam'].add(dp.date)
+
+  for fest_id in expected:
+    assert len(expected[fest_id]) > 0, fest_id
+    assert set(panchaanga.festival_id_to_days.get(fest_id, set())) == expected[fest_id], fest_id
+    assert all(d.get_weekday() == 2 for d in panchaanga.festival_id_to_days[fest_id]), fest_id

--- a/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
+++ b/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
@@ -2,6 +2,7 @@ from jyotisha.panchaanga.spatio_temporal import City, periodical
 from jyotisha.panchaanga.temporal import ComputationSystem
 from jyotisha.panchaanga.temporal.festival.rules import resolve_vaara_index
 from jyotisha.panchaanga.temporal.time import Date
+from jyotisha.panchaanga.temporal.zodiac import AngaType
 
 chennai = City.get_city_from_db('Chennai')
 
@@ -60,3 +61,35 @@ def test_masa_vara_yoga_fests_tn():
     assert len(new_days) > 4, fest_id
     assert new_days == old_days, fest_id
     assert all(d.get_weekday() == weekday for d in new_days), fest_id
+
+
+def test_angaaraki_caturthi():
+  """aGgArakI~caturthI / sukhA~aGgArakI~caturthI: tithi 19 (krishna) / tithi 4 (shukla) touching the day, on a
+  Tuesday. The original Python (VaraFestivalAssigner.assign_tithi_vara_yoga_mangala_angaaraka, now retired) had
+  a latent bug: its "is it shukla" name check reused a variable already reduced mod 15, so a krishna-caturthi
+  (tithi 19) touching sunset specifically (19 % 15 == 4) was misnamed sukhA~ (documented as shukla-paksha only).
+  This conversion fixes that by matching on the true tithi index (4 vs 19) via two separate TOML rules, so it is
+  compared against a *corrected* reference computation, not the original buggy one -- with 2015-09-01 and
+  2016-04-26 (both real krishna-caturthi-on-Tuesday dates the old code mislabeled) checked explicitly."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2015, 1, 1), end_date=Date(2020, 12, 31),
+                                      computation_system=computation_system)
+  daily_panchaangas = panchaanga.daily_panchaangas_sorted()
+
+  expected = {'aGgArakI~caturthI': set(), 'sukhA~aGgArakI~caturthI': set()}
+  for d in range(panchaanga.duration_prior_padding, panchaanga.duration + panchaanga.duration_prior_padding):
+    dp = daily_panchaangas[d]
+    if dp.date.get_weekday() != 2:
+      continue
+    tithi_sunrise = dp.sunrise_day_angas.tithi_at_sunrise.index
+    tithi_sunset = dp.sunrise_day_angas.get_anga_at_jd(jd=dp.jd_sunset, anga_type=AngaType.TITHI).index
+    if tithi_sunrise % 15 == 4 or tithi_sunset % 15 == 4:
+      name = 'sukhA~aGgArakI~caturthI' if (tithi_sunrise == 4 or tithi_sunset == 4) else 'aGgArakI~caturthI'
+      expected[name].add(dp.date)
+
+  for fest_id in expected:
+    assert set(panchaanga.festival_id_to_days.get(fest_id, set())) == expected[fest_id], fest_id
+
+  plain_days = set(panchaanga.festival_id_to_days.get('aGgArakI~caturthI', set()))
+  assert Date(2015, 9, 1) in plain_days  # tithi 18->19 at sunset -- old code mislabeled this sukhA~
+  assert Date(2016, 4, 26) in plain_days  # tithi 19 all day -- likewise mislabeled

--- a/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
+++ b/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
@@ -35,3 +35,28 @@ def test_kaarttika_somavaasara():
   assert len(new_days) > 4  # recurs weekly through most of Kartika, across 3 years -- not just once per year
   assert new_days == old_days
   assert all(d.get_weekday() == 1 for d in new_days)
+
+
+def test_masa_vara_yoga_fests_tn():
+  """The 6 solar-month + weekday Tamil festivals (assign_masa_vara_yoga_fests_tn, now retired) -- same
+  month_type=sidereal_solar_month + vaara shape as kArttika~sOmavAsaraH, just keyed on the solar month."""
+  FESTS = ((5, 0, 'AvaNi~JAyir2r2ukkizhamai'),
+           (6, 6, 'puraTTAci~can2ikkizhamai'),
+           (8, 0, 'kArttigai~JAyir2r2ukkizhamai'),
+           (4, 5, 'ADi~veLLikkizhamai'),
+           (10, 5, 'tai~veLLikkizhamai'),
+           (11, 2, 'mAci~cevvAy'))
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2018, 1, 1), end_date=Date(2020, 12, 31),
+                                      computation_system=computation_system)
+  daily_panchaangas = panchaanga.daily_panchaangas_sorted()
+  for month, weekday, fest_id in FESTS:
+    new_days = set(panchaanga.festival_id_to_days.get(fest_id, set()))
+    old_days = set()
+    for d in range(panchaanga.duration_prior_padding, panchaanga.duration + panchaanga.duration_prior_padding):
+      dp = daily_panchaangas[d]
+      if dp.solar_sidereal_date_sunset.month == month and dp.date.get_weekday() == weekday:
+        old_days.add(dp.date)
+    assert len(new_days) > 4, fest_id
+    assert new_days == old_days, fest_id
+    assert all(d.get_weekday() == weekday for d in new_days), fest_id

--- a/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
+++ b/jyotisha_tests/temporal/festival/applier/vaara_conditioned_test.py
@@ -1,13 +1,23 @@
 from jyotisha.panchaanga.spatio_temporal import City, periodical
 from jyotisha.panchaanga.temporal import ComputationSystem
+from jyotisha.panchaanga.temporal.festival.rules import resolve_vaara_index
 from jyotisha.panchaanga.temporal.time import Date
 
 chennai = City.get_city_from_db('Chennai')
 
 
+def test_resolve_vaara_index_accepts_names_and_ints():
+  assert resolve_vaara_index(2) == 2
+  assert resolve_vaara_index(None) is None
+  for name, expected in [("Bhanu", 1), ("soma", 2), ("Indu", 2), ("Mangala", 3), ("bhauma", 3),
+                          ("Saumya", 4), ("BUDHA", 4), ("guru", 5), ("Shukra", 6), ("bhrigu", 6),
+                          ("Shani", 7), ("sthira", 7)]:
+    assert resolve_vaara_index(name) == expected, name
+
+
 def test_kaarttika_somavaasara():
   """kArttika~sOmavAsaraH: lunar month 8, every Monday -- the first festival converted to the lightweight
-  `[timing] vara = N` mechanism (apply_vara_conditioned_events), as opposed to the heavier multi-anga
+  `[timing] vaara = "soma"` mechanism (apply_vaara_conditioned_events), as opposed to the heavier multi-anga
   intersection search engine. Verifies it recurs on every matching Monday (not just the first) and matches
   the original hand-written condition exactly."""
   computation_system = ComputationSystem.DEFAULT

--- a/jyotisha_tests/temporal/festival/applier/vara_conditioned_test.py
+++ b/jyotisha_tests/temporal/festival/applier/vara_conditioned_test.py
@@ -1,0 +1,27 @@
+from jyotisha.panchaanga.spatio_temporal import City, periodical
+from jyotisha.panchaanga.temporal import ComputationSystem
+from jyotisha.panchaanga.temporal.time import Date
+
+chennai = City.get_city_from_db('Chennai')
+
+
+def test_kaarttika_somavaasara():
+  """kArttika~sOmavAsaraH: lunar month 8, every Monday -- the first festival converted to the lightweight
+  `[timing] vara = N` mechanism (apply_vara_conditioned_events), as opposed to the heavier multi-anga
+  intersection search engine. Verifies it recurs on every matching Monday (not just the first) and matches
+  the original hand-written condition exactly."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2018, 1, 1), end_date=Date(2020, 12, 31),
+                                      computation_system=computation_system)
+  new_days = set(panchaanga.festival_id_to_days.get('kArttika~sOmavAsaraH', set()))
+
+  old_days = set()
+  daily_panchaangas = panchaanga.daily_panchaangas_sorted()
+  for d in range(panchaanga.duration_prior_padding, panchaanga.duration + panchaanga.duration_prior_padding):
+    dp = daily_panchaangas[d]
+    if dp.lunar_date.month.index == 8 and dp.date.get_weekday() == 1:
+      old_days.add(dp.date)
+
+  assert len(new_days) > 4  # recurs weekly through most of Kartika, across 3 years -- not just once per year
+  assert new_days == old_days
+  assert all(d.get_weekday() == 1 for d in new_days)


### PR DESCRIPTION
## Summary

Part of an audit of which hand-written festival-assignment functions in `solar.py`/`vaara.py` are genuinely irreducible vs. only exist because the TOML rule schema couldn't express them. Two pieces of new infrastructure, plus the first batch of conversions:

**1. `AngaType.VARA` + a generalized multi-anga intersection engine.** Weekday becomes a first-class `AngaType` (index 1=Sunday..7=Saturday), resolved via sunrise-anchored day scanning (not ecliptic search, since it's a civil-calendar step function). `SolarFestivalAssigner._assign_yoga` is generalized, renamed `_assign_anga_intersection`, and moved to the shared `FestivalAssigner` base class, gaining list-valued (OR) anga support. `HinduCalendarEventTiming` gains `intersection_groups`/`window` fields so a multi-anga conjunction can be expressed declaratively in TOML, with `RuleLookupAssigner.apply_anga_intersection_events()` as the driver. No existing festival's behavior changed here — purely a refactor + new unused-so-far capability, covered by `anga_intersection_test.py` (including an end-to-end check that a TOML-declared rule reproduces real `gajacchAyA-yOgaH` output).

**2. A lighter `vaara`-conditioned engine, for festivals that don't need a search.** Not every weekday-involving festival is a rare multi-anga coincidence — most are a flat per-day predicate (month + weekday, optionally + a single anga touching that day). `HinduCalendarEventTiming.vaara` (accepting an index or a name like `"budha"`) + `RuleLookupAssigner.apply_vaara_conditioned_events()` handle this directly against already-precomputed per-day facts, no anga-span search at all — a third, much lighter mechanism alongside the two above.

**3. First conversion batch** (companion data in [jyotisham/adyatithi#26](https://github.com/jyotisham/adyatithi/pull/26)): `kArttika~sOmavAsaraH`, the 6 `masa_vara_yoga_fests_tn` festivals, `aGgArakI~caturthI`/`sukhA~aGgArakI~caturthI`, and `kRSNAGgAraka-caturdazI-puNyakAlaH_or_yamatarpaNam`/`pizAcamOcanam` — all removed from `VaraFestivalAssigner` and now TOML-driven. Each was verified byte-identical to the original Python over multi-year ranges before conversion.

**Two real bugs found and fixed along the way** (not silently preserved):
- The original `aGgArakI~caturthI` naming check reused a variable already reduced mod 15, mislabeling ~25 krishna-caturthi occurrences (2015-2028, Chennai) as `sukhA~` (documented as shukla-paksha only).
- `apply_month_anga_events`/`apply_month_day_events` (the pre-existing single-anga engines) had no concept of `vaara` and would independently pick up and assign a rule that also set `anga_type`/`month_number`, ignoring the weekday gate. Both now skip any rule with `vaara` set.

## Test plan

- [x] `jyotisha_tests/temporal` — 55/55 passing
- [x] Each converted festival's dates verified byte-identical to the original Python condition over multi-year, multi-city ranges
- [x] New tests: `anga_intersection_test.py`, `vaara_conditioned_test.py` (including explicit regression checks for both bugs above)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_