### PR TITLE
Cancel stale in-progress CI runs on the same ref to avoid gh-pages push races

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,6 +14,15 @@ on:
         default: 'warning'
         description: 'Dummy field'
 
+# When multiple pushes to the same ref land close together (eg. two merges within a few minutes), only the
+# latest commit's build/deploy matters -- cancel any still-running older run on the same ref rather than letting
+# it race an in-progress deploy for the newer one. This is what previously caused intermittent `Deploy html`
+# failures ("cannot lock ref 'refs/heads/gh-pages'"): two runs' git push --force landing on gh-pages/
+# generated-output at nearly the same time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and test


### PR DESCRIPTION
## Summary
`Deploy html`/`Deploy md` force-push to `gh-pages`/`generated-output`. When two runs on the same ref overlap (eg. two merges landing within the ~10-15 min a full build+deploy takes), both pushes race and the loser fails with `cannot lock ref` — hit twice this session, most recently on master right after merging #203. Since only the latest commit's build/deploy actually matters, add a `concurrency` group so a newer run cancels an older still-running one on the same ref instead of racing it.

Note: `adyatithi`'s own workflow independently deploys to this repo's same `gh-pages`/`generated-output` branches, so a residual cross-repo race remains (GitHub Actions concurrency groups only serialize within a single repo's own workflow runs) — the companion `adyatithi` PR adds the identical guard there, narrowing but not eliminating that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PCePd69pvE74o2SzgjWA5)_