### PR TITLE
Convert AyuSmad-bava-saumya-saMyOgaH to TOML (multi-anga intersection)

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/__init__.py
@@ -51,6 +51,14 @@ class FestivalAssigner(PeriodicPanchaangaApplier):
     for that anga -- eg. karana in {2, 9, 16, ...}); list-valued entries are expanded by trying each candidate
     value independently (so multiple list-valued angas in the same call are tried combinatorially).
 
+    Angas are processed in order, each one searched within the window left by the previous ones (a sequential
+    narrowing search), so ORDER MATTERS when the window is narrower than a full day: unlike AngaSpanFinder-based
+    angas, AngaType.VARA's span (via _find_vara_span) is always the *whole* civil day [sunrise, next_sunrise],
+    not clipped to the query window -- if VARA comes first against eg. a sunrise_to_sunset window, its wide span
+    becomes the narrowed window handed to the remaining angas, silently widening their search into the night.
+    Put VARA *last* in intersect_list when combining it with anything narrower than sunrise_to_next_sunrise, so
+    the other angas narrow to daytime first and VARA only confirms the weekday without re-widening the window.
+
     anga_type may be AngaType.VARA (weekday), resolved via _find_vara_span rather than ecliptic search.
     """
     if jd_start is None:

--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -41,7 +41,6 @@ class SolarFestivalAssigner(FestivalAssigner):
     self.assign_agni_nakshatra()
     self.assign_garbhottam()
     self.assign_padmaka_yoga()
-    self.assign_ayushmad_bava_saumya_yoga()
     self.assign_anadhyayana_dvadashi_yoga()
     self.assign_vaarunii_trayodashi()
     self.assign_mahamagha_utsava()
@@ -425,19 +424,6 @@ class SolarFestivalAssigner(FestivalAssigner):
         if dp_nakshatra is not None:
           self._assign_anga_intersection('dvipuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, dp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
             jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
-
-  def assign_ayushmad_bava_saumya_yoga(self):
-    if 'AyuSmad-bava-saumya-saMyOgaH' not in self.rules_collection.name_to_rule:
-      return
-    BAVA_KARANA = list(range(2, 52, 7))
-    AYUSHMAD_YOGA = 3
-    for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
-      # AYUSHMAN BAVA SAUMYA
-      if self.daily_panchaangas[d].date.get_weekday() == 3:
-        for karana_ID in BAVA_KARANA:
-          self._assign_anga_intersection('AyuSmad-bava-saumya-saMyOgaH', [(zodiac.AngaType.YOGA, AYUSHMAD_YOGA), (zodiac.AngaType.KARANA, karana_ID)],
-                            jd_start=self.daily_panchaangas[d].jd_sunrise, jd_end=self.daily_panchaangas[d].jd_sunset, show_debug_info=False)
-
 
   def assign_padmaka_yoga(self):
     if 'padmaka-yOga-puNyakAlaH' not in self.rules_collection.name_to_rule:

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
@@ -25940,8 +25940,8 @@ UID:āyuṣmad-bava-saumya-saṁyōgaḥ_2019-05-29T15:21:33.120016+05:30
 DESCRIPTION:A rare combination of āyuṣmān yōga\, bava karaṇa and sa
  umyavāsara.<br/><br/>## Details<br/>- References<br/>  - Maha Periva / De
  ivattin Kural<br/>- [Edit config file](https://github.com/jyotisham/adyati
- thi/blob/master/time_focus/misc_combinations/description_only/AyuSmad-bava
- -saumya-saMyOgaH.toml)<br/>- Tags: RareDays Combinations
+ thi/blob/master/time_focus/yoga_intersections/AyuSmad-bava-saumya-saMyOgaH
+ .toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: āyuṣmad-bava-saumya-saṁyōgaḥ

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
@@ -23020,7 +23020,7 @@ A rare combination of āyuṣmān yōga, bava karaṇa and saumyavāsara.
 ###### Details
 - References
   - Maha Periva / Deivattin Kural
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/AyuSmad-bava-saumya-saMyOgaH.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/AyuSmad-bava-saumya-saMyOgaH.toml)
 - Tags: RareDays Combinations
 
 

--- a/jyotisha_tests/temporal/festival/applier/intersection_conversion_test.py
+++ b/jyotisha_tests/temporal/festival/applier/intersection_conversion_test.py
@@ -32,6 +32,32 @@ def test_gajacchaayaa_yoga():
   assert new_days == direct_days
 
 
+def test_ayushmad_bava_saumya_yoga():
+  """AyuSmad-bava-saumya-saMyOgaH: every Wednesday (VARA), YOGA=3 (AyuSmAn) & KARANA in BAVA_KARANA
+  (list(range(2,52,7)) -- the repeating bava karana slot across the lunar month), searched sunrise-to-sunset on
+  each such day -- previously a day-loop in SolarFestivalAssigner.assign_ayushmad_bava_saumya_yoga making one
+  _assign_anga_intersection call per (day, karana value) pair. Verified against a direct reproduction of that
+  same day-loop (8 separate per-karana calls per Wednesday, not a single OR-list call) over a 21-year range, to
+  establish the exact original semantics before converting to a TOML `intersection_groups` OR-list."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2010, 1, 1), end_date=Date(2030, 12, 31),
+                                      computation_system=computation_system)
+  new_days = set(panchaanga.festival_id_to_days.get('AyuSmad-bava-saumya-saMyOgaH', set()))
+
+  assigner = SolarFestivalAssigner(panchaanga)
+  BAVA_KARANA = list(range(2, 52, 7))
+  for daily_panchaanga in assigner.daily_panchaangas:
+    if daily_panchaanga.date.get_weekday() == 3:
+      for karana_ID in BAVA_KARANA:
+        assigner._assign_anga_intersection(
+          'test~ayushmad-direct', [(AngaType.YOGA, 3), (AngaType.KARANA, karana_ID)],
+          jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_sunset, show_debug_info=False)
+  direct_days = set(panchaanga.festival_id_to_days.get('test~ayushmad-direct', set()))
+
+  assert len(direct_days) > 0
+  assert new_days == direct_days
+
+
 def test_padmaka_yoga_3():
   """padmaka-yOgaH-3: SOLAR_NAKSH=16 (vizAkhA) & NAKSHATRA=3 (kRttikA), over the whole computed period, no vaara
   or other gate -- the simplest possible `intersection_groups` conversion (a single unconditional whole-period


### PR DESCRIPTION
## Summary

Follow-up to #195/#196/#197. `AyuSmad-bava-saumya-saMyOgaH` is the third conversion off the "genuine multi-anga search" list: YOGA=3 & KARANA-list (bava) & vaara=Wednesday, previously a day-loop in `SolarFestivalAssigner.assign_ayushmad_bava_saumya_yoga`. Removed the method and its call from `assign_all()`. Companion data change in [jyotisham/adyatithi#30](https://github.com/jyotisham/adyatithi/pull/30).

**Found and fixed a real bug** while verifying against the original day-loop byte-for-byte: `AngaType.VARA`'s span-finder (`_find_vara_span`) returns the whole civil day `[sunrise, next_sunrise]`, not clipped to the query window, unlike every other anga finder. `_assign_anga_intersection` narrows sequentially (each anga searched within the window left by the previous one), so if VARA is listed first against a window narrower than a full day, its wide span silently becomes the narrowed window for the remaining angas — widening e.g. a `sunrise_to_sunset` search into the following night, producing spurious extra matches. Fixed by ordering `vaara` last in the TOML's `intersection_groups`, and documented the requirement directly in `_assign_anga_intersection`'s docstring, since several other not-yet-converted festivals on the list also combine VARA with a narrower window (`tripuSkara`/`dvipuSkara-yOgaH`, `mahOdaya`/`ardhOdaya-puNyakAlaH`, `pAtArka-yOgaH`).

## Test plan

- [x] Verified byte-identical to a direct reproduction of the original day-loop (8 separate per-karana calls per Wednesday) over a 21-year range (`test_ayushmad_bava_saumya_yoga` in `intersection_conversion_test.py`) — this test caught the VARA-ordering bug before it shipped
- [x] Full `pytest jyotisha_tests` (matches CI) — 83 passed

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_