### PR TITLE
Convert tripuSkara-yOgaH/dvipuSkara-yOgaH to TOML (multi-anga intersection)

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -26,7 +26,6 @@ logging.basicConfig(
 
 class SolarFestivalAssigner(FestivalAssigner):
   def assign_all(self):
-    self.assign_pushkara_yoga()
     self.assign_sidereal_sankranti_punyakaala()
     self.assign_mahodaya_ardhodaya()
     self.assign_month_day_kaaradaiyan()
@@ -393,37 +392,6 @@ class SolarFestivalAssigner(FestivalAssigner):
         self.panchaanga.delete_festival_date(fest_id='vyatIpAta-zrAddham', date=date)
         self.panchaanga.add_festival(fest_id='mahAvyatIpAta-zrAddham', date=date)
 
-
-  def assign_pushkara_yoga(self):
-    if 'tripuSkara-yOgaH~0' not in self.rules_collection.name_to_rule:
-      return
-
-    PUSHKARA_TITHI = [2, 7, 12, 17, 22, 27]
-    TRI_PUSHKARA_NAKSHATRA = [3, 7, 12, 16, 21, 25]
-    DVI_PUSHKARA_NAKSHATRA = [5, 14, 23]
-    PUSHKARA_WDAY = [0, 2, 6]
-    for d, daily_panchaanga in enumerate(self.daily_panchaangas):
-      dp_nakshatra = tp_nakshatra = p_tithi = None
-      for nakshatra_span in daily_panchaanga.sunrise_day_angas.nakshatras_with_ends:
-        nakshatra_ID = nakshatra_span.anga.index
-        if nakshatra_ID in TRI_PUSHKARA_NAKSHATRA:
-          tp_nakshatra = nakshatra_ID
-        elif nakshatra_ID in DVI_PUSHKARA_NAKSHATRA:
-          dp_nakshatra = nakshatra_ID
-      
-      for tithi_span in daily_panchaanga.sunrise_day_angas.tithis_with_ends:
-        tithi_ID = tithi_span.anga.index
-        if tithi_ID in PUSHKARA_TITHI:
-          p_tithi = tithi_ID
-      
-      wday = daily_panchaanga.date.get_weekday()
-      if p_tithi is not None and wday in PUSHKARA_WDAY:
-        if tp_nakshatra is not None:
-          self._assign_anga_intersection('tripuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, tp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
-            jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
-        if dp_nakshatra is not None:
-          self._assign_anga_intersection('dvipuSkara-yOgaH~%d' % wday, [(zodiac.AngaType.NAKSHATRA, dp_nakshatra), (zodiac.AngaType.TITHI, p_tithi)],
-            jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
 
   def assign_padmaka_yoga(self):
     if 'padmaka-yOga-puNyakAlaH' not in self.rules_collection.name_to_rule:

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
@@ -185,12 +185,11 @@ DTEND;TZID=Asia/Calcutta:20190102T063513
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-01-02T01:28:39.360016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -4336,12 +4335,11 @@ DTEND;TZID=Asia/Calcutta:20190127T063924
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-01-26T16:19:26.399990+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -4459,12 +4457,11 @@ DTEND;TZID=Asia/Calcutta:20190127T142248
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-01-27T06:39:24.480007+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -5964,12 +5961,11 @@ DTEND;TZID=Asia/Calcutta:20190206T063758
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-02-06T05:15:36.000019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -7883,12 +7879,11 @@ DTEND;TZID=Asia/Calcutta:20190217T063430
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-02-16T19:04:01.919991+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -8173,12 +8168,11 @@ DTEND;TZID=Asia/Calcutta:20190217T081016
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-02-17T06:34:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -9470,12 +9464,11 @@ DTEND;TZID=Asia/Calcutta:20190225T063046
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-02-25T05:04:30.719983+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -10328,12 +10321,11 @@ DTEND;VALUE=DATE:20190303
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-03-02T11:04:39.360008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE
@@ -10473,12 +10465,11 @@ DTEND;TZID=Asia/Calcutta:20190303T085804
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-03-03T06:27:36.000003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -11965,12 +11956,11 @@ DTEND;TZID=Asia/Calcutta:20190313T045159
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-03-13T04:49:58.080017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -15203,12 +15193,11 @@ DTEND;TZID=Asia/Calcutta:20190401T060901
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-04-01T06:04:24.959992+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -19705,12 +19694,11 @@ DTEND;TZID=Asia/Calcutta:20190421T055647
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-04-20T17:57:04.320017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -19822,12 +19810,11 @@ DTEND;TZID=Asia/Calcutta:20190421T123247
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-04-21T05:56:47.040006+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -20746,12 +20733,11 @@ DTEND;TZID=Asia/Calcutta:20190501T055153
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-05-01T00:17:57.119981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -21790,12 +21776,11 @@ DTEND;TZID=Asia/Calcutta:20190506T054952
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-05-06T03:58:50.879997+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -25497,12 +25482,11 @@ DTEND;VALUE=DATE:20190526
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-05-25T10:13:14.880018+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE
@@ -25640,12 +25624,11 @@ DTEND;TZID=Asia/Calcutta:20190526T084935
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-05-26T05:45:24.479999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -27094,12 +27077,11 @@ DTEND;TZID=Asia/Calcutta:20190604T230706
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-06-04T13:57:36.000003+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -30425,12 +30407,11 @@ DTEND;TZID=Asia/Calcutta:20190624T054808
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-06-24T00:05:42.719981+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -31226,12 +31207,11 @@ DTEND;VALUE=DATE:20190630
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-06-29T09:55:58.080009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE
@@ -31388,12 +31368,11 @@ DTEND;TZID=Asia/Calcutta:20190630T061136
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-06-30T05:49:35.040016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -36406,12 +36385,11 @@ DTEND;TZID=Asia/Calcutta:20190729T055712
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-07-28T19:15:59.039980+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -38149,12 +38127,11 @@ DTEND;TZID=Asia/Calcutta:20190806T222110
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-08-06T13:30:14.400016+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -40605,12 +40582,11 @@ DTEND;TZID=Asia/Calcutta:20190817T224848
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-08-17T13:52:42.240019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -42307,12 +42283,11 @@ DTEND;VALUE=DATE:20190828
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-08-27T06:01:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE
@@ -43416,12 +43391,11 @@ DTEND;TZID=Asia/Calcutta:20190901T060114
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-08-31T14:05:22.560015+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -43753,12 +43727,11 @@ DTEND;TZID=Asia/Calcutta:20190901T082641
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-09-01T06:01:14.879993+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -45695,12 +45668,11 @@ DTEND;TZID=Asia/Calcutta:20190910T110640
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-09-10T06:01:23.520019+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -47824,12 +47796,11 @@ DTEND;TZID=Asia/Calcutta:20190921T202055
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-09-21T11:19:20.640000+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -49731,12 +49702,11 @@ DTEND;TZID=Asia/Calcutta:20190930T060132
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-09-29T20:13:43.680009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -53460,12 +53430,11 @@ DTEND;TZID=Asia/Calcutta:20191021T060333
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-10-20T17:49:52.319986+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -55409,12 +55378,11 @@ DTEND;TZID=Asia/Calcutta:20191029T230858
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-10-29T06:13:20.640008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -55871,12 +55839,11 @@ DTEND;TZID=Asia/Calcutta:20191103T060643
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-11-03T01:31:06.240008+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -55967,12 +55934,11 @@ DTEND;VALUE=DATE:20191104
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-11-03T06:06:43.199999+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE
@@ -60399,12 +60365,11 @@ DTEND;TZID=Asia/Calcutta:20191124T034317
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-11-23T14:42:31.680011+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -62464,12 +62429,11 @@ DTEND;TZID=Asia/Calcutta:20191203T141400
 DTSTAMP:20200101T000000Z
 UID:dvipuṣkara-yōgaḥ_2019-12-03T06:19:58.080017+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvi
- puSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/dvipuSkara-yOgaH~2.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: dvipuṣkara-yōgaḥ
@@ -64362,12 +64326,11 @@ DTEND;TZID=Asia/Calcutta:20191214T084716
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-12-14T06:26:00.960004+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -65707,12 +65670,11 @@ DTEND;TZID=Asia/Calcutta:20191223T063046
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-12-22T18:35:48.480012+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~0.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ
@@ -66789,12 +66751,11 @@ DTEND;TZID=Asia/Calcutta:20191228T111007
 DTSTAMP:20200101T000000Z
 UID:tripuṣkara-yōgaḥ_2019-12-28T06:33:04.320009+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/time_focus/misc_combinations/description_only/tri
- puSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/
- >## Details<br/>- References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- 
- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time
- _focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)<br/>- T
- ags: RareDays Combinations
+ am/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.
+ toml)<br/>- Tags: RareDays Combinations<br/><br/><br/><br/>## Details<br/>
+ - References<br/>  - SmritiMuktaPhalam Part 5\, SVR<br/>- [Edit config fil
+ e](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_inte
+ rsections/tripuSkara-yOgaH~6.toml)<br/>- Tags: RareDays Combinations
 BEGIN:VALARM
 ACTION:DISPLAY
 DESCRIPTION:Reminder: tripuṣkara-yōgaḥ

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
@@ -177,7 +177,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -3749,7 +3749,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -3858,7 +3858,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -5173,7 +5173,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -6805,7 +6805,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -7144,7 +7144,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -8318,7 +8318,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -9110,7 +9110,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -9252,7 +9252,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -10612,7 +10612,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -13378,7 +13378,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -17228,7 +17228,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -17359,7 +17359,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -18189,7 +18189,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -19048,7 +19048,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -22632,7 +22632,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -22760,7 +22760,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -23916,7 +23916,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -26680,7 +26680,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -27331,7 +27331,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -27533,7 +27533,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -31910,7 +31910,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -33371,7 +33371,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -35355,7 +35355,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -36802,7 +36802,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -37633,7 +37633,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -37958,7 +37958,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -39472,7 +39472,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -41402,7 +41402,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -43028,7 +43028,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -46360,7 +46360,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -48126,7 +48126,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -48687,7 +48687,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -48791,7 +48791,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -52822,7 +52822,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -54454,7 +54454,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/dvipuSkara-yOgaH~2.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/dvipuSkara-yOgaH~2.toml)
 - Tags: RareDays Combinations
 
 
