### PR TITLE
Add apply_month_transition_events: day-of-month + kaala-threshold engine

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -26,6 +26,16 @@ _INTERSECTION_ANGA_TYPES = {
 }
 
 
+# month_type -> the DailyPanchaanga attribute holding that month system's {month, day, month_transition} date,
+# for apply_month_transition_events(). Not a plain f"{month_type}_date_sunset" concatenation: RulesRepo's
+# schema-facing month_type strings (eg. "sidereal_solar_month") don't all match their backing attribute names
+# (eg. solar_sidereal_date_sunset).
+_MONTH_TRANSITION_DATE_ATTR = {
+  RulesRepo.SIDEREAL_SOLAR_MONTH_DIR: 'solar_sidereal_date_sunset',
+  RulesRepo.TROPICAL_MONTH_DIR: 'tropical_date_sunset',
+}
+
+
 def _resolve_anga_number(anga_type_str, anga_number):
   """anga_number for anga_type="vaara" may be a name (or list of names) instead of an index; everything else
   passes through unchanged."""
@@ -149,6 +159,7 @@ class RuleLookupAssigner(FestivalAssigner):
       self.apply_month_anga_events(day_panchaanga=dp, month_type=RulesRepo.LUNAR_MONTH_DIR, anga_type=AngaType.YOGA)
     self.apply_anga_intersection_events()
     self.apply_vaara_conditioned_events()
+    self.apply_month_transition_events()
 
   @timebudget
   def apply_vaara_conditioned_events(self):
@@ -221,6 +232,35 @@ class RuleLookupAssigner(FestivalAssigner):
           for group in groups:
             self._assign_anga_intersection(fest_id, group, jd_start=jd_start, jd_end=jd_end, show_debug_info=False)
 
