### PR TITLE
Fix crash in ShraaddhaTithiAssigner when an adhika masa starts on the trailing look-ahead day

### DIFF
--- a/jyotisha/panchaanga/temporal/tithi.py
+++ b/jyotisha/panchaanga/temporal/tithi.py
@@ -1,4 +1,3 @@
-
 import logging
 import sys
 
@@ -83,6 +82,15 @@ class ShraaddhaTithiAssigner(PeriodicPanchaangaApplier):
           m = 13
         if m == 2 and (start_time - self.panchaanga.jd_start) > 200:
           m = 14
+        if m not in lunar_tithi_days:
+          # The assignment loop runs one day past lunar_month_list's own
+          # construction window (duration+3 vs duration+2 above), as a
+          # look-ahead for a new month starting on that last day. If an
+          # adhika masa happens to start exactly there, its (fractional)
+          # month index was never registered in lunar_month_list. No paksha
+          # can be completed from a single trailing day anyway, so it's
+          # safe to just drop this entry rather than crash.
+          continue
         if t.anga.index == 1:
           # Check if it has to be assigned to current month or next
           if dp.sunrise_day_angas.get_angas_with_ends(AngaType.TITHI)[0].anga.index == 30:


### PR DESCRIPTION
## Summary

- `ShraaddhaTithiAssigner.assign_shraaddha_tithi()` builds `lunar_month_list` (and the `lunar_tithi_days` dict keyed by it) from `daily_panchaangas_sorted()[2:duration+2]`, then iterates one day further, over `[2:duration+3]`, as a deliberate look-ahead for a new month starting on that extra day.
- When an adhika masa's start lands exactly on that extra trailing day, its fractional month index (e.g. `1.5`) was never registered in `lunar_month_list`, so the append into `lunar_tithi_days` crashed with `KeyError: 1.5`.
- Reproduced via `adyatithi generate samvatsara-dina-panchaanga -c Chennai -y 5111 --lagna --scripts devanagari,tamil` (Kali 5111 ~ Gregorian 2010, which has an adhika Chaitra starting 2010-04-15 — exactly the trailing look-ahead day for that samvatsara's window).
- Fixed by skipping the append when the month key is missing — no paksha can be completed from a single trailing day's data anyway.

## Test plan

- [x] Reproduced the crash for Kali 5111 before the fix, confirmed it's resolved after.
- [x] A/B compared full TeX output for Kali 5130 (a year that does not hit this edge case) with and without the fix — byte-identical once astropy's IERS auto-download (an unrelated, expected source of run-to-run drift for future-dated predictions) was held fixed, confirming the fix is a no-op outside the crash scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMLDRxLHfHMfFHPxbbWXf

---
_Generated by [Claude Code](https://claude.ai/code/session_011BMLDRxLHfHMfFHPxbbWXf)_