### PR TITLE
Convert padmaka-yOgaH-3 to TOML (multi-anga intersection)

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -466,9 +466,6 @@ class SolarFestivalAssigner(FestivalAssigner):
             sunset_zodiac.get_anga(zodiac.AngaType.TITHI).index % 30 == 7):
         self.panchaanga.add_festival_instance(festival_instance=FestivalInstance(name='padmaka-yOgaH-2', interval=Interval(jd_start=None, jd_end=None)), date=daily_panchaanga.date)
 
-    self._assign_anga_intersection('padmaka-yOgaH-3', [(zodiac.AngaType.SOLAR_NAKSH, 16), (zodiac.AngaType.NAKSHATRA, 3)],
-                      jd_start=self.panchaanga.jd_start, jd_end=self.panchaanga.jd_end)
-
   def assign_mahodaya_ardhodaya(self):
     for d, daily_panchaanga in enumerate(self.daily_panchaangas):
 

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
@@ -58184,8 +58184,8 @@ DESCRIPTION:When the Sun is transiting through viśākhā\, and the moon\,
  kr̥ttikāsu ca candramāḥ।  <br/>sa yōgaḥ padmakō nāma puṣkar
  ēṣvapi durlabhaḥ॥ (smr̥tikaustubhē pr̥ 406)<br/><br/><br/><br/>#
  # Details<br/>- [Edit config file](https://github.com/jyotisham/adyatithi/
- blob/master/time_focus/special-tithis/description_only/padmaka-yOgaH-3.tom
- l)<br/>- Tags: RareDays Combinations
+ blob/master/time_focus/yoga_intersections/padmaka-yOgaH-3.toml)<br/>- Tags
+ : RareDays Combinations
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
@@ -50989,7 +50989,7 @@ When the Sun is transiting through viśākhā, and the moon, through kr̥ttikā,
 
 
 ###### Details
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/special-tithis/description_only/padmaka-yOgaH-3.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/padmaka-yOgaH-3.toml)
 - Tags: RareDays Combinations
 
 

--- a/jyotisha_tests/temporal/festival/applier/intersection_conversion_test.py
+++ b/jyotisha_tests/temporal/festival/applier/intersection_conversion_test.py
@@ -30,3 +30,25 @@ def test_gajacchaayaa_yoga():
 
   assert len(direct_days) > 0
   assert new_days == direct_days
+
+
+def test_padmaka_yoga_3():
+  """padmaka-yOgaH-3: SOLAR_NAKSH=16 (vizAkhA) & NAKSHATRA=3 (kRttikA), over the whole computed period, no vaara
+  or other gate -- the simplest possible `intersection_groups` conversion (a single unconditional whole-period
+  search, previously the standalone tail call in SolarFestivalAssigner.assign_padmaka_yoga; the two other
+  sub-cases in that function, padmaka-yOga-puNyakAlaH and padmaka-yOgaH-2, are day-loop-gated/branching and stay
+  custom Python). Verified against a direct call to _assign_anga_intersection with the original intersect_list,
+  over a 25-year range."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2005, 1, 1), end_date=Date(2030, 12, 31),
+                                      computation_system=computation_system)
+  new_days = set(panchaanga.festival_id_to_days.get('padmaka-yOgaH-3', set()))
+
+  assigner = SolarFestivalAssigner(panchaanga)
+  assigner._assign_anga_intersection(
+    'test~padmaka-direct', [(AngaType.SOLAR_NAKSH, 16), (AngaType.NAKSHATRA, 3)],
+    jd_start=panchaanga.jd_start, jd_end=panchaanga.jd_end, show_debug_info=False)
+  direct_days = set(panchaanga.festival_id_to_days.get('test~padmaka-direct', set()))
+
+  assert len(direct_days) > 0
+  assert new_days == direct_days


### PR DESCRIPTION
## Summary

Follow-up to #195/#196. `padmaka-yOgaH-3` is the second conversion off the "genuine multi-anga search" list, and the simplest possible case: a single unconditional whole-period search (`SOLAR_NAKSH=16 & NAKSHATRA=3`), no vaara or branching — previously the standalone tail call in `SolarFestivalAssigner.assign_padmaka_yoga`. Companion data change in [jyotisham/adyatithi#29](https://github.com/jyotisham/adyatithi/pull/29).

The function's other two sub-cases (`padmaka-yOga-puNyakAlaH`, `padmaka-yOgaH-2`) are day-loop-gated/branching and stay custom Python; only the standalone tail call is removed.

## Test plan

- [x] Verified byte-identical to a direct `_assign_anga_intersection` call with the original intersect_list, over a 25-year range (`test_padmaka_yoga_3` in `intersection_conversion_test.py`)
- [x] Full `pytest jyotisha_tests/temporal` — 58 passed

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_