+  @timebudget
+  def apply_month_transition_events(self):
+    """ Apply day-of-month events (anga_type="day") that also set `kaala`: the civil day is decided by
+    comparing the MONTH's own transition jd (not an anga's) against that kaala's threshold jd -- transition
+    before the kaala keeps the event on this day, transition at/after it shifts to the next day. Distinct from
+    apply_month_day_events (no disambiguation at all: the ordinal day is used as-is) and apply_month_anga_events
+    (built for fast-oscillating angas like tithi/nakshatra/yoga via decide_puurvaviddha, not month-scale solar
+    transitions -- get_2_day_interval_boundary_angas is documented as "useful only for tithi, nakShatra or
+    yoga"). Previously several bespoke day-loops in SolarFestivalAssigner (eg. assign_month_day_muDavan_muzhukku,
+    assign_month_day_tulA_kAvErI_snAna_ArambhaH), each hand-comparing a month_transition jd against sunrise, a
+    named kaala's start, or a custom offset.
+    """
+    for fest_id, fest_rule in self.rules_collection.name_to_rule.items():
+      if fest_rule.timing is None or fest_rule.timing.anga_type != RulesRepo.DAY_DIR or fest_rule.timing.kaala is None:
+        continue
+      month_type = fest_rule.timing.month_type
+      date_attr = _MONTH_TRANSITION_DATE_ATTR[month_type]
+      target_day = fest_rule.timing.anga_number
+      target_month = fest_rule.timing.month_number
+      for d, daily_panchaanga in enumerate(self.daily_panchaangas[:-1]):
+        month_date = getattr(daily_panchaanga, date_attr)
+        if month_date.month == target_month and month_date.day == target_day:
+          kaala_interval = daily_panchaanga.get_interval(interval_id=fest_rule.timing.kaala)
+          transition = month_date.month_transition
+          if transition is None or transition < kaala_interval.jd_start:
+            self.panchaanga.add_festival(fest_id=fest_id, date=daily_panchaanga.date)
+          else:
+            self.panchaanga.add_festival(fest_id=fest_id, date=self.daily_panchaangas[d + 1].date)
+
   def apply_month_day_events(self, day_panchaanga, month_type):
     """Apply events set to take place on a given (ordinal) day of a given month. Eg. Jan 1 as per Julian calendar, Aug 15 as per Gregorian calendar, 1st day of sidereal solar month 6. See calls from apply_festival_from_rules_repos().
     
@@ -245,6 +285,11 @@ class RuleLookupAssigner(FestivalAssigner):
     for fest_id, fest in fest_dict.items():
       if fest.timing.vaara is not None:
         # See the matching guard in apply_month_anga_events: owned by apply_vaara_conditioned_events instead.
+        continue
+      if fest.timing.kaala is not None:
+        # A day-of-month rule with a kaala set needs the month_transition-vs-kaala day disambiguation --
+        # owned by apply_month_transition_events instead, to avoid also assigning it here on the plain
+        # ordinal day with no disambiguation.
         continue
       if month_type in [RulesRepo.GREGORIAN_MONTH_DIR, RulesRepo.JULIAN_MONTH_DIR]:
         self.panchaanga.add_festival(date=day_panchaanga.date, fest_id=fest_id, interval_id="julian_day")

--- a/jyotisha/panchaanga/temporal/festival/applier/solar.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/solar.py
@@ -29,7 +29,6 @@ class SolarFestivalAssigner(FestivalAssigner):
     self.assign_sidereal_sankranti_punyakaala()
     self.assign_mahodaya_ardhodaya()
     self.assign_month_day_kaaradaiyan()
-    self.assign_month_day_muDavan_muzhukku()
     self.assign_month_day_tulA_kAvErI_snAna_ArambhaH()
     self.assign_month_day_kuchela()
     self.assign_month_day_ushah_kaala_festival_period('dhanurmAsa', 'solar_sidereal')
@@ -305,16 +304,6 @@ class SolarFestivalAssigner(FestivalAssigner):
           self.panchaanga.add_festival(fest_id=end_fest_id, date=daily_panchaanga.date)
         else:
           self.panchaanga.add_festival(fest_id=end_fest_id, date=self.daily_panchaangas[d + 1].date)
-  
-  def assign_month_day_muDavan_muzhukku(self):
-    if 'muDavan2_muzhukku' not in self.rules_collection.name_to_rule:
-      return
-    for d, daily_panchaanga in enumerate(self.daily_panchaangas):
-      if daily_panchaanga.solar_sidereal_date_sunset.month == 8 and daily_panchaanga.solar_sidereal_date_sunset.day == 1:
-        if daily_panchaanga.solar_sidereal_date_sunset.month_transition is None or daily_panchaanga.solar_sidereal_date_sunset.month_transition < daily_panchaanga.jd_sunrise:
-          self.panchaanga.add_festival(fest_id='muDavan2_muzhukku', date=daily_panchaanga.date)
-        else:
-          self.panchaanga.add_festival(fest_id='muDavan2_muzhukku', date=self.daily_panchaangas[d + 1].date)
 
   def assign_month_day_tulA_kAvErI_snAna_ArambhaH(self):
     if 'tulA-kAvErI-snAna-ArambhaH' not in self.rules_collection.name_to_rule:

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.ics
@@ -59170,10 +59170,11 @@ DTEND;VALUE=DATE:20191118
 DTSTAMP:20200101T000000Z
 UID:MuḍavanMuḻukku_2019-11-17T06:11:54.239994+05:30
 DESCRIPTION:## Details<br/>- [Edit config file](https://github.com/jyotish
- am/adyatithi/blob/master/tamil/description_only/muDavan2_muzhukku.toml)<br
- />- Tags: CommonFestivals<br/><br/><br/><br/>## Details<br/>- [Edit config
-  file](https://github.com/jyotisham/adyatithi/blob/master/tamil/descriptio
- n_only/muDavan2_muzhukku.toml)<br/>- Tags: CommonFestivals
+ am/adyatithi/blob/master/tamil/sidereal_solar_month/day/08/01/muDavan2_muz
+ hukku.toml)<br/>- Tags: CommonFestivals<br/><br/><br/><br/>## Details<br/>
+ - [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/ta
+ mil/sidereal_solar_month/day/08/01/muDavan2_muzhukku.toml)<br/>- Tags: Com
+ monFestivals
 TRANSP:TRANSPARENT
 X-MICROSOFT-CDO-ALLDAYEVENT:TRUE
 X-MICROSOFT-CDO-BUSYSTATUS:FREE

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
@@ -51704,12 +51704,12 @@ Conduct Veda parayanam in the evening, during (or at least on one of) these 48 d
 
 ##### मुडवऩ् मुऴुक्कु
 
-
+Observed on day 1 of Vr̥ścikaḥ (sidereal solar) month (Sunrise/puurvaviddha). 
 
 Nadha Sharma (muḍavan{}, i.e. lame man) and his wife Anavidyambikai came to Mayavaram in order to perform a tulā snānam in Kaveri. However, by the time they arrived, it was the last day of tulā māsa and they could not complete the snānam. They were disappointed yet spent their time doing Puja of Bhagavan, who appeared in their dreams and asked them to take a bath next morning (1st day of Vrschika) and reap full benefits of the Tula Kaveri Snanam itself!
 
 ###### Details
-- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/description_only/muDavan2_muzhukku.toml)
+- [Edit config file](https://github.com/jyotisham/adyatithi/blob/master/tamil/sidereal_solar_month/day/08/01/muDavan2_muzhukku.toml)
 - Tags: CommonFestivals
 
 

--- a/jyotisha_tests/temporal/festival/applier/month_transition_test.py
+++ b/jyotisha_tests/temporal/festival/applier/month_transition_test.py
@@ -1,0 +1,31 @@
+from jyotisha.panchaanga.spatio_temporal import City, periodical
+from jyotisha.panchaanga.temporal import ComputationSystem
+from jyotisha.panchaanga.temporal.festival.applier.solar import SolarFestivalAssigner
+from jyotisha.panchaanga.temporal.time import Date
+
+chennai = City.get_city_from_db('Chennai')
+
+
+def test_mudavan_muzhukku():
+  """muDavan2_muzhukku: day 1 of sidereal_solar month 8 (as reckoned at sunset), decided by comparing the
+  month's own transition jd against sunrise -- transition before sunrise keeps the day, transition at/after
+  sunrise shifts to the next day. Previously a day-loop in
+  SolarFestivalAssigner.assign_month_day_muDavan_muzhukku; now driven by RuleLookupAssigner's new
+  apply_month_transition_events() via a `[timing] month_type/month_number/anga_type="day"/anga_number/kaala`
+  TOML rule. Verified against a direct reproduction of the exact original day-loop over a 20-year range."""
+  computation_system = ComputationSystem.DEFAULT
+  panchaanga = periodical.Panchaanga(city=chennai, start_date=Date(2005, 1, 1), end_date=Date(2025, 12, 31),
+                                      computation_system=computation_system)
+  new_days = set(panchaanga.festival_id_to_days.get('muDavan2_muzhukku', set()))
+
+  direct_days = set()
+  daily_panchaangas = SolarFestivalAssigner(panchaanga).daily_panchaangas
+  for d, daily_panchaanga in enumerate(daily_panchaangas[:-1]):
+    if daily_panchaanga.solar_sidereal_date_sunset.month == 8 and daily_panchaanga.solar_sidereal_date_sunset.day == 1:
+      if daily_panchaanga.solar_sidereal_date_sunset.month_transition is None or daily_panchaanga.solar_sidereal_date_sunset.month_transition < daily_panchaanga.jd_sunrise:
+        direct_days.add(daily_panchaanga.date)
+      else:
+        direct_days.add(daily_panchaangas[d + 1].date)
+
+  assert len(direct_days) > 0
+  assert new_days == direct_days


### PR DESCRIPTION
## Summary

New engine mechanism for day-of-month festivals whose civil day depends on comparing the MONTH's own transition jd against a kaala threshold (transition before kaala keeps the day, transition at/after it shifts to the next day) — distinct from `apply_month_day_events` (no disambiguation at all) and `apply_month_anga_events` (built for fast-oscillating angas like tithi/nakshatra/yoga via `decide_puurvaviddha`/`get_2_day_interval_boundary_angas`, documented as "useful only for tithi, nakShatra or yoga" — not month-scale solar transitions).

First conversion: `muDavan2_muzhukku` (day 1 of sidereal_solar month 8, kaala=sunrise), removing `SolarFestivalAssigner.assign_month_day_muDavan_muzhukku`. Companion data change in [jyotisham/adyatithi#32](https://github.com/jyotisham/adyatithi/pull/32).

**Two real bugs found and fixed during verification:**
- The engine's `date_attr` was computed via naive `f"{month_type}_date_sunset"` concatenation, but `RulesRepo.SIDEREAL_SOLAR_MONTH_DIR` ("sidereal_solar_month") doesn't match the actual `DailyPanchaanga` attribute name ("solar_sidereal_date_sunset") — fixed via an explicit `_MONTH_TRANSITION_DATE_ATTR` mapping.
- A test-harness-only bug (accessed `panchaanga.daily_panchaangas` directly instead of via an assigner instance).

Also adds the matching guard in `apply_month_day_events`, skipping any day-type rule that now has `kaala` set (owned by the new method instead), mirroring the existing `vaara` guard.

This is the first of several candidates for this mechanism — `tulA-kAvErI-snAna-ArambhaH` next (same mechanism, `kaala="braahma"`), then `kAraDaiyAn2_nOn2bu` and the `dhanurmAsa`/`sahOmAsa-uSaHkAla` pair, which need new kaala definitions.

## Test plan

- [x] Verified byte-identical to a direct reproduction of the original day-loop over a 20-year range (`test_mudavan_muzhukku` in the new `month_transition_test.py`)
- [x] Full `pytest jyotisha_tests` (matches CI) — all pass, including regenerated golden `spatio_temporal` fixtures

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_