### PR TITLE
Use kaala instead of window for vaara-conditioned anga-touch checks

### DIFF
--- a/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/applier/rule_repo_based/__init__.py
@@ -6,7 +6,6 @@ from jyotisha.panchaanga.temporal import Anga, AngaType, get_2_day_interval_boun
 from jyotisha.panchaanga.temporal.festival import priority_decision
 from jyotisha.panchaanga.temporal.festival.applier import FestivalAssigner
 from jyotisha.panchaanga.temporal.festival.rules import RulesRepo, resolve_vaara_index
-from jyotisha.panchaanga.temporal.interval import Interval
 
 
 # TOML-facing anga_type names for `intersection_groups`, mapped to the AngaType singletons. Kept distinct from
@@ -175,23 +174,27 @@ class RuleLookupAssigner(FestivalAssigner):
     anga_events already owns and disambiguates via puurvaviddha/paraviddha -- this method would double-process
     it if it also fired without a vaara gate): a rule only reaches this method if it sets `vaara`, `angas`, or
     both. `angas` (a list of {anga_type, anga_number}, same shape as one intersection_groups entry) checks
-    several angas at once, ALL of which must touch `window` -- eg. vAjapEyaphala-snAna-yOgaH (tithi AND
-    nakshatra, both at sunrise, plus vaara) and jayantI~aSTamI (nakshatra AND tithi, both at sunrise, no vaara
-    at all). `anga_type`/`anga_number` (singular) remain supported as shorthand for a single-anga `angas` list
-    of one. `window="sunrise"` checks the anga(s) at the sunrise instant only (a zero-width interval, via the
-    same get_anga_spans_in_interval used elsewhere for a single jd -- see DailyPanchaanga.get_anga_at_jd), as
-    opposed to "touches somewhere in the window" -- needed since not every festival of this shape checks both
-    sunrise and sunset/purvaahna_end; some (eg. sOmavatI amAvAsyA, jayantI~aSTamI) only ever checked the anga
-    at sunrise in the original hand-written code, and touching the wider dinamaana window would pick up extra
-    days where the anga only appears later in the day.
+    several angas at once, ALL of which must touch the `kaala` interval -- eg. vAjapEyaphala-snAna-yOgaH (tithi
+    AND nakshatra, both at sunrise, plus vaara) and jayantI~aSTamI (nakshatra AND tithi, both at sunrise, no
+    vaara at all). `anga_type`/`anga_number` (singular) remain supported as shorthand for a single-anga `angas`
+    list of one.
+
+    `kaala` (a named interval string, same field/lookup used by apply_month_anga_events et al. via
+    DailyPanchaanga.get_interval -- "sunrise" resolves to a zero-width instant, "braahma"/"madhyaahna"/etc. to
+    a named division) bounds the "does the anga touch" check; unset defaults to "dinamaana" (sunrise..sunset,
+    matching every hand-written festival of this shape whose original code checked "anga at sunrise OR anga at
+    sunset" -- a wider touch than a single instant, but never the full sunrise..next_sunrise night-inclusive
+    span). An explicit `kaala="sunrise"` narrows this to the sunrise instant only, for festivals whose original
+    code only ever checked sunrise, never sunset (eg. sOmavatI amAvAsyA, jayantI~aSTamI) -- touching the wider
+    dinamaana default would pick up extra days where the anga only appears later in the day.
     """
     for fest_id, fest_rule in self.rules_collection.name_to_rule.items():
       if fest_rule.timing is None or (fest_rule.timing.vaara is None and fest_rule.timing.angas is None):
         continue
       vaara_index = fest_rule.timing.get_vaara_index() if fest_rule.timing.vaara is not None else None
       # Each entry in target_anga_groups is an OR-list of Angas (eg. tithi in [4, 19]); ALL entries must have at
-      # least one of their Angas touch `window` (AND across entries) -- same OR-within/AND-across shape as
-      # intersection_groups.
+      # least one of their Angas touch the kaala interval (AND across entries) -- same OR-within/AND-across
+      # shape as intersection_groups.
       target_anga_groups = []
       if fest_rule.timing.angas is not None:
         for a in fest_rule.timing.angas:
@@ -201,9 +204,7 @@ class RuleLookupAssigner(FestivalAssigner):
           target_anga_groups.append([Anga.get_cached(index=n, anga_type_id=anga_type.name) for n in numbers])
       elif fest_rule.timing.anga_type is not None:
         target_anga_groups = [[Anga.get_cached(index=fest_rule.timing.anga_number, anga_type_id=_INTERSECTION_ANGA_TYPES[fest_rule.timing.anga_type].name)]]
-      touch_window = fest_rule.timing.window
-      if touch_window is not None and touch_window not in ("sunrise", "sunrise_to_sunset", "sunrise_to_purvaahna"):
-        raise ValueError("Unsupported window %r for vaara-conditioned rule %s (expected sunrise, sunrise_to_sunset or sunrise_to_purvaahna)" % (touch_window, fest_id))
+      kaala = fest_rule.timing.kaala if fest_rule.timing.kaala is not None else "dinamaana"
       for d in range(self.panchaanga.duration_prior_padding, self.panchaanga.duration + self.panchaanga.duration_prior_padding):
         daily_panchaanga = self.daily_panchaangas[d]
         if vaara_index is not None and daily_panchaanga.date.get_weekday() + 1 != vaara_index:
@@ -211,18 +212,7 @@ class RuleLookupAssigner(FestivalAssigner):
         if not _month_matches(daily_panchaanga, fest_rule.timing.month_type, fest_rule.timing.month_number):
           continue
         if target_anga_groups:
-          # Bounded to daytime (dinamaana, sunrise..sunset, or the narrower purvaahna half of it), never the
-          # full sunrise..next_sunrise night-inclusive span: every hand-written festival of this shape checks
-          # "anga at sunrise OR anga at {sunset,purvaahna_end}" (a vrata observed during daylight, sometimes
-          # only its first half), so an anga that only appears later shouldn't count -- matching
-          # find_anga_span's whole-day span would count it and diverge from the original. `window="sunrise"`
-          # narrows this further, to just the sunrise instant.
-          if touch_window == "sunrise":
-            touch_interval = Interval(jd_start=daily_panchaanga.jd_sunrise, jd_end=daily_panchaanga.jd_sunrise)
-          elif touch_window == "sunrise_to_purvaahna":
-            touch_interval = daily_panchaanga.day_length_based_periods.puurvaahna
-          else:
-            touch_interval = daily_panchaanga.day_length_based_periods.dinamaana
+          touch_interval = daily_panchaanga.get_interval(interval_id=kaala)
           if not all(
               any(span.anga == target_anga for target_anga in anga_group
                   for span in daily_panchaanga.sunrise_day_angas.get_anga_spans_in_interval(anga_type=target_anga.get_type(), interval=touch_interval))

--- a/jyotisha/panchaanga/temporal/festival/rules/__init__.py
+++ b/jyotisha/panchaanga/temporal/festival/rules/__init__.py
@@ -156,11 +156,11 @@ class HinduCalendarEventTiming(common.JsonObject):
       },
       "window": {
         "type": "string",
-        "enum": ["full_period", "sunrise", "sunrise_to_sunset", "sunrise_to_next_sunrise", "sunrise_to_purvaahna", "padded_1_day"],
-        "description": "With `intersection_groups`: bounds to search the conjunction within (full_period/sunrise_to_sunset/sunrise_to_next_sunrise/padded_1_day; defaults to full_period). With `vaara` + `anga_type`/`anga_number`/`angas`: bounds the \"does the anga touch today\" check -- sunrise (the sunrise instant only), sunrise_to_sunset [dinamaana], or sunrise_to_purvaahna; defaults to sunrise_to_sunset.",
+        "enum": ["full_period", "sunrise_to_sunset", "sunrise_to_next_sunrise", "sunrise_to_purvaahna", "padded_1_day"],
+        "description": "With `intersection_groups`: bounds to search the conjunction within (full_period/sunrise_to_sunset/sunrise_to_next_sunrise/padded_1_day; defaults to full_period).",
       },
       "vaara": {
-        "description": "A weekday filter: either an int (1=Sunday...7=Saturday, matching AngaType.VARA's index convention) or a name (eg. \"budha\", \"saumya\" -- see VAARA_NAME_TO_INDEX for all accepted names/aliases). The festival recurs on every day within `month_type`/`month_number` (and, if `anga_type`/`anga_number` or `angas` are also set, touching that anga / all of those angas) whose weekday matches. Unlike `intersection_groups`, this is a plain per-day predicate over already-known daily facts -- no search. Mutually exclusive with `intersection_groups`.",
+        "description": "A weekday filter: either an int (1=Sunday...7=Saturday, matching AngaType.VARA's index convention) or a name (eg. \"budha\", \"saumya\" -- see VAARA_NAME_TO_INDEX for all accepted names/aliases). The festival recurs on every day within `month_type`/`month_number` (and, if `anga_type`/`anga_number` or `angas` are also set, touching that anga / all of those angas, per `kaala`) whose weekday matches. Unlike `intersection_groups`, this is a plain per-day predicate over already-known daily facts -- no search. Mutually exclusive with `intersection_groups`.",
       },
       "angas": {
         "type": "array",
@@ -176,7 +176,7 @@ class HinduCalendarEventTiming(common.JsonObject):
             },
           },
         },
-        "description": "For `vaara`-conditioned rules that need more than one anga checked at once (all must touch `window` -- AND semantics), eg. vAjapEyaphala-snAna-yOgaH (tithi AND nakshatra, both at sunrise). Shorthand for a single anga: use `anga_type`/`anga_number` instead. Mutually exclusive with `anga_type`/`anga_number` and with `intersection_groups`.",
+        "description": "For `vaara`-conditioned rules that need more than one anga checked at once (all must touch the `kaala` interval -- AND semantics), eg. vAjapEyaphala-snAna-yOgaH (tithi AND nakshatra, both at sunrise). Shorthand for a single anga: use `anga_type`/`anga_number` instead. Mutually exclusive with `anga_type`/`anga_number` and with `intersection_groups`.",
       },
     }
   }))

--- a/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
+++ b/jyotisha_tests/spatio_temporal/data/Chennai-2019-devanagari.md.txt
@@ -9577,7 +9577,7 @@ Anadhyayana on account of chaturdaśī. Several tithis in a month are nitya-anad
 
 ##### कृष्णाङ्गारक-चतुर्दशी-पुण्यकालः/यम-तर्पणम्
 
-Observed on Kr̥ṣṇa-Caturdaśī tithi falling on Maṅgalaḥ (Sūryōdayaḥ/puurvaviddha). 
+Observed on Kr̥ṣṇa-Caturdaśī tithi falling on Maṅgalaḥ (Puurvaahna/puurvaviddha). 
 
 kr̥ṣṇa chaturdaśī tithi on a Tuesday is very sacred. Perform tarpaṇam to Yama Dharmaraja.
 एकैकेन तिलैर्मिश्रान् दद्यात् त्रींस्त्रीन् जलाञ्जलीन्।
@@ -14936,7 +14936,7 @@ Observed on Kr̥ttikā nakshatra of Mīnaḥ (sidereal solar) month (Prātaḥ/p
 
 ##### सुखा-अङ्गारकी-चतुर्थी
 
-Observed on Śukla-Caturthī tithi falling on Maṅgalaḥ (Sūryōdayaḥ/puurvaviddha). 
+Observed on Śukla-Caturthī tithi falling on Maṅgalaḥ (Dinamaana/puurvaviddha). 
 
 chaturthī tithi on a Tuesday is as sacred as a solar eclipse. When it occurs in śuklapakṣa, it is called sukhā. Good day for doing puja of Ganesha/Subrahmanya with naivedyam of modakam/millet flour respectively.
 
@@ -17552,7 +17552,7 @@ ___________________
 - अङ्गारकी-चतुर्थी, गुरु-सङ्क्रान्तिः, वराह-जयन्ती
 ##### अङ्गारकी-चतुर्थी
 
-Observed on Kr̥ṣṇa-Caturthī tithi falling on Maṅgalaḥ (Sūryōdayaḥ/puurvaviddha). 
+Observed on Kr̥ṣṇa-Caturthī tithi falling on Maṅgalaḥ (Dinamaana/puurvaviddha). 
 
 When chaturthī tithi occurs on a Tuesday, it is known as aṅgārakī and is as sacred as a solar eclipse. Particularly special day for doing puja of Ganesha/Subrahmanya with naivedyam of modakam/millet flour respectively.
 
@@ -40793,7 +40793,7 @@ ___________________
 - अङ्गारकी विघ्नराज-महागणपति-सङ्कटहर-चतुर्थी-व्रतम्, अङ्गारकी-चतुर्थी, अनध्यायः, कजरी-तृतीया, कन्या-रवि-सङ्क्रमण-षडशीति-पुण्यकालः, गौरी-व्रतम्, भौमाश्विनी-योगः, रवि-सङ्क्रमण-पुण्यकालः, विश्वकर्म-जयन्ती, सङ्क्रमण-दिन-अपराह्ण-पुण्यकालः
 ##### अङ्गारकी-चतुर्थी
 
-Observed on Kr̥ṣṇa-Caturthī tithi falling on Maṅgalaḥ (Sūryōdayaḥ/puurvaviddha). 
+Observed on Kr̥ṣṇa-Caturthī tithi falling on Maṅgalaḥ (Dinamaana/puurvaviddha). 
 
 When chaturthī tithi occurs on a Tuesday, it is known as aṅgārakī and is as sacred as a solar eclipse. Particularly special day for doing puja of Ganesha/Subrahmanya with naivedyam of modakam/millet flour respectively.
 
@@ -43300,7 +43300,7 @@ Observed on Śukla-Tr̥tīyā tithi of Āśvayujaḥ (lunar) month (Sūryōdaya�
 
 ##### सुखा-अङ्गारकी-चतुर्थी
 
-Observed on Śukla-Caturthī tithi falling on Maṅgalaḥ (Sūryōdayaḥ/puurvaviddha). 
+Observed on Śukla-Caturthī tithi falling on Maṅgalaḥ (Dinamaana/puurvaviddha). 
 
 chaturthī tithi on a Tuesday is as sacred as a solar eclipse. When it occurs in śuklapakṣa, it is called sukhā. Good day for doing puja of Ganesha/Subrahmanya with naivedyam of modakam/millet flour respectively.
 


### PR DESCRIPTION
## Summary
- `apply_vaara_conditioned_events` now resolves the anga-touch interval via `daily_panchaanga.get_interval(interval_id=kaala)` — the same lookup `apply_month_anga_events`/`apply_month_transition_events` already use — instead of a separate hand-rolled `window` mechanism that duplicated logic already in `get_interval` (its `"sunrise"` special case, and the generic `dinamaana`/`puurvaahna` attribute lookup).
- `window` reverts to `intersection_groups`-only use (its original, pre-existing meaning); defaults to `"dinamaana"` when `kaala` is unset, matching the prior default behavior exactly.
- Regenerated `Chennai-2019-devanagari.md.txt`: the paired `adyatithi` PR also sets `kaala` explicitly on the two older `aGgArakI~caturthI` rules, correcting their auto-generated description text (previously showed a mismatched default "Sūryōdayaḥ"/sunrise label instead of the actual `dinamaana` touch-window). Dates are unaffected — description-text accuracy fix only.

## Test plan
- [x] `pytest jyotisha_tests` — 72 passed
- [x] `pytest jyotisha_manual_tests/temporal/festival/applier/vaara_conditioned_test.py` — 8 passed (multi-decade verification, confirms dates byte-identical before/after this refactor)

Paired with the companion `adyatithi` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_