@@ -55988,7 +55988,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 
@@ -57226,7 +57226,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~0.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~0.toml)
 - Tags: RareDays Combinations
 
 
@@ -58106,7 +58106,7 @@ When a tripādanakṣatra is conjoined with a bhadrā tithi i.e. dvitīyā, sapt
 ###### Details
 - References
   - SmritiMuktaPhalam Part 5, SVR
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/misc_combinations/description_only/tripuSkara-yOgaH~6.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/time_focus/yoga_intersections/tripuSkara-yOgaH~6.toml)
 - Tags: RareDays Combinations
 
 

--- a/jyotisha_tests/temporal/festival/applier/intersection_conversion_test.py
+++ b/jyotisha_tests/temporal/festival/applier/intersection_conversion_test.py
@@ -58,6 +58,59 @@ def test_ayushmad_bava_saumya_yoga():
   assert new_days == direct_days
 
 
+def test_pushkara_yoga():
+  """tripuSkara-yOgaH~{0,2,6} / dvipuSkara-yOgaH~{0,2,6}: 6 separate festival ids (3 weekdays x 2 nakshatra-sets),
+  previously a day-loop in SolarFestivalAssigner.assign_pushkara_yoga. On each day, the loop picks the LAST
+  nakshatra-transition matching TRI_PUSHKARA_NAKSHATRA=[3,7,12,16,21,25] (or DVI_PUSHKARA_NAKSHATRA=[5,14,23])
+  and the LAST tithi-transition matching PUSHKARA_TITHI=[2,7,12,17,22,27] that day, then -- only if the weekday
+  is in PUSHKARA_WDAY=[0,2,6] (Sun/Tue/Sat) -- calls _assign_anga_intersection with that SPECIFIC (single)
+  nakshatra+tithi pair, windowed sunrise-to-next_sunrise, id suffixed by weekday. Verified against a direct
+  reproduction of that exact day-loop (not a naive NAKSHATRA-list x TITHI-list combinatorial search) over a
+  15-year range, since the two are not obviously equivalent (the original always resolves to at most one
+  specific nakshatra/tithi value per day, not every list member)."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2010, 1, 1), end_date=Date(2025, 12, 31),
+                                      computation_system=computation_system)
+
+  PUSHKARA_TITHI = [2, 7, 12, 17, 22, 27]
+  TRI_PUSHKARA_NAKSHATRA = [3, 7, 12, 16, 21, 25]
+  DVI_PUSHKARA_NAKSHATRA = [5, 14, 23]
+  PUSHKARA_WDAY = [0, 2, 6]
+
+  assigner = SolarFestivalAssigner(panchaanga)
+  for daily_panchaanga in assigner.daily_panchaangas:
+    dp_nakshatra = tp_nakshatra = p_tithi = None
+    for nakshatra_span in daily_panchaanga.sunrise_day_angas.nakshatras_with_ends:
+      nakshatra_ID = nakshatra_span.anga.index
+      if nakshatra_ID in TRI_PUSHKARA_NAKSHATRA:
+        tp_nakshatra = nakshatra_ID
+      elif nakshatra_ID in DVI_PUSHKARA_NAKSHATRA:
+        dp_nakshatra = nakshatra_ID
+    for tithi_span in daily_panchaanga.sunrise_day_angas.tithis_with_ends:
+      tithi_ID = tithi_span.anga.index
+      if tithi_ID in PUSHKARA_TITHI:
+        p_tithi = tithi_ID
+    wday = daily_panchaanga.date.get_weekday()
+    if p_tithi is not None and wday in PUSHKARA_WDAY:
+      if tp_nakshatra is not None:
+        assigner._assign_anga_intersection(
+          'test~tripuSkara-direct~%d' % wday, [(AngaType.NAKSHATRA, tp_nakshatra), (AngaType.TITHI, p_tithi)],
+          jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
+      if dp_nakshatra is not None:
+        assigner._assign_anga_intersection(
+          'test~dvipuSkara-direct~%d' % wday, [(AngaType.NAKSHATRA, dp_nakshatra), (AngaType.TITHI, p_tithi)],
+          jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_next_sunrise, show_debug_info=False)
+
+  any_checked = False
+  for wday in PUSHKARA_WDAY:
+    for prefix, direct_prefix in [('tripuSkara-yOgaH', 'test~tripuSkara-direct'), ('dvipuSkara-yOgaH', 'test~dvipuSkara-direct')]:
+      new_days = set(panchaanga.festival_id_to_days.get('%s~%d' % (prefix, wday), set()))
+      direct_days = set(panchaanga.festival_id_to_days.get('%s~%d' % (direct_prefix, wday), set()))
+      assert new_days == direct_days, '%s~%d: %s vs %s' % (prefix, wday, new_days, direct_days)
+      any_checked = True
+  assert any_checked
+
+
 def test_padmaka_yoga_3():
   """padmaka-yOgaH-3: SOLAR_NAKSH=16 (vizAkhA) & NAKSHATRA=3 (kRttikA), over the whole computed period, no vaara
   or other gate -- the simplest possible `intersection_groups` conversion (a single unconditional whole-period


### PR DESCRIPTION
## Summary

Follow-up to #195/#196/#197/#198. `tripuSkara-yOgaH`/`dvipuSkara-yOgaH` is the fourth conversion off the "genuine multi-anga search" list — 6 separate festival ids (3 weekdays x 2 nakshatra sets), previously a day-loop in `SolarFestivalAssigner.assign_pushkara_yoga`. Removed the method and its call from `assign_all()`. Companion data change in [jyotisham/adyatithi#31](https://github.com/jyotisham/adyatithi/pull/31).

The original day-loop resolves to at most one specific nakshatra/tithi value per day (the day's last matching transition), not a full list search; the TOML-driven engine instead tries every NAKSHATRA-list x TITHI-list candidate pair independently. Verified these two approaches produce byte-identical results across all 6 ids over a 15-year range before converting.

## Test plan

- [x] `test_pushkara_yoga` in `intersection_conversion_test.py` — byte-identical across all 6 ids over 15 years
- [x] Full `pytest jyotisha_tests` (matches CI) — all pass, including regenerated golden `spatio_temporal` fixtures reflecting the moved TOML files' URLs

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_